### PR TITLE
feat(footer): Fazier badge

### DIFF
--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -21,6 +21,23 @@ export function Footer() {
           <LocalizedLink to="/terms" className="site-footer__link">{t('footer.terms')}</LocalizedLink>
           <LocalizedLink to="/contact" className="site-footer__link">{t('footer.contact')}</LocalizedLink>
         </nav>
+        <div className="site-footer__badges">
+          <a
+            href="https://fazier.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="site-footer__badge"
+            aria-label="Featured on Fazier"
+          >
+            <img
+              src="https://fazier.com/api/v1/public/badges/embed_image.svg?badge_type=featured"
+              alt="Featured on Fazier"
+              width="250"
+              height="54"
+              loading="lazy"
+            />
+          </a>
+        </div>
         <div className="site-footer__bottom">
           <span className="site-footer__logo">TextStack</span>
           <span className="site-footer__copyright">&copy; {new Date().getFullYear()} TextStack Library Project.</span>

--- a/apps/web/src/styles/home.css
+++ b/apps/web/src/styles/home.css
@@ -545,6 +545,30 @@
   color: var(--color-text);
 }
 
+.site-footer__badges {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+}
+
+.site-footer__badge {
+  display: inline-block;
+  opacity: 0.7;
+  transition: opacity 0.2s ease;
+}
+
+.site-footer__badge:hover {
+  opacity: 1;
+}
+
+.site-footer__badge img {
+  display: block;
+  max-width: 250px;
+  height: auto;
+}
+
 .site-footer__bottom {
   margin-top: 48px;
   padding-top: 48px;


### PR DESCRIPTION
## Summary
- Add Fazier badge to footer with opacity 0.7 → 1.0 on hover
- Generic embed URL (`badge_type=featured`) — may need replace with real `launch_id` after Fazier review for "Verify Badge" to pass
- External image (`fazier.com/api/v1/public/badges/...`), no local asset

## Test plan
- [ ] Local: `pnpm -C apps/web dev` → scroll footer → badge visible, hover works
- [ ] Click badge → fazier.com in new tab
- [ ] After merge: `make rebuild-ssg` → `curl -s https://textstack.app/en/ | grep fazier`
- [ ] Fazier dashboard: click "Verify Badge" → should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)