### PR TITLE
feat(userbook): server sync for progress + bookmarks

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -33,7 +33,7 @@ function LanguageRoutes() {
 
   // Hide header on reader pages (have their own top bar)
   const isReaderPage = /^\/[a-z]{2}\/books\/[^/]+\/[^/]+$/.test(location.pathname)
-  const isUserBookReaderPage = /^\/[a-z]{2}\/library\/my\/[^/]+\/read\/\d+$/.test(location.pathname)
+  const isUserBookReaderPage = /^\/[a-z]{2}\/library\/my\/[^/]+\/read\/[^/]+$/.test(location.pathname)
 
   return (
     <LanguageProvider>
@@ -51,7 +51,7 @@ function LanguageRoutes() {
         <Route path="/about" element={<AboutPage />} />
         <Route path="/library" element={<LibraryPage />} />
         <Route path="/library/my/:id" element={<UserBookDetailPage />} />
-        <Route path="/library/my/:id/read/:chapterNumber" element={<ReaderPage mode="userbook" />} />
+        <Route path="/library/my/:id/read/:chapterSlug" element={<ReaderPage mode="userbook" />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </LanguageProvider>

--- a/apps/web/src/api/userData.ts
+++ b/apps/web/src/api/userData.ts
@@ -1,0 +1,67 @@
+import { refreshToken } from './auth'
+
+const API_BASE = import.meta.env.VITE_API_URL ?? ''
+
+async function authFetch<T>(path: string, options?: RequestInit, retry = true): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    credentials: 'include',
+  })
+
+  if (!res.ok) {
+    if (res.status === 401 && retry) {
+      try {
+        await refreshToken()
+        return authFetch<T>(path, options, false)
+      } catch {
+        throw new Error('Unauthorized')
+      }
+    }
+    if (res.status === 401) throw new Error('Unauthorized')
+    const text = await res.text()
+    let error = `API error: ${res.status}`
+    try {
+      const json = JSON.parse(text)
+      if (json.error) error = json.error
+    } catch {}
+    throw new Error(error)
+  }
+
+  const text = await res.text()
+  if (!text) return {} as T
+  return JSON.parse(text)
+}
+
+// Bookmark types
+export interface PublicBookmark {
+  id: string
+  editionId: string
+  chapterId: string
+  locator: string
+  title: string | null
+  createdAt: string
+}
+
+// Bookmark API
+export async function getPublicBookmarks(editionId: string): Promise<PublicBookmark[]> {
+  return authFetch<PublicBookmark[]>(`/me/bookmarks/${editionId}`)
+}
+
+export async function createPublicBookmark(data: {
+  editionId: string
+  chapterId: string
+  locator: string
+  title?: string
+}): Promise<PublicBookmark> {
+  return authFetch<PublicBookmark>('/me/bookmarks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+}
+
+export async function deletePublicBookmark(id: string): Promise<void> {
+  await authFetch<void>(`/me/bookmarks/${id}`, {
+    method: 'DELETE',
+  })
+}

--- a/apps/web/src/components/reader/ScrollReaderContent.tsx
+++ b/apps/web/src/components/reader/ScrollReaderContent.tsx
@@ -74,11 +74,11 @@ export function ScrollReaderContent({
 
   // Register chapter ref
   const setChapterRef = useCallback(
-    (slug: string, el: HTMLElement | null) => {
+    (identifier: string, el: HTMLElement | null) => {
       if (el) {
-        chapterRefs.current.set(slug, el)
+        chapterRefs.current.set(identifier, el)
       } else {
-        chapterRefs.current.delete(slug)
+        chapterRefs.current.delete(identifier)
       }
     },
     [chapterRefs]
@@ -117,7 +117,7 @@ export function ScrollReaderContent({
   return (
     <div className="scroll-reader" onClick={handleClick}>
       {chapters.map((chapter, i) => (
-        <Fragment key={chapter.slug}>
+        <Fragment key={chapter.identifier}>
           {/* Chapter separator (not for first chapter) */}
           {i > 0 && (
             <div className="chapter-separator">
@@ -129,9 +129,9 @@ export function ScrollReaderContent({
 
           {/* Chapter content */}
           <article
-            ref={(el) => setChapterRef(chapter.slug, el)}
+            ref={(el) => setChapterRef(chapter.identifier, el)}
             className="scroll-reader__chapter"
-            data-chapter-slug={chapter.slug}
+            data-chapter-id={chapter.identifier}
             data-chapter-index={chapter.index}
             style={{
               fontSize: `${settings.fontSize}px`,

--- a/apps/web/src/hooks/useBookmarks.ts
+++ b/apps/web/src/hooks/useBookmarks.ts
@@ -1,11 +1,17 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { openOfflineDb } from '../lib/offlineDb'
+import {
+  getPublicBookmarks,
+  createPublicBookmark,
+  deletePublicBookmark,
+} from '../api/userData'
 
 export interface Bookmark {
   id: string
   bookId: string
   chapterSlug: string
   chapterTitle: string
+  chapterId?: string // For server sync
   createdAt: number
 }
 
@@ -15,7 +21,7 @@ function generateId(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
 }
 
-async function getAllBookmarks(bookId: string): Promise<Bookmark[]> {
+async function getAllBookmarksFromDB(bookId: string): Promise<Bookmark[]> {
   const db = await openOfflineDb()
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readonly')
@@ -25,7 +31,6 @@ async function getAllBookmarks(bookId: string): Promise<Bookmark[]> {
 
     request.onsuccess = () => {
       const bookmarks = request.result as Bookmark[]
-      // Sort by createdAt descending (newest first)
       bookmarks.sort((a, b) => b.createdAt - a.createdAt)
       resolve(bookmarks)
     }
@@ -63,46 +68,168 @@ async function removeBookmarkFromDB(id: string): Promise<void> {
   })
 }
 
-async function findBookmark(bookId: string, chapterSlug: string): Promise<Bookmark | null> {
-  const bookmarks = await getAllBookmarks(bookId)
-  return bookmarks.find((b) => b.chapterSlug === chapterSlug) || null
+async function clearBookmarksFromDB(bookId: string): Promise<void> {
+  const db = await openOfflineDb()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    const store = tx.objectStore(STORE_NAME)
+    const index = store.index('bookId')
+    const request = index.openCursor(bookId)
+
+    request.onsuccess = () => {
+      const cursor = request.result
+      if (cursor) {
+        cursor.delete()
+        cursor.continue()
+      } else {
+        resolve()
+      }
+    }
+    request.onerror = () => reject(request.error)
+  })
 }
 
-export function useBookmarks(bookId: string) {
+interface UseBookmarksOptions {
+  editionId?: string // For server sync (public books)
+  isAuthenticated?: boolean
+}
+
+export function useBookmarks(bookId: string, options?: UseBookmarksOptions) {
+  const { editionId, isAuthenticated } = options || {}
   const [bookmarks, setBookmarks] = useState<Bookmark[]>([])
   const [loading, setLoading] = useState(true)
+  const serverSyncedRef = useRef(false)
 
-  // Load bookmarks on mount
+  // Load bookmarks: IndexedDB first, then server if authenticated
   useEffect(() => {
-    if (!bookId) return
-    setLoading(true)
-    getAllBookmarks(bookId)
-      .then(setBookmarks)
-      .catch(console.error)
-      .finally(() => setLoading(false))
-  }, [bookId])
+    if (!bookId) {
+      setLoading(false)
+      return
+    }
 
-  const addBookmark = useCallback(async (chapterSlug: string, chapterTitle: string) => {
-    const existing = await findBookmark(bookId, chapterSlug)
-    if (existing) return existing
+    let cancelled = false
+    serverSyncedRef.current = false
 
-    const bookmark = await addBookmarkToDB({ bookId, chapterSlug, chapterTitle })
-    setBookmarks((prev) => [bookmark, ...prev])
-    return bookmark
-  }, [bookId])
+    // 1. Load from IndexedDB first (instant)
+    getAllBookmarksFromDB(bookId)
+      .then((localBookmarks) => {
+        if (cancelled) return
+        setBookmarks(localBookmarks)
+      })
+      .catch(() => {})
 
-  const removeBookmark = useCallback(async (id: string) => {
-    await removeBookmarkFromDB(id)
-    setBookmarks((prev) => prev.filter((b) => b.id !== id))
-  }, [])
+    // 2. If authenticated with editionId, fetch from server
+    if (isAuthenticated && editionId) {
+      getPublicBookmarks(editionId)
+        .then(async (serverBookmarks) => {
+          if (cancelled) return
+          serverSyncedRef.current = true
 
-  const isBookmarked = useCallback((chapterSlug: string) => {
-    return bookmarks.some((b) => b.chapterSlug === chapterSlug)
-  }, [bookmarks])
+          // Convert server bookmarks to local format
+          const converted: Bookmark[] = serverBookmarks.map((sb) => ({
+            id: sb.id,
+            bookId,
+            chapterSlug: sb.locator.replace('chapter:', ''),
+            chapterTitle: sb.title || '',
+            chapterId: sb.chapterId,
+            createdAt: new Date(sb.createdAt).getTime(),
+          }))
 
-  const getBookmarkForChapter = useCallback((chapterSlug: string) => {
-    return bookmarks.find((b) => b.chapterSlug === chapterSlug)
-  }, [bookmarks])
+          // Replace local with server data
+          await clearBookmarksFromDB(bookId)
+          for (const bm of converted) {
+            await addBookmarkToDB({ ...bm })
+          }
+
+          if (!cancelled) setBookmarks(converted)
+        })
+        .catch(() => {
+          // Server unavailable, use local data
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false)
+        })
+    } else {
+      setLoading(false)
+    }
+
+    return () => {
+      cancelled = true
+    }
+  }, [bookId, editionId, isAuthenticated])
+
+  const addBookmark = useCallback(
+    async (chapterSlug: string, chapterTitle: string, chapterId?: string) => {
+      // Check if already bookmarked
+      const existing = bookmarks.find((b) => b.chapterSlug === chapterSlug)
+      if (existing) return existing
+
+      // If authenticated with editionId, create on server first
+      if (isAuthenticated && editionId && chapterId) {
+        try {
+          const serverBookmark = await createPublicBookmark({
+            editionId,
+            chapterId,
+            locator: `chapter:${chapterSlug}`,
+            title: chapterTitle,
+          })
+
+          const bookmark: Bookmark = {
+            id: serverBookmark.id,
+            bookId,
+            chapterSlug,
+            chapterTitle,
+            chapterId,
+            createdAt: new Date(serverBookmark.createdAt).getTime(),
+          }
+
+          // Also save to IndexedDB for offline
+          await addBookmarkToDB({ bookId, chapterSlug, chapterTitle, chapterId })
+          setBookmarks((prev) => [bookmark, ...prev])
+          return bookmark
+        } catch {
+          // Fall through to local-only
+        }
+      }
+
+      // Local-only bookmark
+      const bookmark = await addBookmarkToDB({ bookId, chapterSlug, chapterTitle, chapterId })
+      setBookmarks((prev) => [bookmark, ...prev])
+      return bookmark
+    },
+    [bookId, editionId, isAuthenticated, bookmarks]
+  )
+
+  const removeBookmark = useCallback(
+    async (id: string) => {
+      // If authenticated, delete from server
+      if (isAuthenticated && editionId) {
+        try {
+          await deletePublicBookmark(id)
+        } catch {
+          // Server unavailable, continue with local delete
+        }
+      }
+
+      await removeBookmarkFromDB(id)
+      setBookmarks((prev) => prev.filter((b) => b.id !== id))
+    },
+    [editionId, isAuthenticated]
+  )
+
+  const isBookmarked = useCallback(
+    (chapterSlug: string) => {
+      return bookmarks.some((b) => b.chapterSlug === chapterSlug)
+    },
+    [bookmarks]
+  )
+
+  const getBookmarkForChapter = useCallback(
+    (chapterSlug: string) => {
+      return bookmarks.find((b) => b.chapterSlug === chapterSlug)
+    },
+    [bookmarks]
+  )
 
   return {
     bookmarks,

--- a/apps/web/src/hooks/useUserBookBookmarks.ts
+++ b/apps/web/src/hooks/useUserBookBookmarks.ts
@@ -1,0 +1,121 @@
+import { useState, useEffect, useCallback } from 'react'
+import {
+  getUserBookBookmarks,
+  createUserBookBookmark,
+  deleteUserBookBookmark,
+} from '../api/userBooks'
+import type { Bookmark } from './useBookmarks'
+
+export function useUserBookBookmarks(bookId: string) {
+  const [bookmarks, setBookmarks] = useState<Bookmark[]>([])
+  const [loading, setLoading] = useState(true)
+
+  // Load bookmarks from server on mount
+  useEffect(() => {
+    if (!bookId) {
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+
+    getUserBookBookmarks(bookId)
+      .then((serverBookmarks) => {
+        if (cancelled) return
+        setBookmarks(
+          serverBookmarks.map((b) => ({
+            id: b.id,
+            bookId,
+            chapterSlug: b.chapterSlug || b.locator.replace('chapter:', ''),
+            chapterTitle: b.title || '',
+            chapterId: b.chapterId,
+            createdAt: new Date(b.createdAt).getTime(),
+          }))
+        )
+      })
+      .catch(() => {
+        // Server unavailable
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [bookId])
+
+  const addBookmark = useCallback(
+    async (chapterId: string, chapterSlug: string | null, title: string) => {
+      if (!bookId) return null
+
+      const slug = chapterSlug || ''
+
+      // Check if already bookmarked
+      const existing = bookmarks.find((b) => b.chapterSlug === slug)
+      if (existing) return existing
+
+      try {
+        const locator = `chapter:${slug}`
+        const serverBookmark = await createUserBookBookmark(bookId, {
+          chapterId,
+          locator,
+          title,
+        })
+
+        const bookmark: Bookmark = {
+          id: serverBookmark.id,
+          bookId,
+          chapterSlug: serverBookmark.chapterSlug || slug,
+          chapterTitle: serverBookmark.title || title,
+          chapterId: serverBookmark.chapterId,
+          createdAt: new Date(serverBookmark.createdAt).getTime(),
+        }
+
+        setBookmarks((prev) => [bookmark, ...prev])
+        return bookmark
+      } catch {
+        return null
+      }
+    },
+    [bookId, bookmarks]
+  )
+
+  const removeBookmark = useCallback(
+    async (id: string) => {
+      if (!bookId) return
+
+      try {
+        await deleteUserBookBookmark(bookId, id)
+        setBookmarks((prev) => prev.filter((b) => b.id !== id))
+      } catch {
+        // Server unavailable
+      }
+    },
+    [bookId]
+  )
+
+  const isBookmarked = useCallback(
+    (chapterSlug: string) => {
+      return bookmarks.some((b) => b.chapterSlug === chapterSlug)
+    },
+    [bookmarks]
+  )
+
+  const getBookmarkForChapter = useCallback(
+    (chapterSlug: string) => {
+      return bookmarks.find((b) => b.chapterSlug === chapterSlug)
+    },
+    [bookmarks]
+  )
+
+  return {
+    bookmarks,
+    loading,
+    addBookmark,
+    removeBookmark,
+    isBookmarked,
+    getBookmarkForChapter,
+  }
+}

--- a/apps/web/src/hooks/useUserBookProgress.ts
+++ b/apps/web/src/hooks/useUserBookProgress.ts
@@ -1,8 +1,18 @@
 import { useEffect, useCallback, useRef, useState } from 'react'
+import { getUserBookProgress, saveUserBookProgress } from '../api/userBooks'
 
 const STORAGE_KEY = 'userbook.progress.'
+const DEBOUNCE_MS = 2000
 
 interface SavedProgress {
+  chapterSlug: string
+  locator?: string
+  percent: number
+  updatedAt: number
+}
+
+// Legacy format for migration
+interface LegacyProgress {
   chapterNumber: number
   page: number
   percent: number
@@ -11,50 +21,142 @@ interface SavedProgress {
 
 export function useUserBookProgress(bookId: string) {
   const [savedProgress, setSavedProgress] = useState<SavedProgress | null>(null)
+  // Legacy progress requiring migration (has chapterNumber, needs slug)
+  const [legacyProgress, setLegacyProgress] = useState<LegacyProgress | null>(null)
   const [isLoading, setIsLoading] = useState(true)
-  const lastSavedRef = useRef<{ chapter: number; page: number } | null>(null)
+  const lastSavedRef = useRef<{ slug: string; locator?: string } | null>(null)
+  const serverSyncTimerRef = useRef<number | null>(null)
+  const pendingSyncRef = useRef<SavedProgress | null>(null)
 
-  // Load saved progress on mount
+  // Load from localStorage first, then fetch from server
   useEffect(() => {
     if (!bookId) {
       setIsLoading(false)
       return
     }
 
+    let cancelled = false
+
+    // 1. Load from localStorage (instant)
     try {
       const stored = localStorage.getItem(`${STORAGE_KEY}${bookId}`)
       if (stored) {
-        const data = JSON.parse(stored) as SavedProgress
-        setSavedProgress(data)
+        const data = JSON.parse(stored)
+        // Check if this is legacy format (has chapterNumber, no chapterSlug)
+        if ('chapterNumber' in data && !('chapterSlug' in data)) {
+          setLegacyProgress(data as LegacyProgress)
+        } else if ('chapterSlug' in data) {
+          setSavedProgress(data as SavedProgress)
+        }
       }
     } catch {
       // Invalid data, ignore
     }
-    setIsLoading(false)
+
+    // 2. Fetch from server in background
+    getUserBookProgress(bookId).then((serverProgress) => {
+      if (cancelled || !serverProgress?.chapterSlug) return
+
+      const serverData: SavedProgress = {
+        chapterSlug: serverProgress.chapterSlug,
+        locator: serverProgress.locator ?? undefined,
+        percent: serverProgress.percent ?? 0,
+        updatedAt: serverProgress.updatedAt ? new Date(serverProgress.updatedAt).getTime() : 0,
+      }
+
+      // Merge: use newer timestamp
+      const currentStored = localStorage.getItem(`${STORAGE_KEY}${bookId}`)
+      let localData: SavedProgress | null = null
+      if (currentStored) {
+        try {
+          const parsed = JSON.parse(currentStored)
+          if ('chapterSlug' in parsed) localData = parsed
+        } catch {}
+      }
+
+      if (!localData || serverData.updatedAt > localData.updatedAt) {
+        // Server is newer → update localStorage + state
+        try {
+          localStorage.setItem(`${STORAGE_KEY}${bookId}`, JSON.stringify(serverData))
+        } catch {}
+        setSavedProgress(serverData)
+        setLegacyProgress(null)
+      }
+    }).catch(() => {
+      // Server unavailable, use localStorage
+    }).finally(() => {
+      if (!cancelled) setIsLoading(false)
+    })
+
+    return () => { cancelled = true }
   }, [bookId])
 
-  // Save progress
-  const saveProgress = useCallback((chapterNumber: number, page: number, percent: number) => {
+  // Sync to server (debounced)
+  const syncToServer = useCallback((data: SavedProgress) => {
+    pendingSyncRef.current = data
+    if (serverSyncTimerRef.current) clearTimeout(serverSyncTimerRef.current)
+
+    serverSyncTimerRef.current = window.setTimeout(() => {
+      const toSync = pendingSyncRef.current
+      if (!toSync || !bookId) return
+      pendingSyncRef.current = null
+
+      saveUserBookProgress(bookId, {
+        chapterSlug: toSync.chapterSlug,
+        locator: toSync.locator,
+        percent: toSync.percent,
+        updatedAt: new Date(toSync.updatedAt).toISOString(),
+      }).catch(() => {
+        // Server unavailable, localStorage is still saved
+      })
+    }, DEBOUNCE_MS)
+  }, [bookId])
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (serverSyncTimerRef.current) clearTimeout(serverSyncTimerRef.current)
+      // Flush pending sync immediately on unmount
+      const toSync = pendingSyncRef.current
+      if (toSync && bookId) {
+        saveUserBookProgress(bookId, {
+          chapterSlug: toSync.chapterSlug,
+          locator: toSync.locator,
+          percent: toSync.percent,
+          updatedAt: new Date(toSync.updatedAt).toISOString(),
+        }).catch(() => {})
+      }
+    }
+  }, [bookId])
+
+  // Save progress - uses slug + locator
+  const saveProgress = useCallback((chapterSlug: string, _page: number, percent: number, locator?: string) => {
     if (!bookId) return
 
     // Skip if same position
     const last = lastSavedRef.current
-    if (last && last.chapter === chapterNumber && last.page === page) return
-    lastSavedRef.current = { chapter: chapterNumber, page }
+    if (last && last.slug === chapterSlug && last.locator === locator) return
+    lastSavedRef.current = { slug: chapterSlug, locator }
 
     const data: SavedProgress = {
-      chapterNumber,
-      page,
+      chapterSlug,
+      locator,
       percent,
       updatedAt: Date.now(),
     }
 
+    // Save to localStorage immediately
     try {
       localStorage.setItem(`${STORAGE_KEY}${bookId}`, JSON.stringify(data))
+      setLegacyProgress(null)
+      setSavedProgress(data)
     } catch {
       // localStorage full or disabled
     }
-  }, [bookId])
+
+    // Sync to server (debounced)
+    syncToServer(data)
+  }, [bookId, syncToServer])
 
   // Clear progress (e.g., when book is deleted)
   const clearProgress = useCallback(() => {
@@ -69,6 +171,7 @@ export function useUserBookProgress(bookId: string) {
 
   return {
     savedProgress,
+    legacyProgress, // For migration: caller can use chapterNumber to look up slug
     isLoading,
     saveProgress,
     clearProgress,

--- a/backend/src/Application/Common/Interfaces/IAppDbContext.cs
+++ b/backend/src/Application/Common/Interfaces/IAppDbContext.cs
@@ -34,6 +34,7 @@ public interface IAppDbContext
     DbSet<UserChapter> UserChapters { get; }
     DbSet<UserBookFile> UserBookFiles { get; }
     DbSet<UserIngestionJob> UserIngestionJobs { get; }
+    DbSet<UserBookBookmark> UserBookBookmarks { get; }
 
     Task<int> SaveChangesAsync(CancellationToken ct = default);
 }

--- a/backend/src/Contracts/UserBooks/UserBookDtos.cs
+++ b/backend/src/Contracts/UserBooks/UserBookDtos.cs
@@ -31,6 +31,7 @@ public record UserBookDetailDto(
 public record UserChapterSummaryDto(
     Guid Id,
     int ChapterNumber,
+    string? Slug,
     string Title,
     int? WordCount
 );
@@ -38,6 +39,7 @@ public record UserChapterSummaryDto(
 public record UserChapterDto(
     Guid Id,
     int ChapterNumber,
+    string? Slug,
     string Title,
     string Html,
     int? WordCount,
@@ -45,10 +47,39 @@ public record UserChapterDto(
     UserChapterNavDto? Next
 );
 
-public record UserChapterNavDto(int ChapterNumber, string Title);
+public record UserChapterNavDto(int ChapterNumber, string? Slug, string Title);
 
 public record TocEntryDto(string Title, int? ChapterNumber, IReadOnlyList<TocEntryDto>? Children);
 
 public record UploadUserBookResponse(Guid UserBookId, Guid JobId, string Status);
 
 public record StorageQuotaDto(long UsedBytes, long LimitBytes, double UsedPercent);
+
+public record UserBookProgressDto(
+    string? ChapterSlug,
+    string? Locator,
+    double? Percent,
+    DateTimeOffset? UpdatedAt
+);
+
+public record UpsertUserBookProgressRequest(
+    string ChapterSlug,
+    string? Locator,
+    double? Percent,
+    DateTimeOffset? UpdatedAt
+);
+
+public record UserBookBookmarkDto(
+    Guid Id,
+    Guid ChapterId,
+    string? ChapterSlug,
+    string Locator,
+    string? Title,
+    DateTimeOffset CreatedAt
+);
+
+public record CreateUserBookBookmarkRequest(
+    Guid ChapterId,
+    string Locator,
+    string? Title
+);

--- a/backend/src/Domain/Entities/UserBook.cs
+++ b/backend/src/Domain/Entities/UserBook.cs
@@ -17,6 +17,12 @@ public class UserBook
     public DateTimeOffset CreatedAt { get; set; }
     public DateTimeOffset UpdatedAt { get; set; }
 
+    // Reading progress
+    public string? ProgressChapterSlug { get; set; }
+    public string? ProgressLocator { get; set; }
+    public double? ProgressPercent { get; set; }
+    public DateTimeOffset? ProgressUpdatedAt { get; set; }
+
     public User User { get; set; } = null!;
     public ICollection<UserChapter> Chapters { get; set; } = [];
     public ICollection<UserBookFile> BookFiles { get; set; } = [];

--- a/backend/src/Domain/Entities/UserBookBookmark.cs
+++ b/backend/src/Domain/Entities/UserBookBookmark.cs
@@ -1,0 +1,14 @@
+namespace Domain.Entities;
+
+public class UserBookBookmark
+{
+    public Guid Id { get; set; }
+    public Guid UserBookId { get; set; }
+    public Guid ChapterId { get; set; }
+    public required string Locator { get; set; }
+    public string? Title { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+
+    public UserBook UserBook { get; set; } = null!;
+    public UserChapter Chapter { get; set; } = null!;
+}

--- a/backend/src/Domain/Entities/UserChapter.cs
+++ b/backend/src/Domain/Entities/UserChapter.cs
@@ -5,6 +5,7 @@ public class UserChapter
     public Guid Id { get; set; }
     public Guid UserBookId { get; set; }
     public int ChapterNumber { get; set; }
+    public string? Slug { get; set; }
     public required string Title { get; set; }
     public required string Html { get; set; }
     public required string PlainText { get; set; }

--- a/backend/src/Infrastructure/Migrations/20260127224904_AddUserChapterSlug.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260127224904_AddUserChapterSlug.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260127224904_AddUserChapterSlug")]
+    partial class AddUserChapterSlug
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1404,22 +1407,6 @@ namespace Infrastructure.Migrations
                         .HasColumnType("character varying(10)")
                         .HasColumnName("language");
 
-                    b.Property<string>("ProgressChapterSlug")
-                        .HasColumnType("text")
-                        .HasColumnName("progress_chapter_slug");
-
-                    b.Property<string>("ProgressLocator")
-                        .HasColumnType("text")
-                        .HasColumnName("progress_locator");
-
-                    b.Property<double?>("ProgressPercent")
-                        .HasColumnType("double precision")
-                        .HasColumnName("progress_percent");
-
-                    b.Property<DateTimeOffset?>("ProgressUpdatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("progress_updated_at");
-
                     b.Property<string>("Slug")
                         .IsRequired()
                         .HasMaxLength(500)
@@ -1462,48 +1449,6 @@ namespace Infrastructure.Migrations
                         .HasDatabaseName("ix_user_books_user_id_slug");
 
                     b.ToTable("user_books", (string)null);
-                });
-
-            modelBuilder.Entity("Domain.Entities.UserBookBookmark", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid")
-                        .HasColumnName("id");
-
-                    b.Property<Guid>("ChapterId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("chapter_id");
-
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at");
-
-                    b.Property<string>("Locator")
-                        .IsRequired()
-                        .HasMaxLength(1000)
-                        .HasColumnType("character varying(1000)")
-                        .HasColumnName("locator");
-
-                    b.Property<string>("Title")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)")
-                        .HasColumnName("title");
-
-                    b.Property<Guid>("UserBookId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("user_book_id");
-
-                    b.HasKey("Id")
-                        .HasName("pk_user_book_bookmarks");
-
-                    b.HasIndex("ChapterId")
-                        .HasDatabaseName("ix_user_book_bookmarks_chapter_id");
-
-                    b.HasIndex("UserBookId")
-                        .HasDatabaseName("ix_user_book_bookmarks_user_book_id");
-
-                    b.ToTable("user_book_bookmarks", (string)null);
                 });
 
             modelBuilder.Entity("Domain.Entities.UserBookFile", b =>
@@ -2188,27 +2133,6 @@ namespace Infrastructure.Migrations
                         .HasConstraintName("fk_user_books_users_user_id");
 
                     b.Navigation("User");
-                });
-
-            modelBuilder.Entity("Domain.Entities.UserBookBookmark", b =>
-                {
-                    b.HasOne("Domain.Entities.UserChapter", "Chapter")
-                        .WithMany()
-                        .HasForeignKey("ChapterId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_user_book_bookmarks_user_chapters_chapter_id");
-
-                    b.HasOne("Domain.Entities.UserBook", "UserBook")
-                        .WithMany()
-                        .HasForeignKey("UserBookId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_user_book_bookmarks_user_books_user_book_id");
-
-                    b.Navigation("Chapter");
-
-                    b.Navigation("UserBook");
                 });
 
             modelBuilder.Entity("Domain.Entities.UserBookFile", b =>

--- a/backend/src/Infrastructure/Migrations/20260127224904_AddUserChapterSlug.cs
+++ b/backend/src/Infrastructure/Migrations/20260127224904_AddUserChapterSlug.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserChapterSlug : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "slug",
+                table: "user_chapters",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_user_chapters_user_book_id_slug",
+                table: "user_chapters",
+                columns: new[] { "user_book_id", "slug" },
+                unique: true);
+
+            // Data migration: generate slugs for existing chapters
+            migrationBuilder.Sql(@"
+                UPDATE user_chapters
+                SET slug = chapter_number::text || '-' ||
+                    COALESCE(
+                        NULLIF(
+                            regexp_replace(
+                                regexp_replace(lower(trim(title)), '[^a-z0-9]+', '-', 'g'),
+                                '^-+|-+$', '', 'g'
+                            ),
+                            ''
+                        ),
+                        'section-' || chapter_number::text
+                    )
+                WHERE slug IS NULL;
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_user_chapters_user_book_id_slug",
+                table: "user_chapters");
+
+            migrationBuilder.DropColumn(
+                name: "slug",
+                table: "user_chapters");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Migrations/20260127231825_AddUserBookProgress.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260127231825_AddUserBookProgress.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260127231825_AddUserBookProgress")]
+    partial class AddUserBookProgress
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1464,48 +1467,6 @@ namespace Infrastructure.Migrations
                     b.ToTable("user_books", (string)null);
                 });
 
-            modelBuilder.Entity("Domain.Entities.UserBookBookmark", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid")
-                        .HasColumnName("id");
-
-                    b.Property<Guid>("ChapterId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("chapter_id");
-
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at");
-
-                    b.Property<string>("Locator")
-                        .IsRequired()
-                        .HasMaxLength(1000)
-                        .HasColumnType("character varying(1000)")
-                        .HasColumnName("locator");
-
-                    b.Property<string>("Title")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)")
-                        .HasColumnName("title");
-
-                    b.Property<Guid>("UserBookId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("user_book_id");
-
-                    b.HasKey("Id")
-                        .HasName("pk_user_book_bookmarks");
-
-                    b.HasIndex("ChapterId")
-                        .HasDatabaseName("ix_user_book_bookmarks_chapter_id");
-
-                    b.HasIndex("UserBookId")
-                        .HasDatabaseName("ix_user_book_bookmarks_user_book_id");
-
-                    b.ToTable("user_book_bookmarks", (string)null);
-                });
-
             modelBuilder.Entity("Domain.Entities.UserBookFile", b =>
                 {
                     b.Property<Guid>("Id")
@@ -2188,27 +2149,6 @@ namespace Infrastructure.Migrations
                         .HasConstraintName("fk_user_books_users_user_id");
 
                     b.Navigation("User");
-                });
-
-            modelBuilder.Entity("Domain.Entities.UserBookBookmark", b =>
-                {
-                    b.HasOne("Domain.Entities.UserChapter", "Chapter")
-                        .WithMany()
-                        .HasForeignKey("ChapterId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_user_book_bookmarks_user_chapters_chapter_id");
-
-                    b.HasOne("Domain.Entities.UserBook", "UserBook")
-                        .WithMany()
-                        .HasForeignKey("UserBookId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_user_book_bookmarks_user_books_user_book_id");
-
-                    b.Navigation("Chapter");
-
-                    b.Navigation("UserBook");
                 });
 
             modelBuilder.Entity("Domain.Entities.UserBookFile", b =>

--- a/backend/src/Infrastructure/Migrations/20260127231825_AddUserBookProgress.cs
+++ b/backend/src/Infrastructure/Migrations/20260127231825_AddUserBookProgress.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserBookProgress : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "progress_chapter_slug",
+                table: "user_books",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "progress_locator",
+                table: "user_books",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "progress_percent",
+                table: "user_books",
+                type: "double precision",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "progress_updated_at",
+                table: "user_books",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "progress_chapter_slug",
+                table: "user_books");
+
+            migrationBuilder.DropColumn(
+                name: "progress_locator",
+                table: "user_books");
+
+            migrationBuilder.DropColumn(
+                name: "progress_percent",
+                table: "user_books");
+
+            migrationBuilder.DropColumn(
+                name: "progress_updated_at",
+                table: "user_books");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Migrations/20260127232147_AddUserBookBookmarks.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260127232147_AddUserBookBookmarks.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260127232147_AddUserBookBookmarks")]
+    partial class AddUserBookBookmarks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Migrations/20260127232147_AddUserBookBookmarks.cs
+++ b/backend/src/Infrastructure/Migrations/20260127232147_AddUserBookBookmarks.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserBookBookmarks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "user_book_bookmarks",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    user_book_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    chapter_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    locator = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: false),
+                    title = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_user_book_bookmarks", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_user_book_bookmarks_user_books_user_book_id",
+                        column: x => x.user_book_id,
+                        principalTable: "user_books",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_user_book_bookmarks_user_chapters_chapter_id",
+                        column: x => x.chapter_id,
+                        principalTable: "user_chapters",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_user_book_bookmarks_chapter_id",
+                table: "user_book_bookmarks",
+                column: "chapter_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_user_book_bookmarks_user_book_id",
+                table: "user_book_bookmarks",
+                column: "user_book_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "user_book_bookmarks");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.cs
@@ -37,6 +37,7 @@ public class AppDbContext : DbContext, IAppDbContext
     public DbSet<UserChapter> UserChapters => Set<UserChapter>();
     public DbSet<UserBookFile> UserBookFiles => Set<UserBookFile>();
     public DbSet<UserIngestionJob> UserIngestionJobs => Set<UserIngestionJob>();
+    public DbSet<UserBookBookmark> UserBookBookmarks => Set<UserBookBookmark>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -339,7 +340,9 @@ public class AppDbContext : DbContext, IAppDbContext
         {
             e.HasIndex(x => x.UserBookId);
             e.HasIndex(x => new { x.UserBookId, x.ChapterNumber }).IsUnique();
+            e.HasIndex(x => new { x.UserBookId, x.Slug }).IsUnique();
             e.Property(x => x.Title).HasMaxLength(500);
+            e.Property(x => x.Slug).HasMaxLength(255);
             e.HasOne(x => x.UserBook).WithMany(x => x.Chapters).HasForeignKey(x => x.UserBookId).OnDelete(DeleteBehavior.Cascade);
         });
 
@@ -364,6 +367,18 @@ public class AppDbContext : DbContext, IAppDbContext
             e.Property(x => x.SourceFormat).HasMaxLength(50);
             e.HasOne(x => x.UserBook).WithMany(x => x.IngestionJobs).HasForeignKey(x => x.UserBookId).OnDelete(DeleteBehavior.Cascade);
             e.HasOne(x => x.UserBookFile).WithMany().HasForeignKey(x => x.UserBookFileId).OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // UserBookBookmark
+        modelBuilder.Entity<UserBookBookmark>(e =>
+        {
+            e.ToTable("user_book_bookmarks");
+            e.HasKey(x => x.Id);
+            e.HasIndex(x => x.UserBookId);
+            e.Property(x => x.Locator).HasMaxLength(1000);
+            e.Property(x => x.Title).HasMaxLength(500);
+            e.HasOne(x => x.UserBook).WithMany().HasForeignKey(x => x.UserBookId).OnDelete(DeleteBehavior.Cascade);
+            e.HasOne(x => x.Chapter).WithMany().HasForeignKey(x => x.ChapterId).OnDelete(DeleteBehavior.Cascade);
         });
     }
 

--- a/backend/src/Worker/Services/UserIngestionService.cs
+++ b/backend/src/Worker/Services/UserIngestionService.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Application.Common.Interfaces;
 using Domain.Entities;
 using Domain.Enums;
+using Domain.Utilities;
 using HtmlAgilityPack;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -143,12 +144,14 @@ public class UserIngestionService
             foreach (var unit in result.Units)
             {
                 var html = RewriteImageSrcs(unit.Html ?? string.Empty, imageMap);
+                var chapterTitle = SanitizeText(unit.Title ?? $"Chapter {unit.OrderIndex + 1}");
                 var chapter = new UserChapter
                 {
                     Id = Guid.NewGuid(),
                     UserBookId = job.UserBookId,
                     ChapterNumber = unit.OrderIndex + 1,
-                    Title = SanitizeText(unit.Title ?? $"Chapter {unit.OrderIndex + 1}"),
+                    Slug = SlugGenerator.GenerateChapterSlug(chapterTitle, unit.OrderIndex),
+                    Title = chapterTitle,
                     Html = SanitizeText(html),
                     PlainText = SanitizeText(unit.PlainText),
                     WordCount = unit.WordCount,


### PR DESCRIPTION
## Summary
- Add slug field to UserChapter for consistent URL routing
- Store userbook reading progress in database with localStorage fallback
- Add bookmark support for userbooks (server-synced)
- Sync public book bookmarks to server when authenticated
- Add "Auto-saved" display in Bookmarks drawer for userbooks

## Test plan
- [ ] Upload new book → chapters have slugs
- [ ] Read userbook → progress syncs to server
- [ ] Add bookmark in userbook → saved to database
- [ ] Open Bookmarks drawer → shows "Auto-saved" for current position
- [ ] Test on another device → progress and bookmarks sync

🤖 Generated with [Claude Code](https://claude.ai/claude-code)