### PR TITLE
fix(web): clean up reader theme on unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - **GeneratedRegex** - compiled regex patterns for performance
 
 ### Reader
+- **Theme cleanup** - reader theme properly reset on unmount (fixes body class leak)
 - **Mobile progress** - footer shows overall book % instead of chapter %
 - **Help button** - hidden on mobile (keyboard shortcuts not applicable)
 - **Scroll tracking** - mobile progress bar reflects scroll position

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,24 +56,34 @@ dotnet test                 # All tests
 dotnet test tests/TextStack.UnitTests
 dotnet test tests/TextStack.IntegrationTests
 dotnet test --filter "FullyQualifiedName~TestMethodName"  # Single test
+pnpm -C apps/web test       # Frontend tests
+pnpm -C apps/web test:watch # Frontend watch mode
 
 # Local dev (no Docker)
 dotnet run --project backend/src/Api
+dotnet run --project backend/src/Worker
+pnpm -C apps/web dev        # http://localhost:5173
+pnpm -C apps/admin dev
 
-# Frontend
+# Build frontend
 pnpm -C apps/web build
 pnpm -C apps/admin build
+
+# Database
+docker compose exec db psql -U app books   # DB shell
+docker compose down -v                      # Reset all (loses data)
 
 # Migrations
 dotnet ef migrations add <Name> --project backend/src/Infrastructure --startup-project backend/src/Api
 ```
 
-| Service | URL |
-|---------|-----|
-| Web | https://textstack.app |
-| API | https://textstack.app/api |
-| Admin | https://textstack.dev |
-| Aspire | http://127.0.0.1:18888 |
+| Service | Local | Prod |
+|---------|-------|------|
+| Web | http://localhost:5173 | https://textstack.app |
+| API | http://localhost:8080 | https://textstack.app/api |
+| API Docs | http://localhost:8080/scalar/v1 | — |
+| Admin | http://localhost:81 | https://textstack.dev |
+| Aspire | http://127.0.0.1:18888 | — |
 
 ## Key Concepts
 

--- a/apps/web/src/hooks/useReaderSettings.ts
+++ b/apps/web/src/hooks/useReaderSettings.ts
@@ -41,6 +41,10 @@ export function useReaderSettings() {
     save(settings)
     // Apply theme to html element
     document.documentElement.dataset.theme = settings.theme
+    // Cleanup: remove data-theme when reader unmounts
+    return () => {
+      delete document.documentElement.dataset.theme
+    }
   }, [settings])
 
   const update = useCallback((partial: Partial<ReaderSettings>) => {


### PR DESCRIPTION
## Summary
- Reader was setting `data-theme` on `<html>` but not removing on unmount
- Caused conflict: `class="dark"` + `data-theme="light"` → broken dark mode after leaving reader
- Added cleanup function to remove `data-theme` when reader unmounts

## Test plan
- [ ] Enable dark mode
- [ ] Open reader
- [ ] Navigate back → dark mode should persist

🤖 Generated with [Claude Code](https://claude.ai/code)