### PR TITLE
feat(mobile): reset-password screen + deep link

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -43,6 +43,11 @@
               "scheme": "https",
               "host": "textstack.app",
               "pathPrefix": "/uk/books"
+            },
+            {
+              "scheme": "https",
+              "host": "textstack.app",
+              "pathPrefix": "/reset-password"
             }
           ],
           "category": [

--- a/apps/mobile/app/reset-password.tsx
+++ b/apps/mobile/app/reset-password.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react'
+import {
+  View, Text, StyleSheet, TouchableOpacity, TextInput,
+  KeyboardAvoidingView, Platform, ActivityIndicator,
+} from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router'
+import { authApi } from '@textstack/shared'
+import { useTheme } from '../src/context/ThemeContext'
+import { fonts } from '../src/theme/typography'
+
+export default function ResetPasswordScreen() {
+  const { colors } = useTheme()
+  const router = useRouter()
+  const { token } = useLocalSearchParams<{ token?: string }>()
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState(false)
+
+  const handleSubmit = async () => {
+    setError('')
+    if (!token) return
+    if (password.length < 8) { setError('Password must be at least 8 characters.'); return }
+    setLoading(true)
+    try {
+      await authApi.resetPassword(token, password)
+      setSuccess(true)
+    } catch (e: any) {
+      setError(e?.message || 'Reset failed.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!token) {
+    return (
+      <>
+        <Stack.Screen options={{ title: 'Reset Password', headerShown: true, headerStyle: { backgroundColor: colors.background }, headerShadowVisible: false }} />
+        <View style={[styles.container, { backgroundColor: colors.background, justifyContent: 'center' }]}>
+          <Ionicons name="alert-circle-outline" size={48} color={colors.textSecondary} style={{ alignSelf: 'center', marginBottom: 12 }} />
+          <Text style={[styles.title, { color: colors.text, fontFamily: fonts.serifBold }]}>Invalid link</Text>
+          <Text style={[styles.body, { color: colors.textSecondary, fontFamily: fonts.sans }]}>
+            This reset link is invalid or has expired.
+          </Text>
+          <TouchableOpacity
+            style={[styles.btn, { backgroundColor: colors.primary }]}
+            onPress={() => router.replace('/(auth)/login')}
+            activeOpacity={0.85}
+          >
+            <Text style={[styles.btnText, { fontFamily: fonts.sansMedium }]}>Back to Sign in</Text>
+          </TouchableOpacity>
+        </View>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Stack.Screen options={{ title: 'Reset Password', headerShown: true, headerStyle: { backgroundColor: colors.background }, headerShadowVisible: false }} />
+      <KeyboardAvoidingView
+        style={{ flex: 1, backgroundColor: colors.background }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <View style={[styles.container, { backgroundColor: colors.background }]}>
+          {success ? (
+            <>
+              <Ionicons name="checkmark-circle" size={56} color={colors.success} style={{ alignSelf: 'center', marginBottom: 12 }} />
+              <Text style={[styles.title, { color: colors.text, fontFamily: fonts.serifBold }]}>Password reset</Text>
+              <Text style={[styles.body, { color: colors.textSecondary, fontFamily: fonts.sans }]}>
+                Your password has been updated. You can now sign in.
+              </Text>
+              <TouchableOpacity
+                style={[styles.btn, { backgroundColor: colors.primary }]}
+                onPress={() => router.replace('/(auth)/login')}
+                activeOpacity={0.85}
+              >
+                <Text style={[styles.btnText, { fontFamily: fonts.sansMedium }]}>Sign in</Text>
+              </TouchableOpacity>
+            </>
+          ) : (
+            <>
+              <Text style={[styles.title, { color: colors.text, fontFamily: fonts.serifBold }]}>Set new password</Text>
+              <TextInput
+                style={[styles.input, { backgroundColor: colors.surface, borderColor: colors.border, color: colors.text, fontFamily: fonts.sans }]}
+                placeholder="New password (min 8 characters)"
+                placeholderTextColor={colors.textSecondary}
+                secureTextEntry
+                value={password}
+                onChangeText={setPassword}
+                autoFocus
+                autoCapitalize="none"
+                autoCorrect={false}
+                onSubmitEditing={handleSubmit}
+              />
+              {error ? <Text style={[styles.error, { color: colors.error || '#DC2626', fontFamily: fonts.sans }]}>{error}</Text> : null}
+              <TouchableOpacity
+                style={[styles.btn, { backgroundColor: colors.primary, opacity: loading ? 0.6 : 1 }]}
+                onPress={handleSubmit}
+                disabled={loading}
+                activeOpacity={0.85}
+              >
+                {loading
+                  ? <ActivityIndicator color="#fff" />
+                  : <Text style={[styles.btnText, { fontFamily: fonts.sansMedium }]}>Reset password</Text>}
+              </TouchableOpacity>
+            </>
+          )}
+        </View>
+      </KeyboardAvoidingView>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, justifyContent: 'center' },
+  title: { fontSize: 24, marginBottom: 16, textAlign: 'center' },
+  body: { fontSize: 15, lineHeight: 22, textAlign: 'center', marginBottom: 24 },
+  input: { height: 48, borderRadius: 10, borderWidth: 1, paddingHorizontal: 14, fontSize: 15, marginBottom: 12 },
+  error: { fontSize: 13, marginBottom: 12, textAlign: 'center' },
+  btn: { height: 48, borderRadius: 10, justifyContent: 'center', alignItems: 'center', marginTop: 8 },
+  btnText: { color: '#fff', fontSize: 15 },
+})

--- a/packages/shared/src/api/auth.ts
+++ b/packages/shared/src/api/auth.ts
@@ -73,6 +73,19 @@ export async function forgotPassword(email: string): Promise<void> {
   })
 }
 
+export async function resetPassword(token: string, password: string): Promise<void> {
+  const { baseUrl } = getApiConfig()
+  const res = await fetch(`${baseUrl}/auth/reset-password`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token, password }),
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => null)
+    throw Object.assign(new Error(data?.error || 'Reset failed.'), { status: res.status })
+  }
+}
+
 export async function logout(accessToken: string): Promise<void> {
   const { baseUrl } = getApiConfig()
   await fetch(`${baseUrl}/auth/logout`, {


### PR DESCRIPTION
## Summary
- Add mobile `/reset-password` screen (parity with web).
- Add `resetPassword` to shared auth API.
- Add Android intent filter for `textstack.app/reset-password` universal link.

## Test plan
- [ ] Request password reset from mobile login → receive email.
- [ ] Tap link → opens app on `/reset-password?token=...`.
- [ ] Enter new password (min 8) → success → redirect to sign-in.
- [ ] Invalid/expired token → shows "Invalid link".

🤖 Generated with [Claude Code](https://claude.com/claude-code)