### PR TITLE
Fix build errors: Add missing packages and NuGet source configuration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,11 @@
     <PackageVersion Include="VersOne.Epub" Version="3.3.1" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.72" />
 
+    <!-- Extraction (PDF/OCR) -->
+    <PackageVersion Include="PdfPig" Version="0.1.10" />
+    <PackageVersion Include="PdfPig.Rendering.Skia" Version="0.1.10" />
+    <PackageVersion Include="Tesseract" Version="5.2.0" />
+
     <!-- Testing -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="xunit.v3" Version="2.0.2" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/backend/src/Api/Properties/launchSettings.json
+++ b/backend/src/Api/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Api": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:62735;http://localhost:62736"
+    }
+  }
+}


### PR DESCRIPTION
- Add PdfPig, PdfPig.Rendering.Skia, and Tesseract packages to Directory.Packages.props
- Create NuGet.Config to resolve NU1507 error with central package management
- Configure single package source (nuget.org) with proper source mapping
- Fixes OnlineLib.Extraction project build failure