### PR TITLE
fix: persist translation to vocab on word tap/save

### DIFF
--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef, useCallback } from 'react'
 import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Animated, Alert } from 'react-native'
 import { WebView } from 'react-native-webview'
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router'
-import { createBooksApi, readingProgressApi, bookmarksApi, vocabularyApi, highlightsApi } from '@textstack/shared'
+import { createBooksApi, readingProgressApi, bookmarksApi, vocabularyApi, highlightsApi, translationApi } from '@textstack/shared'
 import type { Chapter, BookmarkDto, ChapterSummary, PublicHighlight } from '@textstack/shared'
 import { buildReaderHtml } from '../../../src/lib/readerHtml'
 import { getCachedChapter, getAllCachedBooks } from '../../../src/lib/offlineDb'
@@ -315,6 +315,16 @@ export default function ReaderScreen() {
       setWordSaved(true)
       setSessionWordCount(c => c + 1)
       setTimeout(() => { setSelection(null); setWordSaved(false) }, 1500)
+      // Persist translation to saved word (fire-and-forget)
+      const nativeLang = language === 'uk' ? 'en' : 'uk'
+      translationApi.translate(selection.text, language, nativeLang)
+        .then(res => {
+          if (res.translatedText && saved.id) {
+            vocabularyApi.updateWord(saved.id, { translation: res.translatedText }).catch(() => {})
+            vocabMapRef.current[key] = { ...vocabMapRef.current[key], translation: res.translatedText }
+          }
+        })
+        .catch(() => {})
     } catch {}
   }
 

--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -24,6 +24,7 @@ import { useQuickStats } from '../../../src/hooks/useQuickStats'
 import { Ionicons } from '@expo/vector-icons'
 import { useTheme } from '../../../src/context/ThemeContext'
 import { useLanguage } from '../../../src/context/LanguageContext'
+import { useNativeLanguage } from '../../../src/context/NativeLanguageContext'
 import { fonts } from '../../../src/theme/typography'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { StatusBar } from 'expo-status-bar'
@@ -67,6 +68,7 @@ export default function ReaderScreen() {
 
   const { colors } = useTheme()
   const { language } = useLanguage()
+  const { nativeLanguage } = useNativeLanguage()
   const quickStats = useQuickStats(isAuthenticated)
   const nextChapterRef = useRef<{ slug: string; title: string } | null>(null)
   const insets = useSafeAreaInsets()
@@ -316,8 +318,8 @@ export default function ReaderScreen() {
       setSessionWordCount(c => c + 1)
       setTimeout(() => { setSelection(null); setWordSaved(false) }, 1500)
       // Persist translation to saved word (fire-and-forget)
-      const nativeLang = language === 'uk' ? 'en' : 'uk'
-      translationApi.translate(selection.text, language, nativeLang)
+      const targetLang = nativeLanguage !== language ? nativeLanguage : (language === 'uk' ? 'en' : 'uk')
+      translationApi.translate(selection.text, language, targetLang)
         .then(res => {
           if (res.translatedText && saved.id) {
             vocabularyApi.updateWord(saved.id, { translation: res.translatedText }).catch(() => {})

--- a/apps/web/src/components/reader/WordPopup.tsx
+++ b/apps/web/src/components/reader/WordPopup.tsx
@@ -107,6 +107,14 @@ export function WordPopup({
         {phonetic && (
           <span className="word-popup__phonetic">{phonetic}</span>
         )}
+        <button
+          className="word-popup__close"
+          onClick={onClose}
+          onMouseDown={(e) => e.preventDefault()}
+          aria-label="Close"
+        >
+          ×
+        </button>
       </div>
 
       {/* Translation - primary content */}

--- a/apps/web/src/hooks/useReaderVocabulary.ts
+++ b/apps/web/src/hooks/useReaderVocabulary.ts
@@ -63,5 +63,15 @@ export function useReaderVocabulary() {
     setVocabMap(next)
   }, [])
 
-  return { vocabMap, loading, addWord, markAsKnown, removeWord }
+  const updateTranslation = useCallback((word: string, translation: string) => {
+    const key = word.toLowerCase()
+    const entry = mapRef.current.get(key)
+    if (!entry) return
+    const next = new Map(mapRef.current)
+    next.set(key, { ...entry, translation })
+    mapRef.current = next
+    setVocabMap(next)
+  }, [])
+
+  return { vocabMap, loading, addWord, markAsKnown, removeWord, updateTranslation }
 }

--- a/apps/web/src/hooks/useReaderVocabulary.ts
+++ b/apps/web/src/hooks/useReaderVocabulary.ts
@@ -38,7 +38,7 @@ export function useReaderVocabulary() {
       return saved
     }
     const next = new Map(mapRef.current)
-    next.set(key, { stage: saved.stage, id: saved.id })
+    next.set(key, { stage: saved.stage, id: saved.id, translation: existing?.translation || saved.translation || undefined })
     mapRef.current = next
     setVocabMap(next)
     return saved
@@ -73,5 +73,9 @@ export function useReaderVocabulary() {
     setVocabMap(next)
   }, [])
 
-  return { vocabMap, loading, addWord, markAsKnown, removeWord, updateTranslation }
+  const refreshMarks = useCallback(() => {
+    setVocabMap(new Map(mapRef.current))
+  }, [])
+
+  return { vocabMap, loading, addWord, markAsKnown, removeWord, updateTranslation, refreshMarks }
 }

--- a/apps/web/src/hooks/useWordTap.ts
+++ b/apps/web/src/hooks/useWordTap.ts
@@ -54,7 +54,7 @@ export function useWordTap({
   bookTitle,
   clearSelection,
 }: UseWordTapOptions) {
-  const { vocabMap, addWord: addVocabWord, markAsKnown: markVocabKnown, removeWord: removeVocabWord, updateTranslation } = useReaderVocabulary()
+  const { vocabMap, addWord: addVocabWord, markAsKnown: markVocabKnown, removeWord: removeVocabWord, updateTranslation, refreshMarks } = useReaderVocabulary()
   const { lookup: lookupWord } = useDictionary()
 
   const [tap, setTap] = useState<TapPopupState>(INITIAL_TAP)
@@ -79,7 +79,10 @@ export function useWordTap({
   const close = useCallback(() => {
     clearHighlight()
     setTap(INITIAL_TAP)
-  }, [clearHighlight])
+    // Force VocabWordLayer to re-mark — the tapped word was inside
+    // word-popup-highlight (skipped by TreeWalker), now it's a text node again
+    refreshMarks()
+  }, [clearHighlight, refreshMarks])
 
   // --- Core tap handler ---
 
@@ -143,14 +146,14 @@ export function useWordTap({
       .catch(() => {})
       .finally(() => setTap(prev => ({ ...prev, definitionLoading: false })))
 
-    // Auto-save to vocabulary, then patch translation once it resolves
+    // Auto-save to vocabulary + persist translation; update vocabMap once both resolve
     if (isAuthenticated && !vocabMap.get(word.toLowerCase())) {
       let sentence: string | undefined
       try {
         if (container) sentence = extractSentence(result.range, container)
       } catch {}
 
-      addVocabWord({
+      const savePromise = addVocabWord({
         word,
         language: bookLanguage,
         editionId: userBookId ? undefined : editionId || undefined,
@@ -159,16 +162,24 @@ export function useWordTap({
         sentence: sentence || undefined,
         bookTitle: bookTitle || undefined,
         nativeLanguage: targetLang || undefined,
-      }).then(saved => {
-        translationPromise.then(translation => {
-          if (translation && saved?.id) {
-            updateWord(saved.id, { translation }).catch(() => {})
-            updateTranslation(saved.word, translation)
-          }
-        })
-      }).catch(() => {})
+      }).catch(() => null)
+
+      // Wait for both save + translation, then patch backend and update vocabMap in one go
+      Promise.all([savePromise, translationPromise]).then(([saved, translation]) => {
+        if (saved && translation) {
+          updateWord(saved.id, { translation }).catch(() => {})
+        }
+        if (translation) {
+          updateTranslation(word, translation)
+        }
+      })
+    } else {
+      // Word already in vocabMap (re-tap) — just update translation when it arrives
+      translationPromise.then(translation => {
+        if (translation) updateTranslation(word, translation)
+      })
     }
-  }, [containerRef, clearSelection, clearHighlight, close, bookLanguage, targetLang, lookupWord, isAuthenticated, vocabMap, addVocabWord, editionId, chapterId, userBookId, bookTitle])
+  }, [containerRef, clearSelection, clearHighlight, close, bookLanguage, targetLang, lookupWord, isAuthenticated, vocabMap, addVocabWord, updateTranslation, editionId, chapterId, userBookId, bookTitle])
 
   // --- Attach pointer listeners ---
 

--- a/apps/web/src/hooks/useWordTap.ts
+++ b/apps/web/src/hooks/useWordTap.ts
@@ -2,6 +2,7 @@ import { useRef, useCallback, useState, useEffect } from 'react'
 import { getWordAtPoint } from '../lib/wordAtPoint'
 import { extractSentence } from '../lib/sentenceExtractor'
 import { translate as translateWord } from '../api/translation'
+import { updateWord } from '../api/vocabulary'
 import { useDictionary } from './useDictionary'
 import { useReaderVocabulary } from './useReaderVocabulary'
 
@@ -121,9 +122,12 @@ export function useWordTap({
     // Show popup immediately, load data in parallel
     setTap({ word, rect, translation: null, translationLoading: true, phonetic: undefined, definition: null, definitionLoading: true })
 
-    translateWord(word, bookLanguage, targetLang)
-      .then(res => setTap(prev => ({ ...prev, translation: res.translatedText })))
-      .catch(() => {})
+    const translationPromise = translateWord(word, bookLanguage, targetLang)
+      .then(res => {
+        setTap(prev => ({ ...prev, translation: res.translatedText }))
+        return res.translatedText
+      })
+      .catch(() => null as string | null)
       .finally(() => setTap(prev => ({ ...prev, translationLoading: false })))
 
     lookupWord(word, bookLanguage)
@@ -139,7 +143,7 @@ export function useWordTap({
       .catch(() => {})
       .finally(() => setTap(prev => ({ ...prev, definitionLoading: false })))
 
-    // Auto-save to vocabulary
+    // Auto-save to vocabulary, then patch translation once it resolves
     if (isAuthenticated && !vocabMap.get(word.toLowerCase())) {
       let sentence: string | undefined
       try {
@@ -155,6 +159,12 @@ export function useWordTap({
         sentence: sentence || undefined,
         bookTitle: bookTitle || undefined,
         nativeLanguage: targetLang || undefined,
+      }).then(saved => {
+        translationPromise.then(translation => {
+          if (translation && saved?.id) {
+            updateWord(saved.id, { translation }).catch(() => {})
+          }
+        })
       }).catch(() => {})
     }
   }, [containerRef, clearSelection, clearHighlight, close, bookLanguage, targetLang, lookupWord, isAuthenticated, vocabMap, addVocabWord, editionId, chapterId, userBookId, bookTitle])

--- a/apps/web/src/hooks/useWordTap.ts
+++ b/apps/web/src/hooks/useWordTap.ts
@@ -54,7 +54,7 @@ export function useWordTap({
   bookTitle,
   clearSelection,
 }: UseWordTapOptions) {
-  const { vocabMap, addWord: addVocabWord, markAsKnown: markVocabKnown, removeWord: removeVocabWord } = useReaderVocabulary()
+  const { vocabMap, addWord: addVocabWord, markAsKnown: markVocabKnown, removeWord: removeVocabWord, updateTranslation } = useReaderVocabulary()
   const { lookup: lookupWord } = useDictionary()
 
   const [tap, setTap] = useState<TapPopupState>(INITIAL_TAP)
@@ -163,6 +163,7 @@ export function useWordTap({
         translationPromise.then(translation => {
           if (translation && saved?.id) {
             updateWord(saved.id, { translation }).catch(() => {})
+            updateTranslation(saved.word, translation)
           }
         })
       }).catch(() => {})

--- a/apps/web/src/styles/reader.css
+++ b/apps/web/src/styles/reader.css
@@ -1497,6 +1497,22 @@ html[data-theme="dark"] .reader-search-drawer__context mark {
   gap: 6px;
 }
 
+.word-popup__close {
+  margin-left: auto;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  padding: 0 2px;
+  opacity: 0.5;
+  color: inherit;
+  align-self: center;
+}
+.word-popup__close:hover {
+  opacity: 1;
+}
+
 .word-popup__word {
   font-weight: 600;
   font-size: 18px;


### PR DESCRIPTION
## Summary
- Auto-saved vocab words had `null` translation — inline translations never showed
- Now: save word first, then PATCH translation once it resolves
- Web: `useWordTap` chains `translateWord` → `updateWord` after `addVocabWord`
- Mobile: `handleSaveWord` fires `translationApi.translate` → `vocabularyApi.updateWord`

## Test plan
- [ ] Tap a new word in reader → word saves → translation persists to DB
- [ ] Reload reader → inline translation visible next to the word
- [ ] Mobile: save word via WordCard → translation persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)