### PR TITLE
feat: 2 SEO landing pages (read-books-in-english, books-with-translation)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -31,6 +31,8 @@ import { BlogPage } from './pages/BlogPage'
 import { BlogPostPage } from './pages/BlogPostPage'
 import { LearnEnglishBrazilPage } from './pages/LearnEnglishBrazilPage'
 import { LearnEnglishSpainPage } from './pages/LearnEnglishSpainPage'
+import { ReadBooksInEnglishPage } from './pages/ReadBooksInEnglishPage'
+import { BooksWithTranslationPage } from './pages/BooksWithTranslationPage'
 import { ResetPasswordPage } from './pages/ResetPasswordPage'
 import { NotFoundPage } from './pages/NotFoundPage'
 import { Header } from './components/Header'
@@ -87,6 +89,8 @@ function LanguageRoutes() {
         <Route path="/blog/:slug" element={<BlogPostPage />} />
         <Route path="/learn-english-brazil" element={<LearnEnglishBrazilPage />} />
         <Route path="/learn-english-spain" element={<LearnEnglishSpainPage />} />
+        <Route path="/read-books-in-english" element={<ReadBooksInEnglishPage />} />
+        <Route path="/books-with-translation" element={<BooksWithTranslationPage />} />
         <Route path="/about" element={<AboutPage />} />
         <Route path="/privacy" element={<PrivacyPage />} />
         <Route path="/terms" element={<TermsPage />} />
@@ -145,6 +149,8 @@ function AppRoutes() {
       <Route path="/highlights" element={<LegacyRedirect />} />
       <Route path="/highlights/review" element={<LegacyRedirect />} />
       <Route path="/blog/*" element={<LegacyRedirect />} />
+      <Route path="/read-books-in-english" element={<LegacyRedirect />} />
+      <Route path="/books-with-translation" element={<LegacyRedirect />} />
       <Route path="/:lang/*" element={<LanguageRoutes />} />
     </Routes>
   )

--- a/apps/web/src/components/landing/SeoArticlePage.tsx
+++ b/apps/web/src/components/landing/SeoArticlePage.tsx
@@ -1,0 +1,95 @@
+import type { ReactNode } from 'react'
+import { SeoHead } from '../SeoHead'
+import { Footer } from '../Footer'
+import { LocalizedLink } from '../LocalizedLink'
+import '../../styles/seo-article.css'
+
+// gtag loaded in index.html
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void
+  }
+}
+
+export interface SeoArticleSection {
+  heading: string
+  body: ReactNode
+}
+
+export interface SeoArticleRelatedLink {
+  href: string
+  label: string
+}
+
+export interface SeoArticlePageProps {
+  pageKey: string
+  seo: { title: string; description: string }
+  hero: { h1: string; subhead?: string }
+  sections: SeoArticleSection[]
+  cta: { label: string; href: string }
+  relatedLinks: SeoArticleRelatedLink[]
+}
+
+function trackCtaClick(pageKey: string, label: 'hero' | 'final') {
+  if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+    window.gtag('event', 'landing_cta_click', { page: pageKey, label })
+  }
+}
+
+export function SeoArticlePage({
+  pageKey,
+  seo,
+  hero,
+  sections,
+  cta,
+  relatedLinks,
+}: SeoArticlePageProps) {
+  return (
+    <>
+      <SeoHead title={seo.title} description={seo.description} />
+
+      <main className="seo-article">
+        <header className="seo-article__hero">
+          <h1>{hero.h1}</h1>
+          {hero.subhead && <p className="seo-article__hero-sub">{hero.subhead}</p>}
+          <LocalizedLink
+            to={cta.href}
+            className="seo-article__cta"
+            onClick={() => trackCtaClick(pageKey, 'hero')}
+          >
+            {cta.label}
+          </LocalizedLink>
+        </header>
+
+        {sections.map((s, i) => (
+          <section key={i} className="seo-article__section">
+            <h2>{s.heading}</h2>
+            {typeof s.body === 'string' ? <p>{s.body}</p> : s.body}
+          </section>
+        ))}
+
+        <section className="seo-article__section seo-article__section--cta">
+          <LocalizedLink
+            to={cta.href}
+            className="seo-article__cta"
+            onClick={() => trackCtaClick(pageKey, 'final')}
+          >
+            {cta.label}
+          </LocalizedLink>
+        </section>
+
+        {relatedLinks.length > 0 && (
+          <nav className="seo-article__related" aria-label="Related pages">
+            {relatedLinks.map((link) => (
+              <LocalizedLink key={link.href} to={link.href} className="seo-article__related-link">
+                {link.label}
+              </LocalizedLink>
+            ))}
+          </nav>
+        )}
+      </main>
+
+      <Footer />
+    </>
+  )
+}

--- a/apps/web/src/pages/BooksWithTranslationPage.tsx
+++ b/apps/web/src/pages/BooksWithTranslationPage.tsx
@@ -1,0 +1,52 @@
+import { SeoArticlePage } from '../components/landing/SeoArticlePage'
+import { DEMO_BOOK } from '../config/demoBook'
+
+const DEMO_PATH = `/books/${DEMO_BOOK.bookSlug}/${DEMO_BOOK.chapterSlug}`
+
+export function BooksWithTranslationPage() {
+  return (
+    <SeoArticlePage
+      pageKey="books-with-translation"
+      seo={{
+        title: 'Books with Translation for English Learners',
+        description:
+          'Looking for books with translation? Learn how to read English books with instant word definitions and improve your vocabulary naturally.',
+      }}
+      hero={{
+        h1: 'Books with Translation for English Learners',
+        subhead:
+          'Read English books with built-in translation — without juggling apps or parallel PDFs.',
+      }}
+      sections={[
+        {
+          heading: 'Finding English books with translation is harder than it should be',
+          body:
+            'You want to read a novel in English, but every unknown word slows you down. So you search for "books with translation" and find bad options: low-quality bilingual PDFs, half-baked browser extensions, or parallel-text sites that read like a DMV form.',
+        },
+        {
+          heading: 'Existing solutions get in the way',
+          body:
+            'Parallel-text PDFs split your attention — one eye on each column, neither on the story. Google Translate means copy, paste, wait, switch back. Dictionary pop-ups interrupt the sentence. None of them let you actually read.',
+        },
+        {
+          heading: 'A better way: inline translation, not interruption',
+          body:
+            'What if the translation lived where your finger already was? Tap a word — the meaning appears next to it — keep reading. No tab switching. No copy-paste. The rhythm of the book stays intact.',
+        },
+        {
+          heading: 'TextStack Reader — books with translation, built in',
+          body:
+            'TextStack Reader lets you read books in English with instant translation, vocabulary tracking, and spaced repetition — all in one reader. The public library has thousands of classics, free, no account required. Upload your own EPUB or PDF and read it the same way. Save words you want to learn. Review them later. Watch your vocabulary grow from books you actually read.',
+        },
+      ]}
+      cta={{
+        label: 'Try TextStack Reader',
+        href: DEMO_PATH,
+      }}
+      relatedLinks={[
+        { href: '/', label: '← TextStack Reader home' },
+        { href: '/read-books-in-english', label: 'Read books in English without translating every word →' },
+      ]}
+    />
+  )
+}

--- a/apps/web/src/pages/ReadBooksInEnglishPage.tsx
+++ b/apps/web/src/pages/ReadBooksInEnglishPage.tsx
@@ -1,0 +1,52 @@
+import { SeoArticlePage } from '../components/landing/SeoArticlePage'
+import { DEMO_BOOK } from '../config/demoBook'
+
+const DEMO_PATH = `/books/${DEMO_BOOK.bookSlug}/${DEMO_BOOK.chapterSlug}`
+
+export function ReadBooksInEnglishPage() {
+  return (
+    <SeoArticlePage
+      pageKey="read-books-in-english"
+      seo={{
+        title: 'Read Books in English Without Translating Every Word',
+        description:
+          'Learn how to read books in English without constantly translating. Discover a better way to build fluency using real books and smart tools.',
+      }}
+      hero={{
+        h1: 'Read Books in English Without Translating Every Word',
+        subhead:
+          'A better way to build English fluency through real books — without stopping every sentence.',
+      }}
+      sections={[
+        {
+          heading: "Reading in English shouldn't feel like homework",
+          body:
+            "You open the book. You hit a word you don't know. You grab a dictionary. Two pages later, you've lost the story. Most English learners stop reading not because the book is boring, but because the constant translation breaks the flow.",
+        },
+        {
+          heading: 'Why this happens',
+          body:
+            'When every sentence has an unknown word, your brain spends more energy decoding than understanding. You read slower. You remember less. The book stops feeling like a book and starts feeling like a drill. Most readers quit by chapter two.',
+        },
+        {
+          heading: 'What actually works',
+          body:
+            "Fluent readers don't translate every word. They skip unknowns, use context, and look up only what matters. Vocabulary grows from thousands of real sentences — not flashcards. The trick is staying in flow long enough for your brain to learn from exposure.",
+        },
+        {
+          heading: 'A reader built for flow',
+          body:
+            'TextStack Reader is a reading app that lets you read books in English with instant translation on tap. Tap any word — see its meaning without leaving the page. Keep reading. The word you tapped goes into your vocabulary automatically and comes back for spaced-repetition review later. You read more. You translate less. Your English grows.',
+        },
+      ]}
+      cta={{
+        label: 'Start reading with TextStack Reader',
+        href: DEMO_PATH,
+      }}
+      relatedLinks={[
+        { href: '/', label: '← TextStack Reader home' },
+        { href: '/books-with-translation', label: 'Books with translation for English learners →' },
+      ]}
+    />
+  )
+}

--- a/apps/web/src/styles/seo-article.css
+++ b/apps/web/src/styles/seo-article.css
@@ -1,0 +1,116 @@
+/* SEO landing article pages — topic-targeted (not country-targeted). */
+
+.seo-article {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 64px 20px 96px;
+}
+
+.seo-article__hero {
+  margin-bottom: 32px;
+}
+
+.seo-article__hero h1 {
+  font-family: 'Crimson Pro', serif;
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 500;
+  line-height: 1.15;
+  color: var(--color-text);
+  margin: 0 0 16px;
+  letter-spacing: -0.015em;
+}
+
+.seo-article__hero-sub {
+  font-family: 'Crimson Pro', serif;
+  font-size: 1.125rem;
+  font-style: italic;
+  color: var(--color-text-secondary);
+  margin: 0 0 28px;
+  line-height: 1.5;
+}
+
+.seo-article__section {
+  margin-top: 48px;
+}
+
+.seo-article__section h2 {
+  font-family: 'Inter', sans-serif;
+  font-size: 1.375rem;
+  font-weight: 500;
+  color: var(--color-text);
+  margin: 0 0 12px;
+}
+
+.seo-article__section p {
+  font-size: 1.0625rem;
+  line-height: 1.7;
+  color: var(--color-text);
+  margin: 0 0 12px;
+}
+
+.seo-article__section a {
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.seo-article__section--cta {
+  text-align: center;
+  margin-top: 56px;
+}
+
+.seo-article__cta {
+  display: inline-block;
+  background: var(--color-primary);
+  color: #fff;
+  padding: 14px 32px;
+  border-radius: 10px;
+  text-decoration: none;
+  font-family: 'Inter', sans-serif;
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  transition: opacity 0.15s ease;
+}
+
+.seo-article__cta:hover {
+  opacity: 0.92;
+}
+
+.seo-article__related {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 80px;
+  padding-top: 32px;
+  border-top: 1px solid var(--color-border);
+}
+
+.seo-article__related-link {
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+}
+
+.seo-article__related-link:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+@media (max-width: 600px) {
+  .seo-article {
+    padding: 40px 18px 72px;
+  }
+
+  .seo-article__section {
+    margin-top: 36px;
+  }
+
+  .seo-article__section--cta {
+    margin-top: 44px;
+  }
+}

--- a/backend/src/Api/Endpoints/SeoEndpoints.cs
+++ b/backend/src/Api/Endpoints/SeoEndpoints.cs
@@ -278,6 +278,24 @@ public static class SeoEndpoints
             }
         }
 
+        // English-only SEO landing pages (country + topic targeted).
+        var enLandingPages = new[]
+        {
+            "learn-english-brazil",
+            "learn-english-spain",
+            "read-books-in-english",
+            "books-with-translation",
+        };
+        foreach (var page in enLandingPages)
+        {
+            sb.AppendLine("  <url>");
+            sb.AppendLine($"    <loc>{baseUrl}/en/{page}/</loc>");
+            sb.AppendLine($"    <lastmod>{today}</lastmod>");
+            sb.AppendLine("    <changefreq>weekly</changefreq>");
+            sb.AppendLine("    <priority>0.8</priority>");
+            sb.AppendLine("  </url>");
+        }
+
         sb.AppendLine("</urlset>");
 
         return Task.FromResult(Results.Content(sb.ToString(), "application/xml"));

--- a/backend/src/Api/Endpoints/SsgEndpoints.cs
+++ b/backend/src/Api/Endpoints/SsgEndpoints.cs
@@ -47,6 +47,10 @@ public static class SsgEndpoints
         routes.Add("/en/learn-english-brazil");
         routes.Add("/en/learn-english-spain");
 
+        // Topic-targeted SEO landing pages (English-only).
+        routes.Add("/en/read-books-in-english");
+        routes.Add("/en/books-with-translation");
+
         // Books (each book has a language)
         var books = await db.Editions
             .Where(e => e.SiteId == site.SiteId &&


### PR DESCRIPTION
## Summary

Two topic-targeted SEO landing pages under `/en/`, each focused on one high-intent search query:

- `/en/read-books-in-english` — H1 "Read Books in English Without Translating Every Word"
- `/en/books-with-translation` — H1 "Books with Translation for English Learners"

Each page: hero (h1 + subhead + CTA) → 4 content sections (Problem → Why → What works → Product intro) → final CTA → related-links block (homepage + the other SEO page).

Product positioned as **TextStack Reader** throughout.

## Architecture

- **New reusable component** `SeoArticlePage.tsx` — thin, topic-agnostic, sibling to existing `CountryLandingPage`. Props: `pageKey`, `seo`, `hero`, `sections[]`, `cta`, `relatedLinks[]`.
- Pages live at `/en/...` (not root) — matches existing `LearnEnglishBrazilPage`/`LearnEnglishSpainPage` pattern and avoids LegacyRedirect conflicts. Root-level `/read-books-in-english` and `/books-with-translation` also added as legacy redirects for clean external linking.
- Copy is hardcoded English (matches country-landing pattern, no i18n overhead).
- CTA target: demo book reader (`/books/alices-adventures-in-wonderland/2-down-the-rabbit-hole`) — same zero-friction onboarding used on homepage + country pages.

## Files

**Created**
- `apps/web/src/components/landing/SeoArticlePage.tsx`
- `apps/web/src/styles/seo-article.css`
- `apps/web/src/pages/ReadBooksInEnglishPage.tsx`
- `apps/web/src/pages/BooksWithTranslationPage.tsx`

**Modified**
- `apps/web/src/App.tsx` — 2 routes + 2 legacy redirects
- `backend/src/Api/Endpoints/SsgEndpoints.cs` — prerender both new URLs
- `backend/src/Api/Endpoints/SeoEndpoints.cs` — sitemap entries (also back-filled existing `learn-english-brazil/spain` which were missing)

## Test plan

- [x] `pnpm -C apps/web build` green
- [x] `dotnet build textstack.sln` green
- [x] Visual check: both pages render, H1/subhead/5 sections/2 CTAs/related-links present
- [x] `<title>`, `<meta description>`, `<link rel="canonical">`, OG tags populated via `SeoHead`
- [x] Cross-linking works: page 1 ↔ page 2 ↔ homepage
- [x] Legacy redirect: `/read-books-in-english` → `/en/read-books-in-english`
- [ ] Post-deploy: `make rebuild-ssg` to prerender SEO HTML
- [ ] Post-deploy: `curl https://textstack.app/sitemap.xml` shows new URLs
- [ ] Post-deploy: Google Rich Results test both URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)