### PR TITLE
fix: inline translations above words, no reflow

### DIFF
--- a/apps/mobile/src/lib/readerHtml.ts
+++ b/apps/mobile/src/lib/readerHtml.ts
@@ -360,7 +360,6 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
           var p = n.parentElement;
           if (!p) return NodeFilter.FILTER_REJECT;
           if (p.tagName === 'MARK' || p.tagName === 'SCRIPT' || p.tagName === 'STYLE') return NodeFilter.FILTER_REJECT;
-          if (p.classList && p.classList.contains('vocab-inline-translation')) return NodeFilter.FILTER_REJECT;
           return NodeFilter.FILTER_ACCEPT;
         }
       });
@@ -389,16 +388,16 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
           mark.setAttribute(VOCAB_ATTR, 'true');
           var entry = vocabMap[m.word];
           var stage = entry.stage;
-          mark.style.cssText = 'background:none;color:inherit;padding:0;border-bottom:2px solid ' + (VOCAB_STAGE_COLORS[stage] || VOCAB_STAGE_COLORS[0]) + ';';
+          mark.style.cssText = 'background:none;color:inherit;padding:0;position:relative;border-bottom:2px solid ' + (VOCAB_STAGE_COLORS[stage] || VOCAB_STAGE_COLORS[0]) + ';';
           mark.textContent = text.slice(m.start, m.end);
-          frag.appendChild(mark);
           if (_showInlineTranslations && entry.translation) {
             var span = document.createElement('span');
             span.className = 'vocab-inline-translation';
-            span.style.cssText = 'font-size:0.75em;font-style:italic;opacity:0.5;margin-left:1px;pointer-events:none;user-select:none;';
-            span.textContent = ' (' + entry.translation + ')';
-            frag.appendChild(span);
+            span.style.cssText = 'position:absolute;left:50%;bottom:100%;transform:translateX(-50%);white-space:nowrap;font-size:0.5em;font-style:italic;opacity:0.4;line-height:1;pointer-events:none;user-select:none;max-width:150%;overflow:hidden;text-overflow:ellipsis;';
+            span.textContent = entry.translation;
+            mark.appendChild(span);
           }
+          frag.appendChild(mark);
           lastEnd = m.end;
         }
         if (lastEnd < text.length) frag.appendChild(document.createTextNode(text.slice(lastEnd)));
@@ -413,13 +412,11 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
     }
 
     function removeVocabMarks() {
-      var translations = document.querySelectorAll('.vocab-inline-translation');
-      translations.forEach(function(el) { el.remove(); });
       var marks = document.querySelectorAll('mark[' + VOCAB_ATTR + ']');
       marks.forEach(function(mark) {
         var parent = mark.parentNode;
-        var text = document.createTextNode(mark.textContent || '');
-        parent.replaceChild(text, mark);
+        var wordText = mark.firstChild && mark.firstChild.nodeType === 3 ? mark.firstChild.textContent : mark.textContent;
+        parent.replaceChild(document.createTextNode(wordText || ''), mark);
         parent.normalize();
       });
     }

--- a/apps/web/src/components/reader/VocabWordLayer.tsx
+++ b/apps/web/src/components/reader/VocabWordLayer.tsx
@@ -48,17 +48,13 @@ export function VocabWordLayer({ containerRef, vocabMap, showInlineTranslations 
 }
 
 function removeMarks(container: HTMLElement) {
-  // Remove inline translation spans first
-  const translations = container.querySelectorAll('.vocab-inline-translation')
-  translations.forEach((el) => el.remove())
-
   const marks = container.querySelectorAll(`mark[${MARK_ATTR}]`)
   marks.forEach((mark) => {
     const parent = mark.parentNode
     if (!parent) return
-    // Replace mark with its text content
-    const text = document.createTextNode(mark.textContent || '')
-    parent.replaceChild(text, mark)
+    // Get only the word text (first child text node), not the translation span
+    const wordText = mark.firstChild?.nodeType === Node.TEXT_NODE ? mark.firstChild.textContent : mark.textContent
+    parent.replaceChild(document.createTextNode(wordText || ''), mark)
     parent.normalize()
   })
 }
@@ -114,16 +110,17 @@ function markWords(container: HTMLElement, vocabMap: VocabMap, showInlineTransla
       mark.setAttribute(MARK_ATTR, 'true')
       mark.className = `vocab-underline ${STAGE_CLASSES[entry.stage] || STAGE_CLASSES[0]}`
       mark.textContent = text.slice(token.start, token.end)
-      frag.appendChild(mark)
 
-      // Append inline translation if enabled and translation exists
+      // Translation positioned absolutely inside mark — no text reflow
       if (showInlineTranslations && entry.translation) {
         const span = document.createElement('span')
         span.className = 'vocab-inline-translation'
-        span.textContent = ` (${entry.translation})`
+        span.textContent = entry.translation
         span.setAttribute('aria-hidden', 'true')
-        frag.appendChild(span)
+        mark.appendChild(span)
       }
+
+      frag.appendChild(mark)
 
       lastEnd = token.end
     }

--- a/apps/web/src/hooks/useReaderSettings.ts
+++ b/apps/web/src/hooks/useReaderSettings.ts
@@ -21,7 +21,7 @@ const STORAGE_KEY = 'reader.settings.v1'
 
 const defaults: ReaderSettings = {
   fontSize: 18,
-  lineHeight: 1.65,
+  lineHeight: 1.8,
   textAlign: 'center',
   theme: 'light',
   fontFamily: 'serif',

--- a/apps/web/src/styles/reader.css
+++ b/apps/web/src/styles/reader.css
@@ -1790,6 +1790,7 @@ html[data-theme="dark"] .reader-search-drawer__context mark {
   border-bottom: 2px solid transparent;
   transition: border-color 0.2s;
   animation: vocab-underline-in 0.4s ease-out;
+  position: relative;
 }
 .vocab-underline--new {
   border-bottom-color: rgba(59, 130, 246, 0.5); /* blue */
@@ -1813,11 +1814,19 @@ html[data-theme="dark"] .reader-search-drawer__context mark {
 }
 
 .vocab-inline-translation {
-  font-size: 0.75em;
+  position: absolute;
+  left: 50%;
+  bottom: 100%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  font-size: 0.5em;
   font-style: italic;
-  opacity: 0.5;
-  margin-left: 1px;
+  opacity: 0.4;
+  line-height: 1;
   pointer-events: none;
   user-select: none;
   animation: vocab-fade-in 0.4s ease-out;
+  max-width: 150%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }


### PR DESCRIPTION
## Summary
- Inline translations positioned absolutely above words instead of inline — eliminates text reflow/jump on VocabWordLayer re-render
- Translation span moved inside `<mark>` element for proper positioning context
- Smaller font (0.5em), max-width 150% with ellipsis for long translations
- Default line-height bumped 1.65 → 1.8

## Test plan
- [ ] Tap word → close popup → no text jump
- [ ] Inline translations visible above words
- [ ] Long translations truncated with ellipsis
- [ ] Dark mode readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)