### PR TITLE
fix(tts): production hardening across server + client

### DIFF
--- a/apps/web/src/api/tts.ts
+++ b/apps/web/src/api/tts.ts
@@ -7,14 +7,31 @@ export function getTtsAudioUrl(text: string, lang: string, voice?: string, speed
   return `${API_BASE}/tts?${params}`
 }
 
+export class TtsRateLimitError extends Error {
+  readonly retryAfterSeconds: number
+  constructor(retryAfterSeconds: number) {
+    super(`TTS rate limited, retry after ${retryAfterSeconds}s`)
+    this.name = 'TtsRateLimitError'
+    this.retryAfterSeconds = retryAfterSeconds
+  }
+}
+
 export async function fetchTtsAudio(
   text: string,
   lang: string,
   voice?: string,
-  speed?: number
+  speed?: number,
+  signal?: AbortSignal,
 ): Promise<ArrayBuffer> {
   const url = getTtsAudioUrl(text, lang, voice, speed)
-  const res = await fetch(url)
+  const res = await fetch(url, { signal })
+  if (res.status === 429) {
+    // Server sends Retry-After (seconds) via RateLimiter.OnRejected.
+    // Parse it so callers can back off instead of hammering.
+    const header = res.headers.get('Retry-After')
+    const seconds = header ? parseInt(header, 10) : NaN
+    throw new TtsRateLimitError(Number.isFinite(seconds) && seconds > 0 ? seconds : 60)
+  }
   if (!res.ok) throw new Error(`TTS error: ${res.status}`)
   return res.arrayBuffer()
 }

--- a/apps/web/src/hooks/useTts.ts
+++ b/apps/web/src/hooks/useTts.ts
@@ -1,10 +1,16 @@
-import { useCallback, useRef, useState } from 'react'
-import { fetchTtsAudio } from '../api/tts'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { fetchTtsAudio, TtsRateLimitError } from '../api/tts'
 import { getCachedTtsAudio, cacheTtsAudio } from '../lib/offlineDb'
 
 // Shared playback element + blob URL — a single TTS stream at a time.
 let sharedAudio: HTMLAudioElement | null = null
 let currentBlobUrl: string | null = null
+
+// When one useTts instance takes over the shared audio, the previous owner's
+// onended/onerror handlers get cleared, so their local isPlaying state would
+// be stuck at true. Track the current owner's "I lost the audio" callback so
+// the new owner can reset the previous owner's state before taking over.
+let currentOwnerReset: (() => void) | null = null
 
 // iOS Safari / mobile Chrome block `audio.play()` outside a user gesture
 // (autoplay policy). We auto-play TTS from a useEffect that fires after
@@ -40,11 +46,38 @@ function unlockAudio() {
     })
 }
 
-if (typeof document !== 'undefined') {
+// Listener attachment is idempotent — call to (re)wire the unlock handlers.
+// We re-attach when a programmatic .play() throws NotAllowedError mid-session
+// (e.g. user revoked autoplay permission, switched tabs and lost the gesture
+// budget on Safari, or the original unlock event happened before the audio
+// element existed). Without this re-arm path, audioUnlocked stayed `true`
+// and we never tried to prime the element again — every subsequent speak()
+// silently failed with 'blocked' until full page reload.
+//
+// Idempotency guard: addEventListener({once: true}) deduplicates by (type,
+// listener, capture) tuple, so double-attaching the SAME function reference
+// is a no-op. But to make intent explicit + protect against overlapping
+// resetUnlock() calls firing extra handler runs, we gate on a flag.
+let unlockListenersAttached = false
+function attachUnlockListeners() {
+  if (typeof document === 'undefined') return
+  if (unlockListenersAttached) return
+  unlockListenersAttached = true
   const opts: AddEventListenerOptions = { once: true, passive: true, capture: true }
-  document.addEventListener('pointerdown', unlockAudio, opts)
-  document.addEventListener('touchstart', unlockAudio, opts)
-  document.addEventListener('keydown', unlockAudio, opts)
+  const wrapped = () => {
+    unlockListenersAttached = false
+    unlockAudio()
+  }
+  document.addEventListener('pointerdown', wrapped, opts)
+  document.addEventListener('touchstart', wrapped, opts)
+  document.addEventListener('keydown', wrapped, opts)
+}
+
+attachUnlockListeners()
+
+function resetUnlock() {
+  audioUnlocked = false
+  attachUnlockListeners()
 }
 
 function cleanup() {
@@ -54,29 +87,62 @@ function cleanup() {
   }
 }
 
-export type TtsError = 'blocked' | 'failed' | null
+export type TtsError = 'blocked' | 'failed' | 'rate_limited' | null
 
 export function useTts() {
   const [isPlaying, setIsPlaying] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<TtsError>(null)
+  const [retryAfterSeconds, setRetryAfterSeconds] = useState<number | null>(null)
   const abortRef = useRef<AbortController | null>(null)
+
+  // Stable per-instance callback — used as identity to tell owner-me apart
+  // from owner-other-instance in currentOwnerReset.
+  const localResetRef = useRef<() => void>(() => {})
+  localResetRef.current = () => {
+    setIsPlaying(false)
+    setIsLoading(false)
+  }
+  const localReset = useCallback(() => localResetRef.current(), [])
 
   const stop = useCallback(() => {
     abortRef.current?.abort()
     abortRef.current = null
     const audio = getAudio()
     audio.pause()
+    // Detach handlers BEFORE clearing src — setting src='' on an audio element
+    // with a loaded source triggers an error event, which would otherwise
+    // bubble to onerror and spuriously set error='failed' on user-initiated stop.
+    audio.onended = null
+    audio.onerror = null
     audio.src = ''
     cleanup()
     setIsPlaying(false)
     setIsLoading(false)
-  }, [])
+    if (currentOwnerReset === localReset) currentOwnerReset = null
+  }, [localReset])
+
+  // On unmount, release ownership so we don't leak a stale reset callback
+  // that closes over dead React state.
+  useEffect(() => {
+    return () => {
+      if (currentOwnerReset === localReset) currentOwnerReset = null
+    }
+  }, [localReset])
 
   const speak = useCallback(async (text: string, lang: string, voice?: string, speed?: number) => {
     // Stop any current playback
     stop()
+    // If another instance of useTts currently owns the shared audio, reset
+    // its React state — we just detached its onended/onerror above, so its
+    // isPlaying flag would otherwise be stuck until next render.
+    if (currentOwnerReset && currentOwnerReset !== localReset) {
+      const prev = currentOwnerReset
+      currentOwnerReset = null
+      prev()
+    }
     setError(null)
+    setRetryAfterSeconds(null)
 
     const controller = new AbortController()
     abortRef.current = controller
@@ -92,9 +158,11 @@ export function useTts() {
 
       if (controller.signal.aborted) return
 
-      // Fetch from API if not cached
+      // Fetch from API if not cached. Pass signal so abort during fetch
+      // actually cancels the network request — otherwise stop() sets the flag
+      // but the fetch still downloads to completion (wasted bandwidth).
       if (!audioData) {
-        audioData = await fetchTtsAudio(text, lang, voice, speed)
+        audioData = await fetchTtsAudio(text, lang, voice, speed, controller.signal)
         if (controller.signal.aborted) return
         // Cache for offline
         try { await cacheTtsAudio(lang, text, audioData) } catch { /* ignore */ }
@@ -112,12 +180,21 @@ export function useTts() {
       audio.onended = () => {
         setIsPlaying(false)
         cleanup()
+        if (currentOwnerReset === localReset) currentOwnerReset = null
       }
       audio.onerror = () => {
+        // Mid-playback failure: expose it to UI. Without setError, the popup
+        // just goes silent with no indicator — user thinks it worked.
         setIsPlaying(false)
         cleanup()
+        setError('failed')
+        if (currentOwnerReset === localReset) currentOwnerReset = null
       }
 
+      // Claim ownership of the shared audio right before playing. A later
+      // speak() from another instance will see us as the owner and notify
+      // us via localReset before hijacking.
+      currentOwnerReset = localReset
       setIsLoading(false)
       setIsPlaying(true)
       try {
@@ -128,16 +205,26 @@ export function useTts() {
         setIsPlaying(false)
         cleanup()
         setError(name === 'NotAllowedError' ? 'blocked' : 'failed')
+        // Re-arm the unlock path so the next user gesture tries again. Without
+        // this, audioUnlocked stays true after a permission revoke and every
+        // subsequent speak() fails the same way until full reload.
+        if (name === 'NotAllowedError') resetUnlock()
+        if (currentOwnerReset === localReset) currentOwnerReset = null
       }
     } catch (err) {
       if (!controller.signal.aborted) {
         console.error('TTS error:', err)
         setIsLoading(false)
         setIsPlaying(false)
-        setError('failed')
+        if (err instanceof TtsRateLimitError) {
+          setRetryAfterSeconds(err.retryAfterSeconds)
+          setError('rate_limited')
+        } else {
+          setError('failed')
+        }
       }
     }
-  }, [stop])
+  }, [stop, localReset])
 
-  return { speak, stop, isPlaying, isLoading, error }
+  return { speak, stop, isPlaying, isLoading, error, retryAfterSeconds }
 }

--- a/backend/src/Api/Endpoints/TtsEndpoints.cs
+++ b/backend/src/Api/Endpoints/TtsEndpoints.cs
@@ -1,3 +1,8 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using TextStack.Tts;
 
 namespace Api.Endpoints;
@@ -10,33 +15,65 @@ public static class TtsEndpoints
         // via proxy_pass trailing slash. Frontend calls /api/tts → nginx → /tts → here.
         var group = app.MapGroup("/tts").WithTags("TTS");
 
-        group.MapGet("", Synthesize).WithName("Synthesize");
-        group.MapGet("/voices", GetVoices).WithName("GetTtsVoices");
+        group.MapGet("", Synthesize).WithName("Synthesize").RequireRateLimiting("tts");
+        // Voices list is cheap (cached, no synthesis) — separate bucket so a
+        // burst of voice-list polls doesn't starve the synth budget and vice versa.
+        group.MapGet("/voices", GetVoices).WithName("GetTtsVoices").RequireRateLimiting("tts-voices");
     }
 
     private static async Task<IResult> Synthesize(
+        HttpContext http,
         string? text,
         string? lang,
         string? voice,
         double? speed,
         ITtsService tts,
-        IConfiguration config,
+        IOptions<TtsConfiguration> options,
         CancellationToken ct)
     {
-        var maxLength = config.GetValue("Tts:MaxTextLength", 500);
+        // Bind once via Options instead of `IConfiguration.GetValue` per call.
+        // `GetValue` walks the config providers and re-parses the string on
+        // every request — Options is cached + already strongly typed, so the
+        // hot path is a property read instead of a string lookup + Convert.
+        var cfg = options.Value;
 
         if (string.IsNullOrWhiteSpace(text))
             return Results.BadRequest("Text is required");
 
-        if (text.Length > maxLength)
-            return Results.BadRequest($"Text exceeds maximum length of {maxLength} characters");
+        if (text.Length > cfg.MaxTextLength)
+            return Results.BadRequest($"Text exceeds maximum length of {cfg.MaxTextLength} characters");
 
         if (string.IsNullOrWhiteSpace(lang))
             return Results.BadRequest("Language is required");
 
+        // Deterministic ETag from inputs — same (text, lang, voice, speed) always
+        // yields the same MP3, so a 304 short-circuit saves both bandwidth and a
+        // disk read. Browsers / CDNs can honor this even when IndexedDB cache
+        // is cleared.
+        var etag = ComputeEtag(text, lang, voice, speed ?? 1.0);
+        var responseCacheSeconds = cfg.ResponseCacheSeconds;
+        // RFC 9110: If-None-Match may carry a comma-separated list of validators
+        // ("a", "b", W/"c") or the wildcard "*". Raw `inm == etag` only matched
+        // a single-value header verbatim — multi-value clients (CDNs, fetch-with-
+        // multiple-cached-versions) silently missed the 304 and re-downloaded.
+        if (http.Request.Headers.TryGetValue("If-None-Match", out var inm) && IfNoneMatchMatches(inm, etag))
+        {
+            http.Response.StatusCode = StatusCodes.Status304NotModified;
+            http.Response.Headers.ETag = etag;
+            // RFC 9111 §4.3.4: a 304 SHOULD generate the same Cache-Control,
+            // Content-Location, Date, ETag, Expires, and Vary as the 200 would
+            // — so intermediaries can refresh stored freshness metadata. Without
+            // it, a CDN's cached entry's max-age may not be re-extended on a
+            // successful revalidation, forcing a full GET on next request.
+            http.Response.Headers.CacheControl = new StringValues($"public, max-age={responseCacheSeconds}, immutable");
+            return Results.Empty;
+        }
+
         try
         {
             var audio = await tts.SynthesizeAsync(text, lang, voice, speed ?? 1.0, ct);
+            http.Response.Headers.ETag = etag;
+            http.Response.Headers.CacheControl = new StringValues($"public, max-age={responseCacheSeconds}, immutable");
             return Results.File(audio, "audio/mpeg", enableRangeProcessing: true);
         }
         catch (TaskCanceledException)
@@ -49,6 +86,47 @@ public static class TtsEndpoints
                 detail: $"TTS service error: {ex.Message}",
                 statusCode: 502);
         }
+    }
+
+    private static string ComputeEtag(string text, string lang, string? voice, double speed)
+    {
+        var input = $"{text}|{lang}|{voice ?? ""}|{speed:F2}";
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        return $"\"{Convert.ToHexStringLower(hash)[..16]}\"";
+    }
+
+    // RFC 9110 §13.1.2: If-None-Match accepts "*", a single ETag, or a
+    // comma-separated list. Compare with weak-validator semantics: strip a
+    // leading "W/" so W/"abc" matches "abc". Our ETags are always strong, so
+    // a weak match-of-strong is acceptable for cache hit purposes.
+    //
+    // Span-based scan: previous string.Split(',') allocated an intermediate
+    // string[] + per-token strings on every TTS request. This walks the header
+    // value with IndexOf and slices via ReadOnlySpan<char> — zero allocations
+    // on the hot path.
+    private static bool IfNoneMatchMatches(StringValues header, string etag)
+    {
+        var etagSpan = etag.AsSpan();
+        foreach (var raw in header)
+        {
+            if (string.IsNullOrEmpty(raw)) continue;
+            var rest = raw.AsSpan();
+            while (!rest.IsEmpty)
+            {
+                int comma = rest.IndexOf(',');
+                ReadOnlySpan<char> token;
+                if (comma < 0) { token = rest; rest = default; }
+                else { token = rest[..comma]; rest = rest[(comma + 1)..]; }
+
+                token = token.Trim();
+                if (token.IsEmpty) continue;
+                if (token.Length == 1 && token[0] == '*') return true;
+                if (token.Length >= 2 && token[0] == 'W' && token[1] == '/')
+                    token = token[2..];
+                if (token.SequenceEqual(etagSpan)) return true;
+            }
+        }
+        return false;
     }
 
     private static async Task<IResult> GetVoices(

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -172,7 +172,48 @@ builder.Services.AddRateLimiter(options =>
             QueueLimit = 0,
         });
     });
+    // TTS synthesis — per-IP cap. Generous enough for bursty vocab-review /
+    // reader-tap usage (~2/s average, tolerates ~20-req bursts via window
+    // timing), but blocks scripted abuse hammering the upstream Bing WS.
+    // ETag + server+client cache mean most requests are cheap; this limit
+    // primarily protects synthesis (uncached) throughput.
+    options.AddPolicy("tts", httpContext =>
+    {
+        var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
+        {
+            Window = TimeSpan.FromMinutes(1),
+            PermitLimit = 120,
+            QueueLimit = 0,
+        });
+    });
+    // TTS voices list — cheap (served from 24h server cache), typically
+    // called once per session at voice-picker mount. Separate bucket with
+    // a much higher cap so a user burning through synthesis budget can
+    // still open the voice picker.
+    options.AddPolicy("tts-voices", httpContext =>
+    {
+        var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
+        {
+            Window = TimeSpan.FromMinutes(1),
+            PermitLimit = 600,
+            QueueLimit = 0,
+        });
+    });
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    // Emit Retry-After so clients can back off intelligently instead of
+    // hammering in a tight retry loop. RateLimiter exposes the metadata
+    // via lease.TryGetMetadata when available.
+    options.OnRejected = (context, ct) =>
+    {
+        if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))
+        {
+            var seconds = (int)Math.Ceiling(retryAfter.TotalSeconds);
+            context.HttpContext.Response.Headers.RetryAfter = seconds.ToString();
+        }
+        return ValueTask.CompletedTask;
+    };
 });
 
 // Validate required config at startup

--- a/backend/src/Tts/TextStack.Tts/EdgeTtsClient.cs
+++ b/backend/src/Tts/TextStack.Tts/EdgeTtsClient.cs
@@ -20,7 +20,16 @@ internal static class EdgeTtsClient
     private const string OutputFormat = "audio-24khz-48kbitrate-mono-mp3";
     private const long WinEpoch = 11_644_473_600L;
 
-    public static async Task<byte[]> SynthesizeAsync(string text, string voice, string rate, string volume, string pitch, CancellationToken ct)
+    // Shared HttpClient — the anti-pattern of `new HttpClient()` per call
+    // exhausts sockets under load (TIME_WAIT buildup). This endpoint is
+    // currently called at most once per process (voice list cached), but
+    // keeping the pattern correct prevents future regression.
+    private static readonly HttpClient SharedHttp = new()
+    {
+        Timeout = TimeSpan.FromSeconds(15)
+    };
+
+    public static async Task<byte[]> SynthesizeAsync(string text, string voice, string rate, string volume, string pitch, string lang, CancellationToken ct, long maxAudioBytes = 5L * 1024 * 1024)
     {
         var connectionId = Guid.NewGuid().ToString("N");
         var secGec = GenerateSecMsGec();
@@ -62,70 +71,118 @@ internal static class EdgeTtsClient
         var requestId = Guid.NewGuid().ToString("N");
         var timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
         var escapedText = System.Security.SecurityElement.Escape(text);
+        // Derive BCP-47 lang tag from the voice name (e.g. "uk-UA-PolinaNeural"
+        // → "uk-UA"). Hardcoding en-US was semantically wrong for non-English
+        // voices; engines generally respect <voice> but xml:lang affects
+        // fallback processing and should match.
+        var xmlLang = ResolveXmlLang(voice, lang);
+        var escapedLang = System.Security.SecurityElement.Escape(xmlLang);
+        var escapedVoice = System.Security.SecurityElement.Escape(voice);
         var ssml =
             $"X-RequestId:{requestId}\r\n" +
             "Content-Type:application/ssml+xml\r\n" +
             $"X-Timestamp:{timestamp}\r\n" +
             "Path:ssml\r\n\r\n" +
-            $"<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='en-US'>" +
-            $"<voice name='{voice}'><prosody pitch='{pitch}' rate='{rate}' volume='{volume}'>{escapedText}</prosody></voice></speak>";
+            $"<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='{escapedLang}'>" +
+            $"<voice name='{escapedVoice}'><prosody pitch='{pitch}' rate='{rate}' volume='{volume}'>{escapedText}</prosody></voice></speak>";
         await SendTextAsync(ws, ssml, ct);
 
         // 3. Receive audio chunks
         using var audioStream = new MemoryStream();
         var buffer = new byte[8192];
+        // Reuse one MemoryStream across messages — `using var msgStream = new
+        // MemoryStream()` inside the loop allocated a fresh stream per WS
+        // message (one per ~8KB chunk = many per response), churning the GC
+        // under load. SetLength(0) inside the loop resets without freeing the
+        // backing buffer, so subsequent writes hit the same array.
+        using var msgStream = new MemoryStream();
 
-        while (ws.State == WebSocketState.Open)
+        try
         {
-            using var msgStream = new MemoryStream();
-            WebSocketReceiveResult result;
-            do
+            while (ws.State == WebSocketState.Open)
             {
-                result = await ws.ReceiveAsync(buffer, ct);
-                msgStream.Write(buffer, 0, result.Count);
-            } while (!result.EndOfMessage);
-
-            if (result.MessageType == WebSocketMessageType.Close)
-                break;
-
-            if (result.MessageType == WebSocketMessageType.Binary)
-            {
-                var data = msgStream.ToArray();
-                if (data.Length > 2)
+                msgStream.SetLength(0);
+                WebSocketReceiveResult result;
+                do
                 {
-                    // First 2 bytes = header length (big-endian)
-                    var headerLen = (data[0] << 8) | data[1];
-                    var audioStart = headerLen + 2;
-                    if (audioStart < data.Length)
-                        audioStream.Write(data, audioStart, data.Length - audioStart);
+                    result = await ws.ReceiveAsync(buffer, ct);
+                    msgStream.Write(buffer, 0, result.Count);
+                } while (!result.EndOfMessage);
+
+                if (result.MessageType == WebSocketMessageType.Close)
+                    break;
+
+                if (result.MessageType == WebSocketMessageType.Binary)
+                {
+                    // Use GetBuffer() + length to avoid the ToArray() copy that
+                    // each iteration would otherwise allocate.
+                    var msgLen = (int)msgStream.Length;
+                    var msgBuf = msgStream.GetBuffer();
+                    if (msgLen > 2)
+                    {
+                        // First 2 bytes = header length (big-endian)
+                        var headerLen = (msgBuf[0] << 8) | msgBuf[1];
+                        var audioStart = headerLen + 2;
+                        if (audioStart < msgLen)
+                        {
+                            var chunkLen = msgLen - audioStart;
+                            // Hard cap — Bing should never exceed a few hundred KB for
+                            // a 500-char input, so anything past maxAudioBytes is a
+                            // protocol regression or attack. Bail before OOM.
+                            if (audioStream.Length + chunkLen > maxAudioBytes)
+                                throw new InvalidOperationException(
+                                    $"TTS response exceeded {maxAudioBytes} bytes — aborting");
+                            audioStream.Write(msgBuf, audioStart, chunkLen);
+                        }
+                    }
+                }
+                else if (result.MessageType == WebSocketMessageType.Text)
+                {
+                    var text_ = Encoding.UTF8.GetString(msgStream.GetBuffer(), 0, (int)msgStream.Length);
+                    if (text_.Contains("Path:turn.end"))
+                        break;
                 }
             }
-            else if (result.MessageType == WebSocketMessageType.Text)
+        }
+        finally
+        {
+            // Always attempt a graceful close. Without it, an exception path
+            // (size cap, cancellation, IO error) leaves Bing seeing an abrupt
+            // TCP RST when the `using ws` finalizes — repeated unfriendly
+            // disconnects can attract rate-limiting / IP blocks. Best-effort:
+            // socket may already be in a bad state, so swallow close failures.
+            // Use a short bounded timeout — don't let close hang on a dead peer.
+            if (ws.State == WebSocketState.Open || ws.State == WebSocketState.CloseReceived)
             {
-                var text_ = Encoding.UTF8.GetString(msgStream.ToArray());
-                if (text_.Contains("Path:turn.end"))
-                    break;
+                try
+                {
+                    using var closeCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+                    await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, closeCts.Token);
+                }
+                catch { /* best-effort */ }
             }
         }
-
-        if (ws.State == WebSocketState.Open)
-            await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None);
 
         return audioStream.ToArray();
     }
 
     public static async Task<List<EdgeVoiceData>> GetVoicesAsync(CancellationToken ct)
     {
-        using var http = new HttpClient();
-        http.DefaultRequestHeaders.Add("Authority", "speech.platform.bing.com");
-        http.DefaultRequestHeaders.Add("Sec-CH-UA", $"\"Microsoft Edge\";v=\"{ChromiumVersion.Split('.')[0]}\", \"Chromium\";v=\"{ChromiumVersion.Split('.')[0]}\", \"Not?A_Brand\";v=\"99\"");
-        http.DefaultRequestHeaders.Add("Accept", "application/json");
-        http.DefaultRequestHeaders.Add("Sec-Fetch-Site", "none");
-        http.DefaultRequestHeaders.Add("Sec-Fetch-Mode", "cors");
-        http.DefaultRequestHeaders.Add("Sec-Fetch-Dest", "empty");
-        http.DefaultRequestHeaders.Add("User-Agent", $"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/{ChromiumVersion} Safari/537.36 Edg/{ChromiumVersion}");
+        // Headers per-request (not on SharedHttp.DefaultRequestHeaders) — shared
+        // client is stateless; mutating defaults on a static client would race
+        // across concurrent callers.
+        using var req = new HttpRequestMessage(HttpMethod.Get, VoiceListUrl);
+        req.Headers.Add("Authority", "speech.platform.bing.com");
+        req.Headers.Add("Sec-CH-UA", $"\"Microsoft Edge\";v=\"{ChromiumVersion.Split('.')[0]}\", \"Chromium\";v=\"{ChromiumVersion.Split('.')[0]}\", \"Not?A_Brand\";v=\"99\"");
+        req.Headers.Add("Accept", "application/json");
+        req.Headers.Add("Sec-Fetch-Site", "none");
+        req.Headers.Add("Sec-Fetch-Mode", "cors");
+        req.Headers.Add("Sec-Fetch-Dest", "empty");
+        req.Headers.Add("User-Agent", $"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/{ChromiumVersion} Safari/537.36 Edg/{ChromiumVersion}");
 
-        var json = await http.GetStringAsync(VoiceListUrl, ct);
+        using var res = await SharedHttp.SendAsync(req, HttpCompletionOption.ResponseContentRead, ct);
+        res.EnsureSuccessStatusCode();
+        var json = await res.Content.ReadAsStringAsync(ct);
         return JsonSerializer.Deserialize<List<EdgeVoiceData>>(json) ?? [];
     }
 
@@ -133,6 +190,18 @@ internal static class EdgeTtsClient
     {
         var bytes = Encoding.UTF8.GetBytes(message);
         await ws.SendAsync(bytes, WebSocketMessageType.Text, true, ct);
+    }
+
+    private static string ResolveXmlLang(string voice, string lang)
+    {
+        // Voice names follow "xx-YY-Name…" — first two dash-segments form the
+        // BCP-47 tag. Fall back to caller-provided lang (or en-US) if the
+        // voice name is malformed.
+        var parts = voice.Split('-');
+        if (parts.Length >= 2 && parts[0].Length == 2 && parts[1].Length >= 2)
+            return $"{parts[0]}-{parts[1]}";
+        if (!string.IsNullOrWhiteSpace(lang)) return lang.Contains('-') ? lang : $"{lang.ToLowerInvariant()}-{lang.ToUpperInvariant()}";
+        return "en-US";
     }
 
     private static string GenerateSecMsGec()

--- a/backend/src/Tts/TextStack.Tts/EdgeTtsService.cs
+++ b/backend/src/Tts/TextStack.Tts/EdgeTtsService.cs
@@ -6,17 +6,34 @@ using Microsoft.Extensions.Options;
 
 namespace TextStack.Tts;
 
-public class EdgeTtsService : ITtsService, IHostedService
+public class EdgeTtsService : ITtsService, IHostedService, IDisposable
 {
     private readonly TtsConfiguration _config;
     private readonly ILogger<EdgeTtsService> _logger;
-    private readonly SemaphoreSlim _synthLock = new(3); // max 3 concurrent synthesis
+    private readonly SemaphoreSlim _synthLock;
+    private readonly SemaphoreSlim _voicesLock = new(1, 1); // serialize voice-list fetch
     private List<EdgeVoiceData>? _cachedVoices;
+    private DateTime _cachedVoicesAtUtc;
+    private Timer? _cacheSweepTimer;
+    // Re-entrancy guard for SweepCache. System.Threading.Timer can fire a
+    // second callback on a different ThreadPool thread before the first
+    // returns (sweep on a slow disk could outrun a short interval, or the
+    // CacheSweepInterval could be tuned down). Two concurrent sweeps would
+    // race on the same FileInfo set, doubling delete attempts and the "X
+    // delete(s) failed" warning. 0 = idle, 1 = running.
+    private int _sweepInProgress;
+    private static readonly TimeSpan CacheSweepInterval = TimeSpan.FromHours(1);
+    private static readonly TimeSpan VoicesTtl = TimeSpan.FromHours(24);
+    // On refresh failure, retry sooner than the normal TTL so we recover
+    // quickly from a transient outage instead of waiting a full day.
+    private static readonly TimeSpan VoicesRefreshBackoff = TimeSpan.FromMinutes(5);
 
     public EdgeTtsService(IOptions<TtsConfiguration> config, ILogger<EdgeTtsService> logger)
     {
         _config = config.Value;
         _logger = logger;
+        var concurrency = Math.Max(1, _config.MaxConcurrentSynths);
+        _synthLock = new SemaphoreSlim(concurrency, concurrency);
     }
 
     private bool _cacheAvailable;
@@ -27,7 +44,16 @@ public class EdgeTtsService : ITtsService, IHostedService
         {
             Directory.CreateDirectory(_config.CachePath);
             _cacheAvailable = true;
-            CleanExpiredCache();
+            // Off-load the initial sweep — on a slow disk with a large cache,
+            // a synchronous sweep here would block IHostedService.StartAsync
+            // (and therefore application boot) for seconds. The periodic timer
+            // will retry if this first one is still running by the time it fires.
+            _ = Task.Run(SweepCache);
+            // Periodic sweep — long-running servers otherwise accumulate expired
+            // files until restart, and MaxCacheSizeBytes is never enforced.
+            // Off-load to Task.Run so a long sweep doesn't pin the Timer thread
+            // (the Timer ThreadPool worker is supposed to return promptly).
+            _cacheSweepTimer = new Timer(_ => Task.Run(SweepCache), null, CacheSweepInterval, CacheSweepInterval);
         }
         catch (Exception ex)
         {
@@ -36,7 +62,36 @@ public class EdgeTtsService : ITtsService, IHostedService
         return Task.CompletedTask;
     }
 
-    public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+    public async Task StopAsync(CancellationToken ct)
+    {
+        // DisposeAsync waits for any in-flight Timer callback to return, but
+        // our callback is `_ => Task.Run(SweepCache)` — the lambda returns
+        // immediately while the actual sweep continues on a different thread.
+        // So we additionally poll _sweepInProgress to give that work a chance
+        // to finish (with a bounded deadline so a wedged sweep can't block
+        // shutdown indefinitely).
+        if (_cacheSweepTimer != null)
+        {
+            await _cacheSweepTimer.DisposeAsync();
+            _cacheSweepTimer = null;
+        }
+
+        var waitMs = Math.Max(0, _config.ShutdownSweepWaitSeconds) * 1000;
+        var deadline = Environment.TickCount + waitMs;
+        while (Volatile.Read(ref _sweepInProgress) != 0 && Environment.TickCount < deadline)
+        {
+            try { await Task.Delay(50, ct); }
+            catch (OperationCanceledException) { break; }
+        }
+    }
+
+    public void Dispose()
+    {
+        _cacheSweepTimer?.Dispose();
+        _synthLock.Dispose();
+        _voicesLock.Dispose();
+        GC.SuppressFinalize(this);
+    }
 
     public async Task<byte[]> SynthesizeAsync(string text, string lang, string? voice, double speed, CancellationToken ct)
     {
@@ -50,6 +105,7 @@ public class EdgeTtsService : ITtsService, IHostedService
         if (cachePath != null && File.Exists(cachePath))
         {
             _logger.LogDebug("TTS cache hit: {Key}", cacheKey);
+            TouchCacheFile(cachePath);
             return await File.ReadAllBytesAsync(cachePath, ct);
         }
 
@@ -59,28 +115,44 @@ public class EdgeTtsService : ITtsService, IHostedService
         {
             // Double-check after acquiring lock
             if (cachePath != null && File.Exists(cachePath))
+            {
+                TouchCacheFile(cachePath);
                 return await File.ReadAllBytesAsync(cachePath, ct);
+            }
 
             _logger.LogInformation("TTS synthesizing: voice={Voice}, text={Text}", voice, text[..Math.Min(50, text.Length)]);
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             cts.CancelAfter(TimeSpan.FromSeconds(_config.TimeoutSeconds));
 
-            var audio = await EdgeTtsClient.SynthesizeAsync(text, voice, rate, "+0%", "+0Hz", cts.Token);
+            var audio = await EdgeTtsClient.SynthesizeAsync(text, voice, rate, "+0%", "+0Hz", lang, cts.Token, _config.MaxAudioBytes);
 
             if (audio.Length == 0)
                 throw new InvalidOperationException("TTS returned empty audio");
 
             if (cachePath != null)
             {
+                // Atomic write: tmp file + rename. Direct WriteAllBytesAsync to
+                // the final path leaves a partial/corrupt .mp3 if the process is
+                // killed mid-write — and File.Exists() on next call would treat
+                // it as a cache hit, serving broken audio forever (TTL won't
+                // help since mtime is fresh). Tmp+Move ensures the final path
+                // either contains the complete payload or doesn't exist.
+                // Per-call random suffix avoids collisions when two callers race
+                // on the same key (lock above prevents that today, but the file
+                // op is safe regardless).
+                var tmpPath = cachePath + "." + Guid.NewGuid().ToString("N")[..8] + ".tmp";
                 try
                 {
-                    await File.WriteAllBytesAsync(cachePath, audio, ct);
+                    await File.WriteAllBytesAsync(tmpPath, audio, ct);
+                    File.Move(tmpPath, cachePath, overwrite: true);
                     _logger.LogInformation("TTS cached: {Key} ({Size}KB)", cacheKey, audio.Length / 1024);
                 }
                 catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
                 {
                     _logger.LogWarning(ex, "TTS cache write failed for {Key}, returning audio without caching", cacheKey);
+                    try { if (File.Exists(tmpPath)) File.Delete(tmpPath); }
+                    catch (Exception cleanupEx) when (cleanupEx is UnauthorizedAccessException or IOException) { }
                 }
             }
 
@@ -94,9 +166,55 @@ public class EdgeTtsService : ITtsService, IHostedService
 
     public async Task<IReadOnlyList<TtsVoiceInfo>> GetVoicesAsync(string? lang, CancellationToken ct)
     {
-        _cachedVoices ??= await EdgeTtsClient.GetVoicesAsync(ct);
+        // Serialize first fetch so concurrent callers don't both hit Bing, and
+        // a transient failure doesn't permanently null out the cache field
+        // (`??=` would leave _cachedVoices null on throw, but every subsequent
+        // caller would refetch; we want that, not block — keep null on failure).
+        // TTL refresh: Microsoft occasionally adds/removes voices — without
+        // expiry the process has to restart to pick them up.
+        if (IsVoicesStale())
+        {
+            await _voicesLock.WaitAsync(ct);
+            try
+            {
+                if (IsVoicesStale())
+                {
+                    try
+                    {
+                        var fresh = await EdgeTtsClient.GetVoicesAsync(ct);
+                        // Guard: if Bing returns empty transiently, don't trash
+                        // an existing populated cache. Better stale-real than fresh-empty.
+                        if (fresh.Count > 0 || _cachedVoices == null)
+                        {
+                            _cachedVoices = fresh;
+                            _cachedVoicesAtUtc = DateTime.UtcNow;
+                        }
+                        else
+                        {
+                            _logger.LogWarning("TTS voices fetch returned empty list; keeping previous cache");
+                            _cachedVoicesAtUtc = DateTime.UtcNow; // avoid hammering on transient empties
+                        }
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        // First-ever fetch failed — no cache to serve, surface the error.
+                        if (_cachedVoices == null) throw;
 
-        var voices = _cachedVoices.AsEnumerable();
+                        // Refresh of existing cache failed — serve stale. Bump
+                        // the timestamp by a short backoff so the next caller
+                        // retries soon (not immediately), not in a full TTL.
+                        _logger.LogWarning(ex, "TTS voices refresh failed; serving stale cache for {Backoff}", VoicesRefreshBackoff);
+                        _cachedVoicesAtUtc = DateTime.UtcNow - VoicesTtl + VoicesRefreshBackoff;
+                    }
+                }
+            }
+            finally
+            {
+                _voicesLock.Release();
+            }
+        }
+
+        var voices = (_cachedVoices ?? new List<EdgeVoiceData>()).AsEnumerable();
         if (!string.IsNullOrEmpty(lang))
             voices = voices.Where(v => v.Locale.StartsWith(lang, StringComparison.OrdinalIgnoreCase));
 
@@ -111,10 +229,27 @@ public class EdgeTtsService : ITtsService, IHostedService
             .ToList();
     }
 
+    private bool IsVoicesStale()
+        => _cachedVoices == null || DateTime.UtcNow - _cachedVoicesAtUtc > VoicesTtl;
+
     private string ResolveDefaultVoice(string lang)
     {
         var key = lang.Split('-')[0].ToLowerInvariant();
-        return _config.DefaultVoices.TryGetValue(key, out var voice) ? voice : "en-US-AriaNeural";
+        if (_config.DefaultVoices.TryGetValue(key, out var voice)) return voice;
+
+        // Fallback to whatever the Bing voice list offers for this lang (if we've
+        // already loaded it). Previously any lang outside en/uk silently used
+        // an English voice — Spanish text read by en-US-AriaNeural etc.
+        var loaded = _cachedVoices;
+        if (loaded != null)
+        {
+            var match = loaded.FirstOrDefault(v =>
+                v.Locale.StartsWith(key + "-", StringComparison.OrdinalIgnoreCase));
+            if (match != null) return match.ShortName;
+        }
+
+        _logger.LogWarning("TTS: no default voice for lang={Lang}, falling back to en-US-AriaNeural", lang);
+        return "en-US-AriaNeural";
     }
 
     private static string SpeedToRate(double speed) => speed switch
@@ -135,29 +270,136 @@ public class EdgeTtsService : ITtsService, IHostedService
         return Convert.ToHexStringLower(hash)[..16];
     }
 
-    private void CleanExpiredCache()
+    // Bump LastWriteTimeUtc on cache hit so SweepCache's TTL + size eviction
+    // behave as true LRU (recently-used files survive) instead of purging by
+    // original write age. LastAccessTimeUtc would be natural, but Linux
+    // typically mounts with `noatime` and doesn't update it — manual touch
+    // is portable. Best-effort: silently ignore IO failures.
+    //
+    // Coalesce: only write when the existing mtime is older than the coalesce
+    // window. A hot file hit 1000x/hour generates one write instead of 1000 —
+    // critical on networked filesystems (NFS/EFS) where write syscalls are
+    // orders of magnitude slower than the cache read itself. The precision
+    // loss is at most TouchCoalesceWindow, which is << TTL and << sweep
+    // interval, so LRU ordering stays correct.
+    private static readonly TimeSpan TouchCoalesceWindow = TimeSpan.FromHours(1);
+    private static void TouchCacheFile(string path)
     {
         try
         {
-            var cutoff = DateTime.UtcNow.AddDays(-_config.CacheTtlDays);
-            var dir = new DirectoryInfo(_config.CachePath);
-            if (!dir.Exists) return;
+            var mtime = File.GetLastWriteTimeUtc(path);
+            if (DateTime.UtcNow - mtime < TouchCoalesceWindow) return;
+            File.SetLastWriteTimeUtc(path, DateTime.UtcNow);
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException) { }
+    }
 
-            var deleted = 0;
-            foreach (var file in dir.EnumerateFiles("*.mp3"))
-            {
-                if (file.LastWriteTimeUtc < cutoff)
-                {
-                    file.Delete();
-                    deleted++;
-                }
-            }
-            if (deleted > 0)
-                _logger.LogInformation("TTS cache cleanup: deleted {Count} expired files", deleted);
+    // Two-pass sweep: (1) TTL expiry, (2) if still over MaxCacheSizeBytes,
+    // evict oldest files until under the budget. Runs at startup and on a
+    // periodic Timer so long-lived servers don't drift past the declared
+    // cap (config.MaxCacheSizeBytes was defined but previously never honored).
+    //
+    // Outer wrapper: owns the _sweepInProgress flag and guarantees release.
+    // Splitting the work into a separate method keeps the acquire/release
+    // contract tight — no path between CompareExchange and try/finally
+    // could possibly throw and orphan the flag (previously the body sat
+    // directly under the CompareExchange; safe today but fragile against
+    // future edits).
+    private void SweepCache()
+    {
+        // Skip if a previous sweep is still running. Don't queue — the next
+        // periodic tick will pick up whatever this one missed.
+        if (Interlocked.CompareExchange(ref _sweepInProgress, 1, 0) != 0)
+        {
+            _logger.LogDebug("TTS cache sweep already in progress, skipping this tick");
+            return;
+        }
+        try
+        {
+            SweepCacheCore();
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "TTS cache cleanup failed");
+            _logger.LogWarning(ex, "TTS cache sweep failed");
         }
+        finally
+        {
+            Interlocked.Exchange(ref _sweepInProgress, 0);
+        }
+    }
+
+    private void SweepCacheCore()
+    {
+        var dir = new DirectoryInfo(_config.CachePath);
+        if (!dir.Exists) return;
+
+        var cutoff = DateTime.UtcNow.AddDays(-_config.CacheTtlDays);
+        var tmpCutoff = DateTime.UtcNow.AddMinutes(-10);
+        long totalBytes = 0;
+        var deleted = 0;
+        // Track delete failures so persistent permission/lock issues become
+        // visible — silently swallowed, the cache would grow past
+        // MaxCacheSizeBytes with no operator signal. Aggregate per sweep
+        // (don't log per-file: that would spam on a bad mount).
+        var failed = 0;
+        Exception? lastFailure = null;
+
+        // Two filtered enumerations: lets the OS-level glob filter do the
+        // work. EnumerateFiles() with no pattern would force us to walk every
+        // entry (logs, .DS_Store, future neighbours) and string-compare the
+        // extension twice per file — wasted IO on a busy mount.
+        // Both enumerations are lazy (no upfront materialization).
+
+        // Reap orphan .tmp files left behind by killed writes — they never
+        // get promoted to .mp3 (atomic rename never ran) and nothing else
+        // would clean them up.
+        foreach (var tmp in dir.EnumerateFiles("*.tmp"))
+        {
+            if (tmp.LastWriteTimeUtc < tmpCutoff)
+            {
+                try { tmp.Delete(); deleted++; }
+                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException) { failed++; lastFailure = ex; }
+            }
+        }
+
+        // Pass 1: TTL expiry — survivors collected for potential pass 2.
+        var survivors = new List<FileInfo>();
+        foreach (var file in dir.EnumerateFiles("*.mp3"))
+        {
+            if (file.LastWriteTimeUtc < cutoff)
+            {
+                try { file.Delete(); deleted++; }
+                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException) { failed++; lastFailure = ex; }
+            }
+            else
+            {
+                survivors.Add(file);
+                totalBytes += file.Length;
+            }
+        }
+
+        // Pass 2: size enforcement (LRU by LastWriteTimeUtc). Sort in place
+        // to avoid the OrderBy intermediate allocation.
+        if (totalBytes > _config.MaxCacheSizeBytes)
+        {
+            survivors.Sort(static (a, b) => a.LastWriteTimeUtc.CompareTo(b.LastWriteTimeUtc));
+            foreach (var file in survivors)
+            {
+                if (totalBytes <= _config.MaxCacheSizeBytes) break;
+                var size = file.Length;
+                try
+                {
+                    file.Delete();
+                    totalBytes -= size;
+                    deleted++;
+                }
+                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException) { failed++; lastFailure = ex; }
+            }
+        }
+
+        if (deleted > 0)
+            _logger.LogInformation("TTS cache sweep: deleted {Count} files, size={SizeMb}MB", deleted, totalBytes / 1024 / 1024);
+        if (failed > 0)
+            _logger.LogWarning(lastFailure, "TTS cache sweep: {Failed} delete(s) failed (last error shown)", failed);
     }
 }

--- a/backend/src/Tts/TextStack.Tts/TtsConfiguration.cs
+++ b/backend/src/Tts/TextStack.Tts/TtsConfiguration.cs
@@ -7,10 +7,62 @@ public class TtsConfiguration
     public int TimeoutSeconds { get; set; } = 15;
     public long MaxCacheSizeBytes { get; set; } = 1L * 1024 * 1024 * 1024; // 1GB
     public int CacheTtlDays { get; set; } = 30;
+    // Concurrency cap across the process. Previously hardcoded to 3 — under
+    // burst load (e.g. multiple users streaming TTS at once) that throttled
+    // unnecessarily. Expose so ops can tune per-host.
+    public int MaxConcurrentSynths { get; set; } = 6;
+    public int ResponseCacheSeconds { get; set; } = 86400; // 1 day
+    // Hard ceiling on a single synthesis response. MaxTextLength caps input at
+    // 500 chars; at 24kHz/48kbps mono mp3 that's ~30s of audio ≈ 200KB. 5MB is
+    // a generous safety net — if Bing ever streams unbounded data (bug, attack,
+    // protocol change) we abort instead of OOM-ing the process.
+    public long MaxAudioBytes { get; set; } = 5L * 1024 * 1024;
+    // Bounded wait during graceful shutdown for an in-flight cache sweep to
+    // finish. On a slow disk + large cache the sweep can legitimately take
+    // 10s+; on a healthy host it returns in <100ms. 5s is a reasonable
+    // default — bumpable via config for slow mounts (NFS/EFS).
+    public int ShutdownSweepWaitSeconds { get; set; } = 5;
 
     public Dictionary<string, string> DefaultVoices { get; set; } = new()
     {
+        // Broader coverage so non-English books don't fall back to an English
+        // voice speaking foreign text (worst-quality degradation).
         ["en"] = "en-US-AriaNeural",
-        ["uk"] = "uk-UA-PolinaNeural"
+        ["uk"] = "uk-UA-PolinaNeural",
+        ["ru"] = "ru-RU-SvetlanaNeural",
+        ["es"] = "es-ES-ElviraNeural",
+        ["fr"] = "fr-FR-DeniseNeural",
+        ["de"] = "de-DE-KatjaNeural",
+        ["it"] = "it-IT-ElsaNeural",
+        ["pt"] = "pt-BR-FranciscaNeural",
+        ["pl"] = "pl-PL-AgnieszkaNeural",
+        ["nl"] = "nl-NL-ColetteNeural",
+        ["tr"] = "tr-TR-EmelNeural",
+        ["ja"] = "ja-JP-NanamiNeural",
+        ["ko"] = "ko-KR-SunHiNeural",
+        ["zh"] = "zh-CN-XiaoxiaoNeural",
+        ["ar"] = "ar-SA-ZariyahNeural",
+        ["hi"] = "hi-IN-SwaraNeural",
+        ["cs"] = "cs-CZ-VlastaNeural",
+        ["sk"] = "sk-SK-ViktoriaNeural",
+        ["ro"] = "ro-RO-AlinaNeural",
+        ["hu"] = "hu-HU-NoemiNeural",
+        ["sv"] = "sv-SE-SofieNeural",
+        ["no"] = "nb-NO-PernilleNeural",
+        ["da"] = "da-DK-ChristelNeural",
+        ["fi"] = "fi-FI-NooraNeural",
+        ["el"] = "el-GR-AthinaNeural",
+        ["he"] = "he-IL-HilaNeural",
+        ["id"] = "id-ID-GadisNeural",
+        ["vi"] = "vi-VN-HoaiMyNeural",
+        ["th"] = "th-TH-PremwadeeNeural",
+        ["bg"] = "bg-BG-KalinaNeural",
+        ["hr"] = "hr-HR-GabrijelaNeural",
+        ["sr"] = "sr-RS-SophieNeural",
+        ["lt"] = "lt-LT-OnaNeural",
+        ["lv"] = "lv-LV-EveritaNeural",
+        ["et"] = "et-EE-AnuNeural",
+        ["sl"] = "sl-SI-PetraNeural",
+        ["ca"] = "ca-ES-JoanaNeural"
     };
 }


### PR DESCRIPTION
## Summary

End-to-end TTS reliability/perf pass — server and client.

### Backend (`TextStack.Tts` + `TtsEndpoints` + `Program`)
- **Rate limiting**: `tts` (120/min) + `tts-voices` (600/min) per-IP buckets; `Retry-After` header on 429 via `OnRejected` lease metadata.
- **Caching**: ETag + `Cache-Control: immutable`, RFC-9110 multi-value `If-None-Match`, RFC-9111 cache headers on 304.
- **Disk cache**: atomic write (tmp + rename), orphan `.tmp` reaper, periodic sweep (TTL + LRU), `MaxCacheSizeBytes` enforcement, coalesced `LastWriteTimeUtc` touches.
- **Concurrency**: configurable `MaxConcurrentSynths`, voices fetch serialization, 24h voices TTL with stale-fallback on refresh failure.
- **Lifecycle**: async startup sweep (no boot block), re-entrancy guard, bounded shutdown wait, graceful WebSocket close on exception path.
- **Safety**: `MaxAudioBytes` cap aborts before OOM; XML-escaped voice/lang; dynamic SSML `xml:lang` from voice name; shared `HttpClient` with per-request `HttpRequestMessage`.
- **Defaults**: `DefaultVoices` expanded from 2 → 37 languages.

### Frontend (`useTts.ts` + `tts.ts`)
- `audio.onerror` now surfaces failure; detach handlers before `src=''` to avoid spurious errors on `stop()`.
- `AbortSignal` threaded through fetch — actually cancels in-flight requests.
- `TtsRateLimitError` parses `Retry-After`; new `'rate_limited'` UI state with `retryAfterSeconds`.
- Module-level ownership callback fixes shared-audio race across `useTts` instances.
- Autoplay re-unlock path: re-arms gesture listeners on `NotAllowedError` so revoked permissions recover without page reload.

## Test plan
- [ ] `dotnet test tests/TextStack.UnitTests`
- [ ] Smoke: synth + replay (ETag 304), rapid burst hits 429 with `Retry-After`, voice list cached
- [ ] Reader: TTS in SelectionToolbar / DictionaryPopup / TranslationPopup still works
- [ ] iOS Safari: word tap → audio plays after first gesture
- [ ] Kill API mid-cache-write → next call doesn't serve corrupt MP3
- [ ] Restart API with full cache → boot is fast (sweep is async)

🤖 Generated with [Claude Code](https://claude.com/claude-code)