### PR TITLE
feat(focus): long-press tap + EPUB language for user books

### DIFF
--- a/apps/mobile/src/components/focus/FocusReader.tsx
+++ b/apps/mobile/src/components/focus/FocusReader.tsx
@@ -24,6 +24,7 @@ import {
 import type { Chapter, BookDetail, UserBookChapterDto } from '@textstack/shared'
 import { useLanguage } from '../../context/LanguageContext'
 import { useNativeLanguage } from '../../context/NativeLanguageContext'
+import { useHaptics } from '../../hooks/useHaptics'
 import { fonts } from '../../theme/typography'
 
 export type FocusReaderMode = 'public' | 'userbook'
@@ -71,6 +72,7 @@ export function FocusReader({ mode, bookSlug, bookId, chapterSlug }: Props) {
   const { nativeLanguage } = useNativeLanguage()
   const scheme = useColorScheme()
   const insets = useSafeAreaInsets()
+  const haptics = useHaptics()
 
   // Theme pref (tri-state, persisted)
   const [themePref, setThemePref] = useState<ThemePref>('system')
@@ -101,6 +103,21 @@ export function FocusReader({ mode, bookSlug, bookId, chapterSlug }: Props) {
 
   const cacheRef = useRef<Map<string, string>>(new Map())
   const abortRef = useRef<AbortController | null>(null)
+  const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const LONGPRESS_MS = 400
+
+  const cancelPress = useCallback(() => {
+    if (pressTimerRef.current) {
+      clearTimeout(pressTimerRef.current)
+      pressTimerRef.current = null
+    }
+  }, [])
+
+  // Clean up any pending press timer on unmount
+  useEffect(() => () => {
+    if (pressTimerRef.current) clearTimeout(pressTimerRef.current)
+  }, [])
 
   // Fetch chapter + book metadata
   useEffect(() => {
@@ -122,13 +139,14 @@ export function FocusReader({ mode, bookSlug, bookId, chapterSlug }: Props) {
           setBookLanguage(bk.language || 'en')
         } else {
           if (!bookId) return
-          const ch: UserBookChapterDto = await userBooksApi.getUserBookChapter(bookId, chapterSlug)
+          const [ch, book]: [UserBookChapterDto, { language: string }] = await Promise.all([
+            userBooksApi.getUserBookChapter(bookId, chapterSlug),
+            userBooksApi.getUserBook(bookId),
+          ])
           if (cancelled) return
           setHtml(ch.html)
           setChapterId(ch.id)
-          // UserBookDto has no language field yet; default 'en' to avoid
-          // silent same-lang collision when UI lang == nativeLanguage.
-          setBookLanguage('en')
+          setBookLanguage(book.language || 'en')
         }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load chapter')
@@ -372,7 +390,15 @@ export function FocusReader({ mode, bookSlug, bookId, chapterSlug }: Props) {
                 <Text key={k}>
                   <Text
                     style={wordStyle}
-                    onPress={() => tapWord(clampedIdx, i, t.word)}
+                    onPressIn={sameLang ? undefined : () => {
+                      cancelPress()
+                      pressTimerRef.current = setTimeout(() => {
+                        pressTimerRef.current = null
+                        haptics.play('flip')
+                        tapWord(clampedIdx, i, t.word)
+                      }, LONGPRESS_MS)
+                    }}
+                    onPressOut={sameLang ? undefined : cancelPress}
                   >
                     {t.word}
                   </Text>

--- a/apps/web/e2e/tests/focus-mode.spec.ts
+++ b/apps/web/e2e/tests/focus-mode.spec.ts
@@ -77,7 +77,7 @@ test.describe('Focus Mode', () => {
       .toMatch(new RegExp(`/en/books/${enBook.slug}/${enBook.firstChapterSlug}$`))
   })
 
-  test('tap word triggers inline translation node (loading or result)', async ({ authedPage: page }) => {
+  test('long-press word triggers inline translation (not a quick tap)', async ({ authedPage: page }) => {
     const { enBook } = getTestData()
     // Force native language to 'uk' so translation fires on English text
     // (same-lang path short-circuits and renders no translation node).
@@ -88,9 +88,22 @@ test.describe('Focus Mode', () => {
     await page.goto(`/en/books/${enBook.slug}/focus/${enBook.firstChapterSlug}`)
     const firstWord = page.locator('.focus-reader__word').first()
     await expect(firstWord).toBeVisible({ timeout: 30_000 })
-    await firstWord.click()
 
-    // Either loading "…" appears or a translation result
+    // Quick click should NOT trigger translation (sensitivity fix).
+    await firstWord.click()
+    await page.waitForTimeout(200)
+    await expect(page.locator('.focus-reader__translation')).toHaveCount(0)
+
+    // Press-and-hold > 400ms should trigger.
+    const box = await firstWord.boundingBox()
+    if (!box) throw new Error('word box missing')
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+    await page.mouse.move(cx, cy)
+    await page.mouse.down()
+    await page.waitForTimeout(500)
+    await page.mouse.up()
+
     const translation = page.locator('.focus-reader__translation')
     await expect(translation).toBeVisible({ timeout: 10_000 })
   })

--- a/apps/web/src/pages/FocusReaderPage.tsx
+++ b/apps/web/src/pages/FocusReaderPage.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '../context/AuthContext'
 import { useNativeLanguage } from '../context/NativeLanguageContext'
 import { useVerticalSwipe } from '../hooks/useVerticalSwipe'
 import { splitSentences, tokenizeWords } from '@textstack/shared'
-import { getUserBookChapter } from '../api/userBooks'
+import { getUserBookChapter, getUserBook } from '../api/userBooks'
 import { translate as translateApi } from '../api/translation'
 import { SeoHead } from '../components/SeoHead'
 import '../styles/focus-reader.css'
@@ -49,8 +49,28 @@ export function FocusReaderPage({ mode = 'public' }: Props) {
   const [error, setError] = useState<string | null>(null)
   const [currentIndex, setCurrentIndex] = useState(0)
   const [tap, setTap] = useState<TapState | null>(null)
+  const [pressingKey, setPressingKey] = useState<string | null>(null)
 
   const abortRef = useRef<AbortController | null>(null)
+  const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pressOriginRef = useRef<{ x: number; y: number } | null>(null)
+
+  const LONGPRESS_MS = 400
+  const MOVE_TOLERANCE_PX = 8
+
+  const cancelPress = useCallback(() => {
+    if (pressTimerRef.current) {
+      clearTimeout(pressTimerRef.current)
+      pressTimerRef.current = null
+    }
+    pressOriginRef.current = null
+    setPressingKey(null)
+  }, [])
+
+  // Clean up any pending press timer on unmount
+  useEffect(() => () => {
+    if (pressTimerRef.current) clearTimeout(pressTimerRef.current)
+  }, [])
 
   // Theme: 'light' | 'dark' | 'system'. Persist in localStorage. Default system.
   type ThemePref = 'light' | 'dark' | 'system'
@@ -91,13 +111,15 @@ export function FocusReaderPage({ mode = 'public' }: Props) {
           setBookLanguage(bk.language || 'en')
         } else {
           if (!id || !chapterSlug) return
-          const ch = await getUserBookChapter(id, chapterSlug)
+          const [ch, book] = await Promise.all([
+            getUserBookChapter(id, chapterSlug),
+            getUserBook(id),
+          ])
           if (cancelled) return
           setHtml(ch.html)
           setChapterId(ch.id)
           setTitle(ch.title)
-          // User-book language not fetched here; default to UI language.
-          setBookLanguage(language)
+          setBookLanguage(book.language || 'en')
         }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load chapter')
@@ -297,12 +319,38 @@ export function FocusReaderPage({ mode = 'public' }: Props) {
         {tokens.map((t, i) => {
           const k = `${clampedIdx}:${i}`
           const active = tap?.key === k
+          const pressing = pressingKey === k
+          const disabled = sameLang
+          const handlePointerDown = (e: React.PointerEvent<HTMLSpanElement>) => {
+            if (disabled) return
+            // Only main pointer; ignore right-clicks on desktop
+            if (e.pointerType === 'mouse' && e.button !== 0) return
+            e.currentTarget.setPointerCapture?.(e.pointerId)
+            pressOriginRef.current = { x: e.clientX, y: e.clientY }
+            setPressingKey(k)
+            pressTimerRef.current = setTimeout(() => {
+              pressTimerRef.current = null
+              tapWord(clampedIdx, i, t.word)
+              setPressingKey(null)
+            }, LONGPRESS_MS)
+          }
+          const handlePointerMove = (e: React.PointerEvent<HTMLSpanElement>) => {
+            if (!pressOriginRef.current) return
+            const dx = e.clientX - pressOriginRef.current.x
+            const dy = e.clientY - pressOriginRef.current.y
+            if (Math.abs(dx) + Math.abs(dy) > MOVE_TOLERANCE_PX) cancelPress()
+          }
           return (
             <span key={k}>
               <span className="focus-reader__word-wrap">
                 <span
-                  className={`focus-reader__word${active ? ' focus-reader__word--active' : ''}${sameLang ? ' focus-reader__word--disabled' : ''}`}
-                  onClick={() => tapWord(clampedIdx, i, t.word)}
+                  className={`focus-reader__word${active ? ' focus-reader__word--active' : ''}${pressing ? ' focus-reader__word--pressing' : ''}${disabled ? ' focus-reader__word--disabled' : ''}`}
+                  onPointerDown={handlePointerDown}
+                  onPointerMove={handlePointerMove}
+                  onPointerUp={cancelPress}
+                  onPointerCancel={cancelPress}
+                  onPointerLeave={cancelPress}
+                  onContextMenu={(e) => e.preventDefault()}
                 >
                   {t.word}
                 </span>

--- a/apps/web/src/styles/focus-reader.css
+++ b/apps/web/src/styles/focus-reader.css
@@ -86,10 +86,21 @@
   text-decoration-color: var(--fr-underline);
   text-decoration-thickness: 1px;
   text-underline-offset: 6px;
-  transition: background-color 120ms ease, text-decoration-color 120ms ease;
+  /* Suppress native text selection & long-press context menu on touch devices */
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+  touch-action: manipulation;
+  transition: background-color 160ms ease, text-decoration-color 160ms ease;
 }
 
 .focus-reader__word:hover {
+  background-color: var(--fr-word-hover);
+  text-decoration-color: currentColor;
+}
+
+/* Subtle feedback during the 400ms long-press window */
+.focus-reader__word--pressing {
   background-color: var(--fr-word-hover);
   text-decoration-color: currentColor;
 }

--- a/backend/src/Extraction/TextStack.Extraction/Extractors/EpubTextExtractor.cs
+++ b/backend/src/Extraction/TextStack.Extraction/Extractors/EpubTextExtractor.cs
@@ -39,6 +39,7 @@ public sealed class EpubTextExtractor : ITextExtractor
         var title = book.Title;
         var authors = book.AuthorList?.Count > 0 ? string.Join(", ", book.AuthorList) : null;
         var description = book.Description;
+        var language = ExtractLanguage(book);
 
         // Build navigation title map from EPUB's NCX/NAV
         var navTitleMap = BuildNavigationTitleMap(book);
@@ -258,10 +259,37 @@ public sealed class EpubTextExtractor : ITextExtractor
             // Image extraction is optional, don't fail
         }
 
-        var metadata = new ExtractionMetadata(title, authors, null, description, coverImage, coverMimeType);
+        var metadata = new ExtractionMetadata(title, authors, language, description, coverImage, coverMimeType);
         var diagnostics = new ExtractionDiagnostics(TextSource.NativeText, null, warnings);
 
         return new ExtractionResult(SourceFormat.Epub, metadata, units, images, diagnostics, toc);
+    }
+
+    /// <summary>
+    /// Extracts the primary language from EPUB metadata (&lt;dc:language&gt;).
+    /// Normalizes BCP47 tags like "en-US" to ISO 639-1 "en". Returns null if absent/invalid.
+    /// </summary>
+    private static string? ExtractLanguage(EpubBook book)
+    {
+        try
+        {
+            var languages = book.Schema?.Package?.Metadata?.Languages;
+            if (languages == null || languages.Count == 0)
+                return null;
+
+            var raw = languages[0]?.Language?.Trim();
+            if (string.IsNullOrEmpty(raw))
+                return null;
+
+            // "en-US" / "en_US" → "en"; already-2-letter stays as-is
+            var sep = raw.IndexOfAny(['-', '_']);
+            var code = sep > 0 ? raw[..sep] : raw;
+            return code.Length is >= 2 and <= 3 ? code.ToLowerInvariant() : null;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static string? GetMimeType(EpubContentType contentType)

--- a/backend/src/Worker/Services/UserIngestionService.cs
+++ b/backend/src/Worker/Services/UserIngestionService.cs
@@ -212,6 +212,10 @@ public class UserIngestionService
             if (string.IsNullOrEmpty(job.UserBook.Author) && !string.IsNullOrEmpty(result.Metadata.Authors))
                 job.UserBook.Author = result.Metadata.Authors;
 
+            // Prefer extracted EPUB language over upload-time guess. PDF/FB2 return null → keep user's choice.
+            if (!string.IsNullOrEmpty(result.Metadata.Language))
+                job.UserBook.Language = result.Metadata.Language;
+
             job.UserBook.TotalWordCount = result.Units.Sum(u => u.WordCount ?? 0);
 
             // If title was auto-generated, update with extracted title

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -292,6 +292,7 @@ export interface UserBookDto {
   id: string
   title: string | null
   author: string | null
+  language: string
   coverPath: string | null
   genre: string | null
   totalWordCount: number | null


### PR DESCRIPTION
## Summary

- Replace sensitive single-tap with 400ms press-and-hold on Focus Mode words (web: pointer events + move-tolerance cancel; mobile: onPressIn/Out + timer, Light haptic on trigger).
- Extract `<dc:language>` from EPUB via VersOne.Epub and propagate through `UserIngestionService` → `UserBook.Language`. Added `language` to shared `UserBookDto` so web + mobile Focus Reader use the real book language for user uploads (fixes silent same-lang guard that blocked translation). PDF/FB2 keep default.
- Updated web E2E focus-mode spec: quick tap asserts no tooltip; long-press asserts translation renders.

## Test plan

- [x] `dotnet build` (Extraction + Worker) — clean
- [x] `pnpm -C apps/web typecheck` — pass
- [x] `cd apps/mobile && npx tsc --noEmit` — pass
- [x] `pnpm -C apps/web test:e2e focus-mode` — 7/7 green
- [x] `dotnet test tests/TextStack.Extraction.Tests` — 3/3 pass
- [ ] Manually upload non-English EPUB → verify `UserBook.Language` reflects `<dc:language>`
- [ ] Focus Reader on user book: quick tap → no tooltip; long-press → tooltip + haptic (mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)