### PR TITLE
feat: Google Auth + Library + Reading Progress

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,11 +8,13 @@ ASPNETCORE_ENVIRONMENT=Development
 
 # JWT
 JWT_SECRET=your-256-bit-secret-key-here-min-32-chars
-JWT_ISSUER=books-api
-JWT_AUDIENCE=books-client
+JWT_ISSUER=textstack.app
+
+# Google OAuth
+GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 
 # Frontend
-VITE_API_BASE_URL=http://localhost:8080
+VITE_API_URL=http://localhost:8080
 
 # SEO Verification (update index.html meta tags in production)
 # GOOGLE_SITE_VERIFICATION=your-google-verification-code

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -7,5 +7,6 @@ COPY package.json pnpm-lock.yaml* ./
 RUN pnpm install
 
 COPY . .
+
 EXPOSE 5173
 CMD ["pnpm", "dev", "--host", "0.0.0.0"]

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate, useParams, useLocation } from 'react-router-dom'
 import { SiteProvider, useSite } from './context/SiteContext'
+import { AuthProvider } from './context/AuthContext'
 import { LanguageProvider, isValidLanguage } from './context/LanguageContext'
 import { HomePage } from './pages/HomePage'
 import { ReaderPage } from './pages/ReaderPage'
@@ -11,6 +12,7 @@ import { AuthorDetailPage } from './pages/AuthorDetailPage'
 import { GenresPage } from './pages/GenresPage'
 import { GenreDetailPage } from './pages/GenreDetailPage'
 import { AboutPage } from './pages/AboutPage'
+import { LibraryPage } from './pages/LibraryPage'
 import { NotFoundPage } from './pages/NotFoundPage'
 import { Header } from './components/Header'
 import './styles/theme.css'
@@ -43,6 +45,7 @@ function LanguageRoutes() {
         <Route path="/genres" element={<GenresPage />} />
         <Route path="/genres/:slug" element={<GenreDetailPage />} />
         <Route path="/about" element={<AboutPage />} />
+        <Route path="/library" element={<LibraryPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </LanguageProvider>
@@ -68,7 +71,9 @@ function App() {
   return (
     <BrowserRouter>
       <SiteProvider>
-        <AppRoutes />
+        <AuthProvider>
+          <AppRoutes />
+        </AuthProvider>
       </SiteProvider>
     </BrowserRouter>
   )

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -1,0 +1,130 @@
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080'
+
+export interface User {
+  id: string
+  email: string
+  name: string | null
+  picture: string | null
+  createdAt: string
+}
+
+export interface AuthResponse {
+  user: User
+}
+
+async function authFetch<T>(path: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...options?.headers,
+    },
+  })
+
+  if (!res.ok) {
+    if (res.status === 401) {
+      throw new Error('Unauthorized')
+    }
+    throw new Error(`API error: ${res.status}`)
+  }
+
+  // Handle empty response (logout)
+  const text = await res.text()
+  if (!text) return {} as T
+  return JSON.parse(text)
+}
+
+export async function loginWithGoogle(idToken: string): Promise<AuthResponse> {
+  return authFetch<AuthResponse>('/auth/google', {
+    method: 'POST',
+    body: JSON.stringify({ idToken }),
+  })
+}
+
+export async function refreshToken(): Promise<AuthResponse> {
+  return authFetch<AuthResponse>('/auth/refresh', {
+    method: 'POST',
+  })
+}
+
+export async function logout(): Promise<void> {
+  await authFetch<void>('/auth/logout', {
+    method: 'POST',
+  })
+}
+
+export async function getCurrentUser(): Promise<AuthResponse> {
+  return authFetch<AuthResponse>('/auth/me')
+}
+
+// Reading Progress API
+export interface ReadingProgressDto {
+  editionId: string
+  chapterId: string
+  chapterSlug: string | null
+  locator: string
+  percent: number | null
+  updatedAt: string
+}
+
+export interface UpsertProgressRequest {
+  chapterId: string
+  locator: string
+  percent: number | null
+  updatedAt?: string
+}
+
+export async function getProgress(editionId: string): Promise<ReadingProgressDto | null> {
+  try {
+    return await authFetch<ReadingProgressDto>(`/me/progress/${editionId}`)
+  } catch {
+    return null
+  }
+}
+
+export interface AllProgressResponse {
+  total: number
+  items: ReadingProgressDto[]
+}
+
+export async function getAllProgress(): Promise<AllProgressResponse> {
+  return authFetch<AllProgressResponse>('/me/progress')
+}
+
+export async function upsertProgress(editionId: string, data: UpsertProgressRequest): Promise<ReadingProgressDto> {
+  return authFetch<ReadingProgressDto>(`/me/progress/${editionId}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  })
+}
+
+// Library API
+export interface LibraryItem {
+  editionId: string
+  slug: string
+  title: string
+  coverPath: string | null
+  createdAt: string
+}
+
+export interface LibraryResponse {
+  total: number
+  items: LibraryItem[]
+}
+
+export async function getLibrary(): Promise<LibraryResponse> {
+  return authFetch<LibraryResponse>('/me/library')
+}
+
+export async function addToLibrary(editionId: string): Promise<LibraryItem> {
+  return authFetch<LibraryItem>(`/me/library/${editionId}`, {
+    method: 'POST',
+  })
+}
+
+export async function removeFromLibrary(editionId: string): Promise<void> {
+  await authFetch<void>(`/me/library/${editionId}`, {
+    method: 'DELETE',
+  })
+}

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -2,12 +2,16 @@ import { useState } from 'react'
 import { LocalizedLink } from './LocalizedLink'
 import { MobileSearchOverlay } from './Search'
 import { LanguageSwitcher } from './LanguageSwitcher'
+import { LoginButton } from './auth/LoginButton'
+import { UserMenu } from './auth/UserMenu'
 import { useSite } from '../context/SiteContext'
+import { useAuth } from '../context/AuthContext'
 import { useScrolled } from '../hooks/useScrolled'
 
 export function Header() {
   const [searchOpen, setSearchOpen] = useState(false)
   const { site } = useSite()
+  const { isAuthenticated, isLoading } = useAuth()
   const isProgramming = site?.siteCode === 'programming'
   const isScrolled = useScrolled(50)
 
@@ -23,6 +27,7 @@ export function Header() {
           About
         </LocalizedLink>
         <LanguageSwitcher />
+        {!isLoading && (isAuthenticated ? <UserMenu /> : <LoginButton />)}
       </nav>
       <button
         className="search-btn"

--- a/apps/web/src/components/auth/LoginButton.tsx
+++ b/apps/web/src/components/auth/LoginButton.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react'
+import { useAuth } from '../../context/AuthContext'
+
+export function LoginButton() {
+  const { isLoading, isAuthenticated } = useAuth()
+  const buttonRef = useRef<HTMLDivElement>(null)
+  const renderedRef = useRef(false)
+
+  useEffect(() => {
+    if (renderedRef.current || isAuthenticated || !buttonRef.current) return
+    if (typeof google === 'undefined' || !google.accounts?.id) return
+
+    // Render official Google button
+    google.accounts.id.renderButton(buttonRef.current, {
+      type: 'standard',
+      theme: 'outline',
+      size: 'large',
+      text: 'signin_with',
+      shape: 'rectangular',
+      logo_alignment: 'left',
+    })
+    renderedRef.current = true
+  }, [isAuthenticated])
+
+  if (isLoading) {
+    return <span className="login-btn">Loading...</span>
+  }
+
+  return <div ref={buttonRef} id="google-signin-button" />
+}

--- a/apps/web/src/components/auth/UserMenu.tsx
+++ b/apps/web/src/components/auth/UserMenu.tsx
@@ -1,0 +1,73 @@
+import { useState, useRef, useEffect } from 'react'
+import { useAuth } from '../../context/AuthContext'
+import { LocalizedLink } from '../LocalizedLink'
+
+export function UserMenu() {
+  const { user, logout } = useAuth()
+  const [open, setOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Close on outside click
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+
+    if (open) {
+      document.addEventListener('click', handleClick)
+      return () => document.removeEventListener('click', handleClick)
+    }
+  }, [open])
+
+  if (!user) return null
+
+  const initials = user.name
+    ? user.name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2)
+    : user.email[0].toUpperCase()
+
+  return (
+    <div className="user-menu" ref={menuRef}>
+      <button
+        className="user-menu__trigger"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        aria-haspopup="true"
+      >
+        {user.picture ? (
+          <img src={user.picture} alt="" className="user-menu__avatar-img" referrerPolicy="no-referrer" />
+        ) : (
+          <span className="user-menu__avatar">{initials}</span>
+        )}
+      </button>
+
+      {open && (
+        <div className="user-menu__dropdown">
+          <div className="user-menu__info">
+            <span className="user-menu__name">{user.name || 'User'}</span>
+            <span className="user-menu__email">{user.email}</span>
+          </div>
+          <hr className="user-menu__divider" />
+          <LocalizedLink
+            to="/library"
+            className="user-menu__item"
+            onClick={() => setOpen(false)}
+          >
+            My Library
+          </LocalizedLink>
+          <hr className="user-menu__divider" />
+          <button
+            className="user-menu__item user-menu__item--danger"
+            onClick={() => {
+              setOpen(false)
+              logout()
+            }}
+          >
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -5,7 +5,6 @@ interface AuthContextValue {
   user: User | null
   isLoading: boolean
   isAuthenticated: boolean
-  login: () => void
   logout: () => Promise<void>
 }
 
@@ -13,17 +12,14 @@ const AuthContext = createContext<AuthContextValue>({
   user: null,
   isLoading: true,
   isAuthenticated: false,
-  login: () => {},
   logout: async () => {},
 })
 
-// TODO: Remove hardcoded value after fixing env var issue
-const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID || '301013894506-7ouh9ops30ubjg6s6govpeep19h26r6q.apps.googleusercontent.com'
+const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
   const [isLoading, setIsLoading] = useState(true)
-  const [googleReady, setGoogleReady] = useState(false)
   const initializedRef = useRef(false)
 
   // Google callback - stable ref to avoid stale closures
@@ -89,34 +85,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           cancel_on_tap_outside: true,
         })
         initializedRef.current = true
-        setGoogleReady(true)
-        console.log('[Auth] Google Sign-In initialized')
       }
     }
 
     initGoogle().catch(err => console.error('[Auth] Failed to init Google:', err))
   }, [handleGoogleCallback])
-
-  const login = useCallback(() => {
-    if (!googleReady || typeof google === 'undefined') {
-      console.error('Google Sign-In not loaded')
-      return
-    }
-
-    google.accounts.id.prompt((notification) => {
-      if (notification.isNotDisplayed()) {
-        // Fallback: show button-based login
-        const button = document.getElementById('google-signin-button')
-        if (button) {
-          google.accounts.id.renderButton(button, {
-            type: 'standard',
-            theme: 'outline',
-            size: 'large',
-          })
-        }
-      }
-    })
-  }, [googleReady])
 
   const logout = useCallback(async () => {
     try {
@@ -136,7 +109,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         user,
         isLoading,
         isAuthenticated: !!user,
-        login,
         logout,
       }}
     >

--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -1,0 +1,150 @@
+import { createContext, useContext, useEffect, useState, useCallback, useRef, ReactNode } from 'react'
+import { User, getCurrentUser, loginWithGoogle, logout as logoutApi, refreshToken } from '../api/auth'
+
+interface AuthContextValue {
+  user: User | null
+  isLoading: boolean
+  isAuthenticated: boolean
+  login: () => void
+  logout: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  isLoading: true,
+  isAuthenticated: false,
+  login: () => {},
+  logout: async () => {},
+})
+
+// TODO: Remove hardcoded value after fixing env var issue
+const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID || '301013894506-7ouh9ops30ubjg6s6govpeep19h26r6q.apps.googleusercontent.com'
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [googleReady, setGoogleReady] = useState(false)
+  const initializedRef = useRef(false)
+
+  // Google callback - stable ref to avoid stale closures
+  const handleGoogleCallback = useCallback(async (response: google.accounts.id.CredentialResponse) => {
+    try {
+      setIsLoading(true)
+      const authResponse = await loginWithGoogle(response.credential)
+      setUser(authResponse.user)
+    } catch (error) {
+      console.error('Login failed:', error)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  // Check current auth status on mount
+  useEffect(() => {
+    const checkAuth = async () => {
+      try {
+        const response = await getCurrentUser()
+        setUser(response.user)
+      } catch {
+        // Try to refresh token
+        try {
+          const response = await refreshToken()
+          setUser(response.user)
+        } catch {
+          setUser(null)
+        }
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    checkAuth()
+  }, [])
+
+  // Load and initialize Google Sign-In in single effect
+  useEffect(() => {
+    if (!GOOGLE_CLIENT_ID || initializedRef.current) return
+
+    const initGoogle = async () => {
+      // Load script if not present
+      if (!document.getElementById('google-signin-script')) {
+        await new Promise<void>((resolve, reject) => {
+          const script = document.createElement('script')
+          script.id = 'google-signin-script'
+          script.src = 'https://accounts.google.com/gsi/client'
+          script.async = true
+          script.defer = true
+          script.onload = () => resolve()
+          script.onerror = () => reject(new Error('Failed to load Google Sign-In'))
+          document.head.appendChild(script)
+        })
+      }
+
+      // Initialize Google Sign-In
+      if (typeof google !== 'undefined' && google.accounts?.id) {
+        google.accounts.id.initialize({
+          client_id: GOOGLE_CLIENT_ID,
+          callback: handleGoogleCallback,
+          auto_select: false,
+          cancel_on_tap_outside: true,
+        })
+        initializedRef.current = true
+        setGoogleReady(true)
+        console.log('[Auth] Google Sign-In initialized')
+      }
+    }
+
+    initGoogle().catch(err => console.error('[Auth] Failed to init Google:', err))
+  }, [handleGoogleCallback])
+
+  const login = useCallback(() => {
+    if (!googleReady || typeof google === 'undefined') {
+      console.error('Google Sign-In not loaded')
+      return
+    }
+
+    google.accounts.id.prompt((notification) => {
+      if (notification.isNotDisplayed()) {
+        // Fallback: show button-based login
+        const button = document.getElementById('google-signin-button')
+        if (button) {
+          google.accounts.id.renderButton(button, {
+            type: 'standard',
+            theme: 'outline',
+            size: 'large',
+          })
+        }
+      }
+    })
+  }, [googleReady])
+
+  const logout = useCallback(async () => {
+    try {
+      await logoutApi()
+      setUser(null)
+      if (typeof google !== 'undefined') {
+        google.accounts.id.disableAutoSelect()
+      }
+    } catch (error) {
+      console.error('Logout failed:', error)
+    }
+  }, [])
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        isLoading,
+        isAuthenticated: !!user,
+        login,
+        logout,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  return useContext(AuthContext)
+}

--- a/apps/web/src/hooks/useLibrary.ts
+++ b/apps/web/src/hooks/useLibrary.ts
@@ -1,0 +1,78 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useAuth } from '../context/AuthContext'
+import { getLibrary, addToLibrary, removeFromLibrary, LibraryItem } from '../api/auth'
+
+export function useLibrary() {
+  const { isAuthenticated } = useAuth()
+  const [items, setItems] = useState<LibraryItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Fetch library on mount (if authenticated)
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setItems([])
+      return
+    }
+
+    const fetchLibrary = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const response = await getLibrary()
+        setItems(response.items)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load library')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchLibrary()
+  }, [isAuthenticated])
+
+  const add = useCallback(async (editionId: string) => {
+    if (!isAuthenticated) return
+    try {
+      const item = await addToLibrary(editionId)
+      setItems(prev => [item, ...prev])
+      return item
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add to library')
+      throw err
+    }
+  }, [isAuthenticated])
+
+  const remove = useCallback(async (editionId: string) => {
+    if (!isAuthenticated) return
+    try {
+      await removeFromLibrary(editionId)
+      setItems(prev => prev.filter(item => item.editionId !== editionId))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to remove from library')
+      throw err
+    }
+  }, [isAuthenticated])
+
+  const isInLibrary = useCallback((editionId: string) => {
+    return items.some(item => item.editionId === editionId)
+  }, [items])
+
+  const toggle = useCallback(async (editionId: string) => {
+    if (isInLibrary(editionId)) {
+      await remove(editionId)
+    } else {
+      await add(editionId)
+    }
+  }, [isInLibrary, add, remove])
+
+  return {
+    items,
+    loading,
+    error,
+    add,
+    remove,
+    toggle,
+    isInLibrary,
+  }
+}

--- a/apps/web/src/hooks/useReadingProgress.ts
+++ b/apps/web/src/hooks/useReadingProgress.ts
@@ -1,63 +1,105 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
+import { useAuth } from '../context/AuthContext'
+import { getProgress, upsertProgress } from '../api/auth'
 
 interface StoredProgress {
   chapterSlug: string
-  scrollPercent: number
+  chapterId?: string
+  percent: number
+  page?: number
   updatedAt: number
+}
+
+interface UseReadingProgressOptions {
+  editionId?: string
+  chapterId?: string
 }
 
 function getKey(bookSlug: string) {
   return `reader.progress.${bookSlug}`
 }
 
-export function useReadingProgress(bookSlug: string, chapterSlug: string) {
-  const [scrollPercent, setScrollPercent] = useState(0)
-  const throttleRef = useRef<number | null>(null)
+export function useReadingProgress(
+  bookSlug: string,
+  chapterSlug: string,
+  options?: UseReadingProgressOptions
+) {
+  const { isAuthenticated } = useAuth()
+  const [progress, setProgress] = useState(0)
+  const serverSyncRef = useRef<number | null>(null)
+  const lastSyncedRef = useRef<number>(0)
+  const { editionId, chapterId } = options || {}
 
   // Load saved progress on mount
   useEffect(() => {
-    try {
-      const stored = localStorage.getItem(getKey(bookSlug))
-      if (stored) {
-        const data: StoredProgress = JSON.parse(stored)
-        if (data.chapterSlug === chapterSlug && data.scrollPercent > 0) {
-          // Restore scroll position after content loads
-          requestAnimationFrame(() => {
-            const maxScroll = document.documentElement.scrollHeight - window.innerHeight
-            window.scrollTo(0, maxScroll * data.scrollPercent)
-          })
+    const loadProgress = async () => {
+      // If authenticated and have IDs, try server first
+      if (isAuthenticated && editionId) {
+        try {
+          const serverProgress = await getProgress(editionId)
+          if (serverProgress && serverProgress.percent != null) {
+            setProgress(serverProgress.percent)
+            return
+          }
+        } catch {
+          // Fall through to localStorage
         }
       }
-    } catch {}
-  }, [bookSlug, chapterSlug])
 
-  // Track scroll and save
-  useEffect(() => {
-    const handleScroll = () => {
-      if (throttleRef.current) return
-
-      throttleRef.current = window.setTimeout(() => {
-        throttleRef.current = null
-        const maxScroll = document.documentElement.scrollHeight - window.innerHeight
-        const percent = maxScroll > 0 ? window.scrollY / maxScroll : 0
-        setScrollPercent(percent)
-
-        // Save to localStorage
-        const data: StoredProgress = {
-          chapterSlug,
-          scrollPercent: percent,
-          updatedAt: Date.now(),
+      // Fallback to localStorage
+      try {
+        const stored = localStorage.getItem(getKey(bookSlug))
+        if (stored) {
+          const data: StoredProgress = JSON.parse(stored)
+          if (data.chapterSlug === chapterSlug) {
+            setProgress(data.percent)
+          }
         }
-        localStorage.setItem(getKey(bookSlug), JSON.stringify(data))
-      }, 300)
+      } catch {}
     }
 
-    window.addEventListener('scroll', handleScroll, { passive: true })
-    return () => {
-      window.removeEventListener('scroll', handleScroll)
-      if (throttleRef.current) clearTimeout(throttleRef.current)
+    loadProgress()
+  }, [bookSlug, chapterSlug, isAuthenticated, editionId])
+
+  // Update progress (called by reader when page changes)
+  const updateProgress = useCallback((percent: number, page?: number) => {
+    setProgress(percent)
+
+    // Save to localStorage (always, as fallback)
+    const data: StoredProgress = {
+      chapterSlug,
+      chapterId,
+      percent,
+      page,
+      updatedAt: Date.now(),
     }
-  }, [bookSlug, chapterSlug])
+    localStorage.setItem(getKey(bookSlug), JSON.stringify(data))
+
+    // Debounced sync to server (if authenticated)
+    if (isAuthenticated && editionId && chapterId) {
+      // Skip if same value synced recently
+      if (Math.abs(percent - lastSyncedRef.current) < 0.01) return
+
+      if (serverSyncRef.current) clearTimeout(serverSyncRef.current)
+      serverSyncRef.current = window.setTimeout(() => {
+        lastSyncedRef.current = percent
+        upsertProgress(editionId, {
+          chapterId,
+          locator: page != null ? `page:${page}` : `percent:${percent.toFixed(4)}`,
+          percent,
+        }).catch(() => {
+          // Silently fail, localStorage is backup
+        })
+      }, 2000) // Debounce 2s for server sync
+    }
+  }, [bookSlug, chapterSlug, isAuthenticated, editionId, chapterId])
+
+  // Cleanup
+  useEffect(() => {
+    return () => {
+      if (serverSyncRef.current) clearTimeout(serverSyncRef.current)
+    }
+  }, [])
 
   const getLastPosition = useCallback((): StoredProgress | null => {
     try {
@@ -67,5 +109,5 @@ export function useReadingProgress(bookSlug: string, chapterSlug: string) {
     return null
   }, [bookSlug])
 
-  return { scrollPercent, getLastPosition }
+  return { progress, updateProgress, getLastPosition }
 }

--- a/apps/web/src/hooks/useReadingProgress.ts
+++ b/apps/web/src/hooks/useReadingProgress.ts
@@ -1,22 +1,10 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useEffect, useCallback, useRef } from 'react'
 import { useAuth } from '../context/AuthContext'
-import { getProgress, upsertProgress } from '../api/auth'
-
-interface StoredProgress {
-  chapterSlug: string
-  chapterId?: string
-  percent: number
-  page?: number
-  updatedAt: number
-}
+import { upsertProgress } from '../api/auth'
 
 interface UseReadingProgressOptions {
   editionId?: string
   chapterId?: string
-}
-
-function getKey(bookSlug: string) {
-  return `reader.progress.${bookSlug}`
 }
 
 export function useReadingProgress(
@@ -25,56 +13,12 @@ export function useReadingProgress(
   options?: UseReadingProgressOptions
 ) {
   const { isAuthenticated } = useAuth()
-  const [progress, setProgress] = useState(0)
   const serverSyncRef = useRef<number | null>(null)
   const lastSyncedRef = useRef<number>(0)
   const { editionId, chapterId } = options || {}
 
-  // Load saved progress on mount
-  useEffect(() => {
-    const loadProgress = async () => {
-      // If authenticated and have IDs, try server first
-      if (isAuthenticated && editionId) {
-        try {
-          const serverProgress = await getProgress(editionId)
-          if (serverProgress && serverProgress.percent != null) {
-            setProgress(serverProgress.percent)
-            return
-          }
-        } catch {
-          // Fall through to localStorage
-        }
-      }
-
-      // Fallback to localStorage
-      try {
-        const stored = localStorage.getItem(getKey(bookSlug))
-        if (stored) {
-          const data: StoredProgress = JSON.parse(stored)
-          if (data.chapterSlug === chapterSlug) {
-            setProgress(data.percent)
-          }
-        }
-      } catch {}
-    }
-
-    loadProgress()
-  }, [bookSlug, chapterSlug, isAuthenticated, editionId])
-
   // Update progress (called by reader when page changes)
   const updateProgress = useCallback((percent: number, page?: number) => {
-    setProgress(percent)
-
-    // Save to localStorage (always, as fallback)
-    const data: StoredProgress = {
-      chapterSlug,
-      chapterId,
-      percent,
-      page,
-      updatedAt: Date.now(),
-    }
-    localStorage.setItem(getKey(bookSlug), JSON.stringify(data))
-
     // Debounced sync to server (if authenticated)
     if (isAuthenticated && editionId && chapterId) {
       // Skip if same value synced recently
@@ -87,10 +31,8 @@ export function useReadingProgress(
           chapterId,
           locator: page != null ? `page:${page}` : `percent:${percent.toFixed(4)}`,
           percent,
-        }).catch(() => {
-          // Silently fail, localStorage is backup
-        })
-      }, 2000) // Debounce 2s for server sync
+        }).catch(() => {})
+      }, 2000)
     }
   }, [bookSlug, chapterSlug, isAuthenticated, editionId, chapterId])
 
@@ -101,13 +43,5 @@ export function useReadingProgress(
     }
   }, [])
 
-  const getLastPosition = useCallback((): StoredProgress | null => {
-    try {
-      const stored = localStorage.getItem(getKey(bookSlug))
-      if (stored) return JSON.parse(stored)
-    } catch {}
-    return null
-  }, [bookSlug])
-
-  return { progress, updateProgress, getLastPosition }
+  return { updateProgress }
 }

--- a/apps/web/src/pages/BookDetailPage.tsx
+++ b/apps/web/src/pages/BookDetailPage.tsx
@@ -3,6 +3,8 @@ import { useParams, Link } from 'react-router-dom'
 import { useApi } from '../hooks/useApi'
 import { getStorageUrl } from '../api/client'
 import { useLanguage, SupportedLanguage } from '../context/LanguageContext'
+import { useAuth } from '../context/AuthContext'
+import { useLibrary } from '../hooks/useLibrary'
 import { LocalizedLink } from '../components/LocalizedLink'
 import { SeoHead } from '../components/SeoHead'
 import { JsonLd } from '../components/JsonLd'
@@ -19,9 +21,12 @@ export function BookDetailPage() {
   const { bookSlug } = useParams<{ bookSlug: string }>()
   const api = useApi()
   const { language } = useLanguage()
+  const { isAuthenticated } = useAuth()
+  const { toggle: toggleLibrary, isInLibrary } = useLibrary()
   const [book, setBook] = useState<BookDetail | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [libraryLoading, setLibraryLoading] = useState(false)
 
   useEffect(() => {
     if (!bookSlug) return
@@ -122,14 +127,32 @@ export function BookDetailPage() {
           <p className="book-detail__meta">
             {book.chapters.length} chapters · {book.language.toUpperCase()}
           </p>
-          {firstChapter && (
-            <LocalizedLink
-              to={`/books/${book.slug}/${firstChapter.slug}`}
-              className="book-detail__read-btn"
-            >
-              Start Reading
-            </LocalizedLink>
-          )}
+          <div className="book-detail__actions">
+            {firstChapter && (
+              <LocalizedLink
+                to={`/books/${book.slug}/${firstChapter.slug}`}
+                className="book-detail__read-btn"
+              >
+                Start Reading
+              </LocalizedLink>
+            )}
+            {isAuthenticated && (
+              <button
+                className={`book-detail__library-btn ${isInLibrary(book.id) ? 'in-library' : ''}`}
+                onClick={async () => {
+                  setLibraryLoading(true)
+                  try {
+                    await toggleLibrary(book.id)
+                  } finally {
+                    setLibraryLoading(false)
+                  }
+                }}
+                disabled={libraryLoading}
+              >
+                {libraryLoading ? '...' : isInLibrary(book.id) ? 'In Library' : 'Add to Library'}
+              </button>
+            )}
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/pages/LibraryPage.tsx
+++ b/apps/web/src/pages/LibraryPage.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useAuth } from '../context/AuthContext'
 import { useLibrary } from '../hooks/useLibrary'
-import { useLanguage } from '../context/LanguageContext'
 import { LocalizedLink } from '../components/LocalizedLink'
 import { SeoHead } from '../components/SeoHead'
 import { getStorageUrl } from '../api/client'
@@ -11,7 +10,6 @@ import { getAllProgress, ReadingProgressDto } from '../api/auth'
 export function LibraryPage() {
   const { isAuthenticated, user } = useAuth()
   const { items, loading, remove } = useLibrary()
-  const { t } = useLanguage()
   const [progressMap, setProgressMap] = useState<Record<string, ReadingProgressDto>>({})
 
   // Fetch all reading progress

--- a/apps/web/src/pages/LibraryPage.tsx
+++ b/apps/web/src/pages/LibraryPage.tsx
@@ -1,0 +1,123 @@
+import { useState, useEffect } from 'react'
+import { useAuth } from '../context/AuthContext'
+import { useLibrary } from '../hooks/useLibrary'
+import { useLanguage } from '../context/LanguageContext'
+import { LocalizedLink } from '../components/LocalizedLink'
+import { SeoHead } from '../components/SeoHead'
+import { getStorageUrl } from '../api/client'
+import { stringToColor } from '../utils/colors'
+import { getAllProgress, ReadingProgressDto } from '../api/auth'
+
+export function LibraryPage() {
+  const { isAuthenticated, user } = useAuth()
+  const { items, loading, remove } = useLibrary()
+  const { t } = useLanguage()
+  const [progressMap, setProgressMap] = useState<Record<string, ReadingProgressDto>>({})
+
+  // Fetch all reading progress
+  useEffect(() => {
+    if (!isAuthenticated) return
+    getAllProgress()
+      .then((res) => {
+        const map: Record<string, ReadingProgressDto> = {}
+        res.items.forEach((p) => {
+          map[p.editionId] = p
+        })
+        setProgressMap(map)
+      })
+      .catch(() => {})
+  }, [isAuthenticated])
+
+  if (!isAuthenticated) {
+    return (
+      <div className="library-page">
+        <SeoHead title="My Library" />
+        <div className="library-page__empty">
+          <h1>My Library</h1>
+          <p>Sign in to save books to your library and track your reading progress.</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="library-page">
+      <SeoHead title="My Library" />
+      <div className="library-page__header">
+        <h1>My Library</h1>
+        {user && <p className="library-page__user">{user.email}</p>}
+      </div>
+
+      {loading ? (
+        <div className="library-page__loading">Loading...</div>
+      ) : items.length === 0 ? (
+        <div className="library-page__empty">
+          <p>Your library is empty.</p>
+          <LocalizedLink to="/books" className="library-page__browse-btn">
+            Browse Books
+          </LocalizedLink>
+        </div>
+      ) : (
+        <div className="library-page__grid">
+          {items.map((item) => {
+            const progress = progressMap[item.editionId]
+            const percent = progress?.percent ?? 0
+            return (
+              <div key={item.editionId} className="library-card">
+                <LocalizedLink to={`/books/${item.slug}`} className="library-card__cover">
+                  {item.coverPath ? (
+                    <img src={getStorageUrl(item.coverPath)} alt={item.title} />
+                  ) : (
+                    <div
+                      className="library-card__cover-placeholder"
+                      style={{ backgroundColor: stringToColor(item.title) }}
+                    >
+                      {item.title?.[0] || '?'}
+                    </div>
+                  )}
+                  {percent > 0 && (
+                    <div className="library-card__progress-bar">
+                      <div
+                        className="library-card__progress-fill"
+                        style={{ width: `${Math.round(percent * 100)}%` }}
+                      />
+                    </div>
+                  )}
+                </LocalizedLink>
+                <div className="library-card__info">
+                  <div className="library-card__text">
+                    <LocalizedLink to={`/books/${item.slug}`} className="library-card__title">
+                      {item.title}
+                    </LocalizedLink>
+                    {percent > 0 && progress?.chapterSlug && (
+                      <LocalizedLink
+                        to={`/books/${item.slug}/${progress.chapterSlug}`}
+                        className="library-card__continue"
+                      >
+                        Continue · {Math.round(percent * 100)}%
+                      </LocalizedLink>
+                    )}
+                    {percent > 0 && !progress?.chapterSlug && (
+                      <span className="library-card__progress-text">
+                        {Math.round(percent * 100)}% read
+                      </span>
+                    )}
+                  </div>
+                  <button
+                    className="library-card__remove"
+                    onClick={() => remove(item.editionId)}
+                    title="Remove from library"
+                  >
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <path d="M18 6L6 18M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/styles/books.css
+++ b/apps/web/src/styles/books.css
@@ -93,6 +93,134 @@
   color: var(--color-text, #191919);
 }
 
+/* Login Button */
+.login-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border: 1px solid var(--color-border, #E8E2D9);
+  border-radius: 6px;
+  background: var(--color-bg, #fff);
+  color: var(--color-text, #191919);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.login-btn:hover {
+  background: var(--color-bg-secondary, #F5F0E8);
+  border-color: var(--color-text-secondary, #555);
+}
+
+.login-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* User Menu */
+.user-menu {
+  position: relative;
+}
+
+.user-menu__trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 50%;
+  background: var(--color-brand, #C4704B);
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.15s ease, opacity 0.15s ease;
+}
+
+.user-menu__trigger:hover {
+  opacity: 0.9;
+  transform: scale(1.05);
+}
+
+.user-menu__avatar {
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.user-menu__avatar-img {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.user-menu__dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 200px;
+  background: var(--color-bg, #fff);
+  border: 1px solid var(--color-border, #E8E2D9);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  z-index: 200;
+  overflow: hidden;
+}
+
+.user-menu__info {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-border, #E8E2D9);
+}
+
+.user-menu__name {
+  display: block;
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--color-text, #191919);
+}
+
+.user-menu__email {
+  display: block;
+  font-size: 12px;
+  color: var(--color-text-secondary, #555);
+  margin-top: 2px;
+}
+
+.user-menu__divider {
+  margin: 0;
+  border: none;
+  border-top: 1px solid var(--color-border, #E8E2D9);
+}
+
+.user-menu__item {
+  display: block;
+  width: 100%;
+  padding: 10px 16px;
+  border: none;
+  background: none;
+  text-decoration: none;
+  color: inherit;
+  text-align: left;
+  font-size: 14px;
+  color: var(--color-text, #191919);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.user-menu__item:hover {
+  background: var(--color-bg-secondary, #F5F0E8);
+}
+
+.user-menu__item--danger {
+  color: #dc2626;
+}
+
+.user-menu__item--danger:hover {
+  background: #fef2f2;
+}
+
 /* Static pages (Public Domain, etc.) */
 .static-page {
   max-width: 640px;
@@ -382,6 +510,43 @@
 
 .book-detail__read-btn:hover {
   background: #333;
+}
+
+.book-detail__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.book-detail__library-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  color: #1a1a1a;
+  padding: 11px 20px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.book-detail__library-btn:hover {
+  border-color: #1a1a1a;
+  background: #f5f5f5;
+}
+
+.book-detail__library-btn.in-library {
+  background: #e8f5e9;
+  border-color: #4caf50;
+  color: #2e7d32;
+}
+
+.book-detail__library-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .book-detail__toc {
@@ -1525,4 +1690,166 @@
 
 .error-boundary button:hover {
   background: #333;
+}
+
+/* Library Page */
+.library-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px;
+}
+
+.library-page__header {
+  margin-bottom: 32px;
+}
+
+.library-page__header h1 {
+  font-size: 28px;
+  margin: 0 0 8px;
+}
+
+.library-page__user {
+  color: #666;
+  margin: 0;
+}
+
+.library-page__loading {
+  text-align: center;
+  padding: 48px;
+  color: #666;
+}
+
+.library-page__empty {
+  text-align: center;
+  padding: 48px 24px;
+}
+
+.library-page__empty h1 {
+  font-size: 24px;
+  margin: 0 0 16px;
+}
+
+.library-page__empty p {
+  color: #666;
+  margin: 0 0 24px;
+}
+
+.library-page__browse-btn {
+  display: inline-block;
+  background: #1a1a1a;
+  color: #fff;
+  padding: 12px 24px;
+  border-radius: 8px;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.library-page__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 24px;
+}
+
+.library-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.library-card__cover {
+  position: relative;
+  aspect-ratio: 2/3;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #f0f0f0;
+  margin-bottom: 8px;
+}
+
+.library-card__cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.library-card__cover-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 48px;
+  font-weight: 700;
+  color: rgba(255,255,255,0.8);
+}
+
+.library-card__info {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.library-card__text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.library-card__title {
+  font-size: 14px;
+  font-weight: 500;
+  color: #1a1a1a;
+  text-decoration: none;
+  line-height: 1.3;
+}
+
+.library-card__title:hover {
+  text-decoration: underline;
+}
+
+.library-card__remove {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  color: #999;
+  border-radius: 4px;
+}
+
+.library-card__remove:hover {
+  background: #f0f0f0;
+  color: #666;
+}
+
+.library-card__progress-bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.library-card__progress-fill {
+  height: 100%;
+  background: var(--color-primary, #4a6da7);
+  transition: width 0.3s ease;
+}
+
+.library-card__progress-text {
+  font-size: 0.75rem;
+  color: #666;
+  margin-top: 2px;
+}
+
+.library-card__continue {
+  font-size: 0.75rem;
+  color: var(--color-primary, #4a6da7);
+  text-decoration: none;
+  margin-top: 2px;
+}
+
+.library-card__continue:hover {
+  text-decoration: underline;
 }

--- a/apps/web/src/types/google.d.ts
+++ b/apps/web/src/types/google.d.ts
@@ -1,0 +1,43 @@
+declare namespace google.accounts.id {
+  interface CredentialResponse {
+    credential: string
+    select_by: string
+  }
+
+  interface PromptNotification {
+    isNotDisplayed(): boolean
+    isSkippedMoment(): boolean
+    isDismissedMoment(): boolean
+  }
+
+  interface ButtonConfig {
+    type?: 'standard' | 'icon'
+    theme?: 'outline' | 'filled_blue' | 'filled_black'
+    size?: 'large' | 'medium' | 'small'
+    text?: 'signin_with' | 'signup_with' | 'continue_with' | 'signin'
+    shape?: 'rectangular' | 'pill' | 'circle' | 'square'
+    logo_alignment?: 'left' | 'center'
+    width?: number
+    locale?: string
+  }
+
+  interface InitializeConfig {
+    client_id: string
+    callback: (response: CredentialResponse) => void
+    auto_select?: boolean
+    cancel_on_tap_outside?: boolean
+    context?: 'signin' | 'signup' | 'use'
+    ux_mode?: 'popup' | 'redirect'
+    login_uri?: string
+    native_callback?: (response: CredentialResponse) => void
+    itp_support?: boolean
+  }
+
+  function initialize(config: InitializeConfig): void
+  function prompt(callback?: (notification: PromptNotification) => void): void
+  function renderButton(parent: HTMLElement, config: ButtonConfig): void
+  function disableAutoSelect(): void
+  function storeCredential(credential: { id: string; password: string }, callback?: () => void): void
+  function cancel(): void
+  function revoke(hint: string, callback?: (response: { successful: boolean; error?: string }) => void): void
+}

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -17,8 +17,15 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
 
     <!-- Application Layer -->
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
+
+    <!-- Authentication -->
+    <PackageVersion Include="Google.Apis.Auth" Version="1.68.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.3.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
 
     <!-- Search -->
     <PackageVersion Include="Dapper" Version="2.1.35" />

--- a/backend/src/Api/Endpoints/AuthEndpoints.cs
+++ b/backend/src/Api/Endpoints/AuthEndpoints.cs
@@ -1,0 +1,132 @@
+using Application.Auth;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Endpoints;
+
+public static class AuthEndpoints
+{
+    private const string AccessTokenCookie = "access_token";
+    private const string RefreshTokenCookie = "refresh_token";
+
+    public static void MapAuthEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/auth").WithTags("Auth");
+
+        group.MapPost("/google", LoginWithGoogle).WithName("LoginWithGoogle");
+        group.MapPost("/refresh", RefreshToken).WithName("RefreshToken");
+        group.MapPost("/logout", Logout).WithName("Logout");
+        group.MapGet("/me", GetCurrentUser).WithName("GetCurrentUser");
+    }
+
+    private static async Task<IResult> LoginWithGoogle(
+        [FromBody] GoogleLoginRequest request,
+        AuthService authService,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var result = await authService.LoginWithGoogleAsync(request.IdToken, ct);
+
+        if (result == null)
+            return Results.Unauthorized();
+
+        var (user, accessToken, refreshToken) = result.Value;
+
+        SetAuthCookies(httpContext, accessToken, refreshToken);
+
+        return Results.Ok(new AuthResponse(new UserDto(user.Id, user.Email, user.Name, user.Picture, user.CreatedAt)));
+    }
+
+    private static async Task<IResult> RefreshToken(
+        AuthService authService,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var refreshToken = httpContext.Request.Cookies[RefreshTokenCookie];
+
+        if (string.IsNullOrEmpty(refreshToken))
+            return Results.Unauthorized();
+
+        var result = await authService.RefreshTokenAsync(refreshToken, ct);
+
+        if (result == null)
+        {
+            ClearAuthCookies(httpContext);
+            return Results.Unauthorized();
+        }
+
+        var (user, newAccessToken, newRefreshToken) = result.Value;
+
+        SetAuthCookies(httpContext, newAccessToken, newRefreshToken);
+
+        return Results.Ok(new AuthResponse(new UserDto(user.Id, user.Email, user.Name, user.Picture, user.CreatedAt)));
+    }
+
+    private static async Task<IResult> Logout(
+        AuthService authService,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var refreshToken = httpContext.Request.Cookies[RefreshTokenCookie];
+
+        if (!string.IsNullOrEmpty(refreshToken))
+            await authService.LogoutAsync(refreshToken, ct);
+
+        ClearAuthCookies(httpContext);
+
+        return Results.Ok();
+    }
+
+    private static async Task<IResult> GetCurrentUser(
+        AuthService authService,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var accessToken = httpContext.Request.Cookies[AccessTokenCookie];
+
+        if (string.IsNullOrEmpty(accessToken))
+            return Results.Unauthorized();
+
+        var userId = authService.ValidateAccessToken(accessToken);
+
+        if (userId == null)
+            return Results.Unauthorized();
+
+        var user = await authService.GetUserByIdAsync(userId.Value, ct);
+
+        if (user == null)
+            return Results.Unauthorized();
+
+        return Results.Ok(new AuthResponse(new UserDto(user.Id, user.Email, user.Name, user.Picture, user.CreatedAt)));
+    }
+
+    private static void SetAuthCookies(HttpContext httpContext, string accessToken, string refreshToken)
+    {
+        var isProduction = !httpContext.RequestServices
+            .GetRequiredService<IWebHostEnvironment>()
+            .IsDevelopment();
+
+        httpContext.Response.Cookies.Append(AccessTokenCookie, accessToken, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = isProduction,
+            SameSite = SameSiteMode.Lax,
+            MaxAge = TimeSpan.FromMinutes(15),
+            Path = "/"
+        });
+
+        httpContext.Response.Cookies.Append(RefreshTokenCookie, refreshToken, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = isProduction,
+            SameSite = SameSiteMode.Lax,
+            MaxAge = TimeSpan.FromDays(30),
+            Path = "/"
+        });
+    }
+
+    private static void ClearAuthCookies(HttpContext httpContext)
+    {
+        httpContext.Response.Cookies.Delete(AccessTokenCookie);
+        httpContext.Response.Cookies.Delete(RefreshTokenCookie);
+    }
+}

--- a/backend/src/Api/Endpoints/UserDataEndpoints.cs
+++ b/backend/src/Api/Endpoints/UserDataEndpoints.cs
@@ -1,0 +1,491 @@
+using Api.Sites;
+using Application.Auth;
+using Application.Common.Interfaces;
+using Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.Endpoints;
+
+public static class UserDataEndpoints
+{
+    public static void MapUserDataEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/me").WithTags("User Data");
+
+        // Reading Progress
+        group.MapGet("/progress", GetAllProgress).WithName("GetAllProgress");
+        group.MapGet("/progress/{editionId:guid}", GetProgress).WithName("GetProgress");
+        group.MapPut("/progress/{editionId:guid}", UpsertProgress).WithName("UpsertProgress");
+        group.MapDelete("/progress/{editionId:guid}", DeleteProgress).WithName("DeleteProgress");
+
+        // Bookmarks
+        group.MapGet("/bookmarks", GetAllBookmarks).WithName("GetAllBookmarks");
+        group.MapGet("/bookmarks/{editionId:guid}", GetBookmarks).WithName("GetBookmarks");
+        group.MapPost("/bookmarks", CreateBookmark).WithName("CreateBookmark");
+        group.MapDelete("/bookmarks/{id:guid}", DeleteBookmark).WithName("DeleteBookmark");
+
+        // Library
+        group.MapGet("/library", GetLibrary).WithName("GetLibrary");
+        group.MapPost("/library/{editionId:guid}", AddToLibrary).WithName("AddToLibrary");
+        group.MapDelete("/library/{editionId:guid}", RemoveFromLibrary).WithName("RemoveFromLibrary");
+    }
+
+    private static Guid? GetUserId(HttpContext httpContext, AuthService authService)
+    {
+        var accessToken = httpContext.Request.Cookies["access_token"];
+        if (string.IsNullOrEmpty(accessToken)) return null;
+        return authService.ValidateAccessToken(accessToken);
+    }
+
+    // Reading Progress Endpoints
+
+    private static async Task<IResult> GetAllProgress(
+        HttpContext httpContext,
+        AuthService authService,
+        IAppDbContext db,
+        [FromQuery] int? limit,
+        [FromQuery] int? offset,
+        CancellationToken ct)
+    {
+        var userId = GetUserId(httpContext, authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var siteId = httpContext.GetSiteId();
+
+        var query = db.ReadingProgresses
+            .Where(p => p.UserId == userId.Value && p.SiteId == siteId)
+            .OrderByDescending(p => p.UpdatedAt);
+
+        var total = await query.CountAsync(ct);
+        var items = await query
+            .Skip(offset ?? 0)
+            .Take(limit ?? 50)
+            .Join(db.Chapters, p => p.ChapterId, c => c.Id, (p, c) => new { p, c })
+            .Select(x => new ReadingProgressDto(
+                x.p.EditionId,
+                x.p.ChapterId,
+                x.c.Slug,
+                x.p.Locator,
+                x.p.Percent,
+                x.p.UpdatedAt
+            ))
+            .ToListAsync(ct);
+
+        return Results.Ok(new { total, items });
+    }
+
+    private static async Task<IResult> GetProgress(
+        Guid editionId,
+        HttpContext httpContext,
+        AuthService authService,
+        IAppDbContext db,
+        CancellationToken ct)
+    {
+        var userId = GetUserId(httpContext, authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var siteId = httpContext.GetSiteId();
+
+        var progress = await db.ReadingProgresses
+            .Where(p => p.UserId == userId.Value && p.SiteId == siteId && p.EditionId == editionId)
+            .Join(db.Chapters, p => p.ChapterId, c => c.Id, (p, c) => new { p, c })
+            .Select(x => new ReadingProgressDto(
+                x.p.EditionId,
+                x.p.ChapterId,
+                x.c.Slug,
+                x.p.Locator,
+                x.p.Percent,
+                x.p.UpdatedAt
+            ))
+            .FirstOrDefaultAsync(ct);
+
+        return progress is null ? Results.NotFound() : Results.Ok(progress);
+    }
+
+    private static async Task<IResult> UpsertProgress(
+        Guid editionId,
+        [FromBody] UpsertProgressRequest request,
+        HttpContext httpContext,
+        AuthService authService,
+        IAppDbContext db,
+        CancellationToken ct)
+    {
+        var userId = GetUserId(httpContext, authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var siteId = httpContext.GetSiteId();
+
+        // Validate edition exists
+        var edition = await db.Editions
+            .Where(e => e.Id == editionId && e.SiteId == siteId)
+            .FirstOrDefaultAsync(ct);
+
+        if (edition == null) return Results.NotFound("Edition not found");
+
+        // Validate chapter exists
+        var chapter = await db.Chapters
+            .Where(c => c.Id == request.ChapterId && c.EditionId == editionId)
+            .FirstOrDefaultAsync(ct);
+
+        if (chapter == null) return Results.NotFound("Chapter not found");
+
+        var existing = await db.ReadingProgresses
+            .Where(p => p.UserId == userId.Value && p.SiteId == siteId && p.EditionId == editionId)
+            .FirstOrDefaultAsync(ct);
+
+        if (existing != null)
+        {
+            // Update only if client timestamp is newer (conflict resolution)
+            if (request.UpdatedAt.HasValue && request.UpdatedAt.Value <= existing.UpdatedAt)
+            {
+                // Get current chapter slug for response
+                var existingChapter = await db.Chapters.FirstOrDefaultAsync(c => c.Id == existing.ChapterId, ct);
+                return Results.Ok(new ReadingProgressDto(
+                    existing.EditionId,
+                    existing.ChapterId,
+                    existingChapter?.Slug,
+                    existing.Locator,
+                    existing.Percent,
+                    existing.UpdatedAt
+                ));
+            }
+
+            existing.ChapterId = request.ChapterId;
+            existing.Locator = request.Locator;
+            existing.Percent = request.Percent;
+            existing.UpdatedAt = DateTimeOffset.UtcNow;
+        }
+        else
+        {
+            var progress = new ReadingProgress
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId.Value,
+                SiteId = siteId,
+                EditionId = editionId,
+                ChapterId = request.ChapterId,
+                Locator = request.Locator,
+                Percent = request.Percent,
+                UpdatedAt = DateTimeOffset.UtcNow
+            };
+            db.ReadingProgresses.Add(progress);
+            existing = progress;
+        }
+
+        await db.SaveChangesAsync(ct);
+
+        return Results.Ok(new ReadingProgressDto(
+            existing.EditionId,
+            existing.ChapterId,
+            chapter.Slug,
+            existing.Locator,
+            existing.Percent,
+            existing.UpdatedAt
+        ));
+    }
+
+    private static async Task<IResult> DeleteProgress(
+        Guid editionId,
+        HttpContext httpContext,
+        AuthService authService,
+        IAppDbContext db,
+        CancellationToken ct)
+    {
+        var userId = GetUserId(httpContext, authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var siteId = httpContext.GetSiteId();
+
+        var progress = await db.ReadingProgresses
+            .Where(p => p.UserId == userId.Value && p.SiteId == siteId && p.EditionId == editionId)
+            .FirstOrDefaultAsync(ct);
+
+        if (progress == null) return Results.NotFound();
+
+        db.ReadingProgresses.Remove(progress);
+        await db.SaveChangesAsync(ct);
+
+        return Results.NoContent();
+    }
+
+    // Bookmarks Endpoints
+
+    private static async Task<IResult> GetAllBookmarks(
+        HttpContext httpContext,
+        AuthService authService,
+        IAppDbContext db,
+        [FromQuery] int? limit,
+        [FromQuery] int? offset,
+        CancellationToken ct)
+    {
+        var userId = GetUserId(httpContext, authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var siteId = httpContext.GetSiteId();
+
+        var query = db.Bookmarks
+            .Where(b => b.UserId == userId.Value && b.SiteId == siteId)
+            .OrderByDescending(b => b.CreatedAt);
+
+        var total = await query.CountAsync(ct);
+        var items = await query
+            .Skip(offset ?? 0)
+            .Take(limit ?? 100)
+            .Select(b => new BookmarkDto(
+                b.Id,
+                b.EditionId,
+                b.ChapterId,
+                b.Locator,
+                b.Title,
+                b.CreatedAt
+            ))
+            .ToListAsync(ct);
+
+        return Results.Ok(new { total, items });
+    }
+
+    private static async Task<IResult> GetBookmarks(
+        Guid editionId,
+        HttpContext httpContext,
+        AuthService authService,
+        IAppDbContext db,
+        CancellationToken ct)
+    {
+        var userId = GetUserId(httpContext, authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var siteId = httpContext.GetSiteId();
+
+        var bookmarks = await db.Bookmarks
+            .Where(b => b.UserId == userId.Value && b.SiteId == siteId && b.EditionId == editionId)
+            .OrderByDescending(b => b.CreatedAt)
+            .Select(b => new BookmarkDto(
+                b.Id,
+                b.EditionId,
+                b.ChapterId,
+                b.Locator,
+                b.Title,
+                b.CreatedAt
+            ))
+            .ToListAsync(ct);
+
+        return Results.Ok(bookmarks);
+    }
+
+    private static async Task<IResult> CreateBookmark(
+        [FromBody] CreateBookmarkRequest request,
+        HttpContext httpContext,
+        AuthService authService,
+        IAppDbContext db,
+        CancellationToken ct)
+    {
+        var userId = GetUserId(httpContext, authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var siteId = httpContext.GetSiteId();
+
+        // Validate edition exists
+        var edition = await db.Editions
+            .Where(e => e.Id == request.EditionId && e.SiteId == siteId)
+            .FirstOrDefaultAsync(ct);
+
+        if (edition == null) return Results.NotFound("Edition not found");
+
+        // Validate chapter exists
+        var chapter = await db.Chapters
+            .Where(c => c.Id == request.ChapterId && c.EditionId == request.EditionId)
+            .FirstOrDefaultAsync(ct);
+
+        if (chapter == null) return Results.NotFound("Chapter not found");
+
+        var bookmark = new Bookmark
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId.Value,
+            SiteId = siteId,
+            EditionId = request.EditionId,
+            ChapterId = request.ChapterId,
+            Locator = request.Locator,
+            Title = request.Title,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        db.Bookmarks.Add(bookmark);
+        await db.SaveChangesAsync(ct);
+
+        return Results.Created($"/me/bookmarks/{bookmark.Id}", new BookmarkDto(
+            bookmark.Id,
+            bookmark.EditionId,
+            bookmark.ChapterId,
+            bookmark.Locator,
+            bookmark.Title,
+            bookmark.CreatedAt
+        ));
+    }
+
+    private static async Task<IResult> DeleteBookmark(
+        Guid id,
+        HttpContext httpContext,
+        AuthService authService,
+        IAppDbContext db,
+        CancellationToken ct)
+    {
+        var userId = GetUserId(httpContext, authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var bookmark = await db.Bookmarks
+            .Where(b => b.Id == id && b.UserId == userId.Value)
+            .FirstOrDefaultAsync(ct);
+
+        if (bookmark == null) return Results.NotFound();
+
+        db.Bookmarks.Remove(bookmark);
+        await db.SaveChangesAsync(ct);
+
+        return Results.NoContent();
+    }
+
+    // Library Endpoints
+
+    private static async Task<IResult> GetLibrary(
+        HttpContext httpContext,
+        AuthService authService,
+        IAppDbContext db,
+        [FromQuery] int? limit,
+        [FromQuery] int? offset,
+        CancellationToken ct)
+    {
+        var userId = GetUserId(httpContext, authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var query = db.UserLibraries
+            .Where(l => l.UserId == userId.Value)
+            .OrderByDescending(l => l.CreatedAt);
+
+        var total = await query.CountAsync(ct);
+        var items = await query
+            .Skip(offset ?? 0)
+            .Take(limit ?? 50)
+            .Include(l => l.Edition)
+            .Select(l => new LibraryItemDto(
+                l.EditionId,
+                l.Edition.Slug,
+                l.Edition.Title,
+                l.Edition.CoverPath,
+                l.CreatedAt
+            ))
+            .ToListAsync(ct);
+
+        return Results.Ok(new { total, items });
+    }
+
+    private static async Task<IResult> AddToLibrary(
+        Guid editionId,
+        HttpContext httpContext,
+        AuthService authService,
+        IAppDbContext db,
+        CancellationToken ct)
+    {
+        var userId = GetUserId(httpContext, authService);
+        if (userId == null) return Results.Unauthorized();
+
+        // Check if edition exists
+        var edition = await db.Editions.FirstOrDefaultAsync(e => e.Id == editionId, ct);
+        if (edition == null) return Results.NotFound("Edition not found");
+
+        // Check if already in library
+        var existing = await db.UserLibraries
+            .FirstOrDefaultAsync(l => l.UserId == userId.Value && l.EditionId == editionId, ct);
+
+        if (existing != null)
+            return Results.Ok(new LibraryItemDto(
+                existing.EditionId,
+                edition.Slug,
+                edition.Title,
+                edition.CoverPath,
+                existing.CreatedAt
+            ));
+
+        var libraryItem = new UserLibrary
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId.Value,
+            EditionId = editionId,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        db.UserLibraries.Add(libraryItem);
+        await db.SaveChangesAsync(ct);
+
+        return Results.Created($"/me/library/{editionId}", new LibraryItemDto(
+            libraryItem.EditionId,
+            edition.Slug,
+            edition.Title,
+            edition.CoverPath,
+            libraryItem.CreatedAt
+        ));
+    }
+
+    private static async Task<IResult> RemoveFromLibrary(
+        Guid editionId,
+        HttpContext httpContext,
+        AuthService authService,
+        IAppDbContext db,
+        CancellationToken ct)
+    {
+        var userId = GetUserId(httpContext, authService);
+        if (userId == null) return Results.Unauthorized();
+
+        var libraryItem = await db.UserLibraries
+            .FirstOrDefaultAsync(l => l.UserId == userId.Value && l.EditionId == editionId, ct);
+
+        if (libraryItem == null) return Results.NotFound();
+
+        db.UserLibraries.Remove(libraryItem);
+        await db.SaveChangesAsync(ct);
+
+        return Results.NoContent();
+    }
+}
+
+// DTOs
+public record ReadingProgressDto(
+    Guid EditionId,
+    Guid ChapterId,
+    string? ChapterSlug,
+    string Locator,
+    double? Percent,
+    DateTimeOffset UpdatedAt
+);
+
+public record UpsertProgressRequest(
+    Guid ChapterId,
+    string Locator,
+    double? Percent,
+    DateTimeOffset? UpdatedAt
+);
+
+public record BookmarkDto(
+    Guid Id,
+    Guid EditionId,
+    Guid ChapterId,
+    string Locator,
+    string? Title,
+    DateTimeOffset CreatedAt
+);
+
+public record CreateBookmarkRequest(
+    Guid EditionId,
+    Guid ChapterId,
+    string Locator,
+    string? Title
+);
+
+public record LibraryItemDto(
+    Guid EditionId,
+    string Slug,
+    string Title,
+    string? CoverPath,
+    DateTimeOffset CreatedAt
+);

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -48,7 +48,9 @@ builder.Services.AddCors(options =>
                 "http://programming.localhost",
                 "http://programming.localhost:5173",
                 "http://admin.localhost",
-                "http://admin.localhost:5174"
+                "http://admin.localhost:5174",
+                "https://textstack.app",
+                "https://textstack.dev"
             )
             .AllowAnyHeader()
             .AllowAnyMethod()
@@ -60,6 +62,7 @@ builder.Services.AddOpenApi();
 
 // Application layer
 builder.Services.AddApplication();
+builder.Services.AddAuthSettings(builder.Configuration);
 
 var connectionString = builder.Configuration.GetConnectionString("Default")
     ?? "Host=localhost;Port=5432;Database=books;Username=app;Password=changeme";
@@ -157,6 +160,8 @@ app.MapAuthorsEndpoints();
 app.MapGenresEndpoints();
 app.MapSiteEndpoints();
 app.MapSeoEndpoints();
+app.MapAuthEndpoints();
+app.MapUserDataEndpoints();
 
 // CLI: import-textstack command
 if (args.Length > 0 && args[0] == "import-textstack")

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -8,5 +8,14 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Jwt": {
+    "SecretKey": "dev-secret-key-min-32-characters-long-for-testing",
+    "Issuer": "textstack.app",
+    "AccessTokenExpiryMinutes": 15,
+    "RefreshTokenExpiryDays": 30
+  },
+  "Google": {
+    "ClientId": "301013894506-7ouh9ops30ubjg6s6govpeep19h26r6q.apps.googleusercontent.com"
+  }
 }

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -10,12 +10,12 @@
   },
   "AllowedHosts": "*",
   "Jwt": {
-    "SecretKey": "dev-secret-key-min-32-characters-long-for-testing",
+    "SecretKey": "",
     "Issuer": "textstack.app",
     "AccessTokenExpiryMinutes": 15,
     "RefreshTokenExpiryDays": 30
   },
   "Google": {
-    "ClientId": "301013894506-7ouh9ops30ubjg6s6govpeep19h26r6q.apps.googleusercontent.com"
+    "ClientId": ""
   }
 }

--- a/backend/src/Application/Application.csproj
+++ b/backend/src/Application/Application.csproj
@@ -6,10 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Apis.Auth" />
     <PackageReference Include="HtmlAgilityPack" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/Application/Auth/AuthDtos.cs
+++ b/backend/src/Application/Auth/AuthDtos.cs
@@ -1,0 +1,7 @@
+namespace Application.Auth;
+
+public record GoogleLoginRequest(string IdToken);
+
+public record AuthResponse(UserDto User);
+
+public record UserDto(Guid Id, string Email, string? Name, string? Picture, DateTimeOffset CreatedAt);

--- a/backend/src/Application/Auth/AuthService.cs
+++ b/backend/src/Application/Auth/AuthService.cs
@@ -1,0 +1,195 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using Application.Common.Interfaces;
+using Domain.Entities;
+using Google.Apis.Auth;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Application.Auth;
+
+public class AuthService
+{
+    private readonly IAppDbContext _db;
+    private readonly JwtSettings _jwtSettings;
+    private readonly GoogleSettings _googleSettings;
+
+    public AuthService(
+        IAppDbContext db,
+        IOptions<JwtSettings> jwtSettings,
+        IOptions<GoogleSettings> googleSettings)
+    {
+        _db = db;
+        _jwtSettings = jwtSettings.Value;
+        _googleSettings = googleSettings.Value;
+    }
+
+    public async Task<(User user, string accessToken, string refreshToken)?> LoginWithGoogleAsync(
+        string googleIdToken,
+        CancellationToken ct)
+    {
+        GoogleJsonWebSignature.Payload payload;
+        try
+        {
+            payload = await GoogleJsonWebSignature.ValidateAsync(googleIdToken, new GoogleJsonWebSignature.ValidationSettings
+            {
+                Audience = [_googleSettings.ClientId]
+            });
+        }
+        catch (InvalidJwtException)
+        {
+            return null;
+        }
+
+        var user = await GetOrCreateUserAsync(payload, ct);
+        var accessToken = GenerateAccessToken(user);
+        var refreshToken = await CreateRefreshTokenAsync(user.Id, ct);
+
+        return (user, accessToken, refreshToken);
+    }
+
+    public async Task<(User user, string accessToken, string refreshToken)?> RefreshTokenAsync(
+        string refreshToken,
+        CancellationToken ct)
+    {
+        var token = await _db.UserRefreshTokens
+            .Include(x => x.User)
+            .FirstOrDefaultAsync(x => x.Token == refreshToken && x.ExpiresAt > DateTimeOffset.UtcNow, ct);
+
+        if (token == null)
+            return null;
+
+        // Rotate refresh token
+        _db.UserRefreshTokens.Remove(token);
+        var newRefreshToken = await CreateRefreshTokenAsync(token.UserId, ct);
+        var accessToken = GenerateAccessToken(token.User);
+
+        return (token.User, accessToken, newRefreshToken);
+    }
+
+    public async Task<bool> LogoutAsync(string refreshToken, CancellationToken ct)
+    {
+        var token = await _db.UserRefreshTokens
+            .FirstOrDefaultAsync(x => x.Token == refreshToken, ct);
+
+        if (token == null)
+            return false;
+
+        _db.UserRefreshTokens.Remove(token);
+        await _db.SaveChangesAsync(ct);
+        return true;
+    }
+
+    public async Task<User?> GetUserByIdAsync(Guid userId, CancellationToken ct)
+    {
+        return await _db.Users.FirstOrDefaultAsync(x => x.Id == userId, ct);
+    }
+
+    public Guid? ValidateAccessToken(string accessToken)
+    {
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.UTF8.GetBytes(_jwtSettings.SecretKey);
+
+        try
+        {
+            var principal = tokenHandler.ValidateToken(accessToken, new TokenValidationParameters
+            {
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(key),
+                ValidateIssuer = true,
+                ValidIssuer = _jwtSettings.Issuer,
+                ValidateAudience = false,
+                ValidateLifetime = true,
+                ClockSkew = TimeSpan.Zero
+            }, out _);
+
+            var userIdClaim = principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            return userIdClaim != null ? Guid.Parse(userIdClaim) : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private async Task<User> GetOrCreateUserAsync(GoogleJsonWebSignature.Payload payload, CancellationToken ct)
+    {
+        var user = await _db.Users.FirstOrDefaultAsync(x => x.GoogleSubject == payload.Subject, ct);
+
+        if (user != null)
+        {
+            // Update name/email/picture if changed
+            if (user.Email != payload.Email || user.Name != payload.Name || user.Picture != payload.Picture)
+            {
+                user.Email = payload.Email;
+                user.Name = payload.Name;
+                user.Picture = payload.Picture;
+                await _db.SaveChangesAsync(ct);
+            }
+            return user;
+        }
+
+        user = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = payload.Email,
+            Name = payload.Name,
+            Picture = payload.Picture,
+            GoogleSubject = payload.Subject,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        _db.Users.Add(user);
+        await _db.SaveChangesAsync(ct);
+        return user;
+    }
+
+    private string GenerateAccessToken(User user)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtSettings.SecretKey));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+            new Claim(ClaimTypes.Email, user.Email),
+            new Claim(ClaimTypes.Name, user.Name ?? user.Email)
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: _jwtSettings.Issuer,
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(_jwtSettings.AccessTokenExpiryMinutes),
+            signingCredentials: credentials
+        );
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private async Task<string> CreateRefreshTokenAsync(Guid userId, CancellationToken ct)
+    {
+        var token = new UserRefreshToken
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Token = GenerateSecureToken(),
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(_jwtSettings.RefreshTokenExpiryDays),
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        _db.UserRefreshTokens.Add(token);
+        await _db.SaveChangesAsync(ct);
+        return token.Token;
+    }
+
+    private static string GenerateSecureToken()
+    {
+        var bytes = new byte[64];
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(bytes);
+        return Convert.ToBase64String(bytes);
+    }
+}

--- a/backend/src/Application/Auth/GoogleSettings.cs
+++ b/backend/src/Application/Auth/GoogleSettings.cs
@@ -1,0 +1,8 @@
+namespace Application.Auth;
+
+public class GoogleSettings
+{
+    public const string SectionName = "Google";
+
+    public required string ClientId { get; set; }
+}

--- a/backend/src/Application/Auth/JwtSettings.cs
+++ b/backend/src/Application/Auth/JwtSettings.cs
@@ -1,0 +1,11 @@
+namespace Application.Auth;
+
+public class JwtSettings
+{
+    public const string SectionName = "Jwt";
+
+    public required string SecretKey { get; set; }
+    public string Issuer { get; set; } = "textstack.app";
+    public int AccessTokenExpiryMinutes { get; set; } = 15;
+    public int RefreshTokenExpiryDays { get; set; } = 30;
+}

--- a/backend/src/Application/Common/Interfaces/IAppDbContext.cs
+++ b/backend/src/Application/Common/Interfaces/IAppDbContext.cs
@@ -20,6 +20,7 @@ public interface IAppDbContext
     DbSet<AdminUser> AdminUsers { get; }
     DbSet<AdminRefreshToken> AdminRefreshTokens { get; }
     DbSet<AdminAuditLog> AdminAuditLogs { get; }
+    DbSet<UserRefreshToken> UserRefreshTokens { get; }
     DbSet<Author> Authors { get; }
     DbSet<EditionAuthor> EditionAuthors { get; }
     DbSet<Genre> Genres { get; }

--- a/backend/src/Application/DependencyInjection.cs
+++ b/backend/src/Application/DependencyInjection.cs
@@ -1,7 +1,9 @@
 using Application.Admin;
+using Application.Auth;
 using Application.Books;
 using Application.Seo;
 using Application.Sites;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Application;
@@ -15,6 +17,14 @@ public static class DependencyInjection
         services.AddScoped<AdminService>();
         services.AddScoped<SiteService>();
         services.AddScoped<Ingestion.IngestionService>();
+        services.AddScoped<AuthService>();
+        return services;
+    }
+
+    public static IServiceCollection AddAuthSettings(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<JwtSettings>(configuration.GetSection(JwtSettings.SectionName));
+        services.Configure<GoogleSettings>(configuration.GetSection(GoogleSettings.SectionName));
         return services;
     }
 }

--- a/backend/src/Domain/Entities/User.cs
+++ b/backend/src/Domain/Entities/User.cs
@@ -5,6 +5,7 @@ public class User
     public Guid Id { get; set; }
     public required string Email { get; set; }
     public string? Name { get; set; }
+    public string? Picture { get; set; }
     public required string GoogleSubject { get; set; }
     public DateTimeOffset CreatedAt { get; set; }
 

--- a/backend/src/Domain/Entities/UserRefreshToken.cs
+++ b/backend/src/Domain/Entities/UserRefreshToken.cs
@@ -1,0 +1,12 @@
+namespace Domain.Entities;
+
+public class UserRefreshToken
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public required string Token { get; set; }
+    public DateTimeOffset ExpiresAt { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+
+    public User User { get; set; } = null!;
+}

--- a/backend/src/Infrastructure/Migrations/20260109232810_AddUserRefreshTokens.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260109232810_AddUserRefreshTokens.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260109232810_AddUserRefreshTokens")]
+    partial class AddUserRefreshTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -970,10 +973,6 @@ namespace Infrastructure.Migrations
                         .HasMaxLength(255)
                         .HasColumnType("character varying(255)")
                         .HasColumnName("name");
-
-                    b.Property<string>("Picture")
-                        .HasColumnType("text")
-                        .HasColumnName("picture");
 
                     b.HasKey("Id")
                         .HasName("pk_users");

--- a/backend/src/Infrastructure/Migrations/20260109232810_AddUserRefreshTokens.cs
+++ b/backend/src/Infrastructure/Migrations/20260109232810_AddUserRefreshTokens.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserRefreshTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "user_refresh_tokens",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    token = table.Column<string>(type: "text", nullable: false),
+                    expires_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_user_refresh_tokens", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_user_refresh_tokens_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_user_refresh_tokens_expires_at",
+                table: "user_refresh_tokens",
+                column: "expires_at");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_user_refresh_tokens_token",
+                table: "user_refresh_tokens",
+                column: "token",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_user_refresh_tokens_user_id",
+                table: "user_refresh_tokens",
+                column: "user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "user_refresh_tokens");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Migrations/20260110065304_AddUserPicture.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260110065304_AddUserPicture.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260110065304_AddUserPicture")]
+    partial class AddUserPicture
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Migrations/20260110065304_AddUserPicture.cs
+++ b/backend/src/Infrastructure/Migrations/20260110065304_AddUserPicture.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserPicture : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "picture",
+                table: "users",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "picture",
+                table: "users");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.cs
@@ -23,6 +23,7 @@ public class AppDbContext : DbContext, IAppDbContext
     public DbSet<AdminUser> AdminUsers => Set<AdminUser>();
     public DbSet<AdminRefreshToken> AdminRefreshTokens => Set<AdminRefreshToken>();
     public DbSet<AdminAuditLog> AdminAuditLogs => Set<AdminAuditLog>();
+    public DbSet<UserRefreshToken> UserRefreshTokens => Set<UserRefreshToken>();
     public DbSet<Author> Authors => Set<Author>();
     public DbSet<EditionAuthor> EditionAuthors => Set<EditionAuthor>();
     public DbSet<Genre> Genres => Set<Genre>();
@@ -191,6 +192,15 @@ public class AppDbContext : DbContext, IAppDbContext
             e.HasIndex(x => x.ActionType);
             e.HasIndex(x => x.CreatedAt);
             e.HasOne(x => x.AdminUser).WithMany(x => x.AuditLogs).HasForeignKey(x => x.AdminUserId).OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // UserRefreshToken
+        modelBuilder.Entity<UserRefreshToken>(e =>
+        {
+            e.HasIndex(x => x.UserId);
+            e.HasIndex(x => x.ExpiresAt);
+            e.HasIndex(x => x.Token).IsUnique();
+            e.HasOne(x => x.User).WithMany().HasForeignKey(x => x.UserId).OnDelete(DeleteBehavior.Cascade);
         });
 
         // Author

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,9 +115,11 @@ services:
       ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT:-Development}
       ConnectionStrings__Default: "Host=db;Port=5432;Database=${POSTGRES_DB:-books};Username=${POSTGRES_USER:-app};Password=${POSTGRES_PASSWORD:-changeme}"
       Storage__RootPath: /storage
-      Jwt__Secret: ${JWT_SECRET:-dev-secret-key-min-32-characters-long}
-      Jwt__Issuer: ${JWT_ISSUER:-books-api}
-      Jwt__Audience: ${JWT_AUDIENCE:-books-client}
+      Jwt__SecretKey: ${JWT_SECRET:-dev-secret-key-min-32-characters-long-for-testing}
+      Jwt__Issuer: ${JWT_ISSUER:-textstack.app}
+      Jwt__AccessTokenExpiryMinutes: ${JWT_ACCESS_TOKEN_EXPIRY_MINUTES:-15}
+      Jwt__RefreshTokenExpiryDays: ${JWT_REFRESH_TOKEN_EXPIRY_DAYS:-30}
+      Google__ClientId: ${GOOGLE_CLIENT_ID:-301013894506-7ouh9ops30ubjg6s6govpeep19h26r6q.apps.googleusercontent.com}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
     volumes:
       - ./data/storage:/storage
@@ -167,6 +169,7 @@ services:
     container_name: books_web
     environment:
       VITE_API_URL: ${VITE_API_URL:-http://localhost:8080}
+      VITE_GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-301013894506-7ouh9ops30ubjg6s6govpeep19h26r6q.apps.googleusercontent.com}
     ports:
       - "5173:5173"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
       Jwt__Issuer: ${JWT_ISSUER:-textstack.app}
       Jwt__AccessTokenExpiryMinutes: ${JWT_ACCESS_TOKEN_EXPIRY_MINUTES:-15}
       Jwt__RefreshTokenExpiryDays: ${JWT_REFRESH_TOKEN_EXPIRY_DAYS:-30}
-      Google__ClientId: ${GOOGLE_CLIENT_ID:-301013894506-7ouh9ops30ubjg6s6govpeep19h26r6q.apps.googleusercontent.com}
+      Google__ClientId: ${GOOGLE_CLIENT_ID:-}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
     volumes:
       - ./data/storage:/storage
@@ -169,7 +169,7 @@ services:
     container_name: books_web
     environment:
       VITE_API_URL: ${VITE_API_URL:-http://localhost:8080}
-      VITE_GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-301013894506-7ouh9ops30ubjg6s6govpeep19h26r6q.apps.googleusercontent.com}
+      VITE_GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
     ports:
       - "5173:5173"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Google OAuth login with JWT + httpOnly cookies
- User profile with Google picture
- Personal library (add/remove books)
- Reading progress sync (server-first when authenticated)
- Overall book progress calculation (based on word counts)
- Continue reading from saved chapter
- LibraryPage with progress display

## Config Required
Set env vars before deploying:
```
GOOGLE_CLIENT_ID=xxx.apps.googleusercontent.com
JWT_SECRET=<32+ char secret>
```

## Test plan
- [ ] Google Sign-In works
- [ ] Profile shows Google picture
- [ ] Add/remove books from library
- [ ] Reading progress syncs across devices
- [ ] Library shows overall book progress %
- [ ] "Continue" links to saved chapter

🤖 Generated with [Claude Code](https://claude.ai/code)