### PR TITLE
feat(reader): word auto-save on tap + UX polish

### DIFF
--- a/apps/web/src/components/reader/NoteEditor.tsx
+++ b/apps/web/src/components/reader/NoteEditor.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState, useCallback } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, useCallback } from 'react'
 import type { StoredHighlight } from '../../lib/offlineDb'
+import { useTranslation } from '../../hooks/useTranslation'
 
 interface NoteEditorProps {
   highlight: StoredHighlight
@@ -18,12 +19,14 @@ export function NoteEditor({
   onDelete,
   onClose,
 }: NoteEditorProps) {
+  const { t } = useTranslation()
   const editorRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [noteText, setNoteText] = useState(highlight.noteText ?? '')
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null)
 
-  useEffect(() => {
+  // useLayoutEffect: reposition before paint, no flash when editor mounts or rect changes.
+  useLayoutEffect(() => {
     if (!rect || !containerRef.current || !editorRef.current) {
       setPosition(null)
       return
@@ -125,9 +128,9 @@ export function NoteEditor({
         <button
           className="note-editor__close"
           onClick={onClose}
-          aria-label="Close"
+          aria-label={t('reader.noteEditor.close')}
         >
-          x
+          ×
         </button>
       </div>
 
@@ -136,7 +139,7 @@ export function NoteEditor({
         className="note-editor__textarea"
         value={noteText}
         onChange={(e) => setNoteText(e.target.value)}
-        placeholder="Add a note..."
+        placeholder={t('reader.noteEditor.placeholder')}
         rows={4}
       />
 
@@ -144,16 +147,17 @@ export function NoteEditor({
         <button
           className="note-editor__delete"
           onClick={onDelete}
-          title="Delete highlight"
+          title={t('reader.noteEditor.deleteHighlight')}
+          aria-label={t('reader.noteEditor.deleteHighlight')}
         >
           <TrashIcon />
         </button>
         <div className="note-editor__actions">
           <button className="note-editor__cancel" onClick={onClose}>
-            Cancel
+            {t('reader.noteEditor.cancel')}
           </button>
           <button className="note-editor__save" onClick={handleSave}>
-            Save
+            {t('reader.noteEditor.save')}
           </button>
         </div>
       </div>

--- a/apps/web/src/components/reader/ReaderHighlights.tsx
+++ b/apps/web/src/components/reader/ReaderHighlights.tsx
@@ -8,6 +8,7 @@ import { useReaderVocabulary } from '../../hooks/useReaderVocabulary'
 import { useDictionary } from '../../hooks/useDictionary'
 import { useTranslation } from '../../hooks/useTranslation'
 import { updateWord } from '../../api/vocabulary'
+import { translate as translateApi } from '../../api/translation'
 import { extractSentence } from '../../lib/sentenceExtractor'
 import { createTextAnchor, findTextByAnchor } from '../../lib/textAnchor'
 import { tokenizeVocabWords, normalizeVocabKey, extractWordFromRange } from '../../lib/vocabKey'
@@ -93,6 +94,12 @@ export function ReaderHighlights({
   // selections fired by iOS tap-to-select / scroll-jitter / incidental taps.
   const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const STABILIZE_MS = 220
+  // Auto-save dedup: word keys that have an in-flight or completed save in this
+  // component instance. Prevents duplicate POST /me/vocabulary/words when two
+  // openBubble calls race (e.g. rapid re-tap before vocabMap re-renders).
+  const autoSavedRef = useRef<Set<string>>(new Set())
+  // Translation-patch dedup: one backend patch per (wordId, translation) pair.
+  const patchedTranslationRef = useRef<Set<string>>(new Set())
 
   const closeBubble = useCallback(() => {
     if (openTimerRef.current) { clearTimeout(openTimerRef.current); openTimerRef.current = null }
@@ -103,34 +110,10 @@ export function ReaderHighlights({
     clearSelection()
   }, [clearSelection])
 
-  // Popup creation, extracted so the scheduling effect has tight deps and doesn't
-  // re-fire on translation/definition arrival. Save is now EXPLICIT — only fetches
-  // translation + dictionary; `handleSave` is invoked from WordPopup on user click.
-  const openBubble = useCallback((word: string, rect: DOMRect, range: Range | null) => {
-    bubbleAbortRef.current?.abort()
-    const ctrl = new AbortController()
-    bubbleAbortRef.current = ctrl
-    setBubble({
-      word,
-      translation: null,
-      translationLoading: !!targetLang,
-      phonetic: undefined,
-      definition: null,
-      definitionLoading: true,
-      rect,
-      range,
-    })
-    fetchWordBubble({
-      word, bookLanguage, targetLang,
-      lookup: lookupWord, vocabMap, updateTranslation,
-      signal: ctrl.signal,
-      patch: (fields) => setBubble((prev) => (prev && prev.word === word ? { ...prev, ...fields } : prev)),
-    })
-  }, [bookLanguage, targetLang, vocabMap, updateTranslation, lookupWord])
-
-  // Explicit save: invoked from WordPopup when user clicks Save. Captures sentence
-  // from the range stored on the bubble at tap time (may be stale if selection was
-  // cleared, but vocab save doesn't require a live range).
+  // Auto-save: invoked from openBubble on every word tap (unless the word is
+  // already saved or a save is in-flight). Captures sentence from the live range
+  // at tap time. Translation may be null at this point — `fetchWordBubble` resolves
+  // it async, and the translation-patch effect below forwards it to the backend.
   const handleSave = useCallback(async (word: string, range: Range | null) => {
     const container = containerRef.current
     const sentence = range && container ? extractSentence(range, container) : undefined
@@ -156,13 +139,126 @@ export function ReaderHighlights({
     bubble?.word, bubble?.translation,
   ])
 
+  // Popup creation, extracted so the scheduling effect has tight deps and doesn't
+  // re-fire on translation/definition arrival. Also fires auto-save for the tapped
+  // word (fire-and-forget) so the user doesn't need an explicit Save click.
+  const openBubble = useCallback((word: string, rect: DOMRect, range: Range | null) => {
+    bubbleAbortRef.current?.abort()
+    const ctrl = new AbortController()
+    bubbleAbortRef.current = ctrl
+    setBubble({
+      word,
+      translation: null,
+      translationLoading: !!targetLang,
+      phonetic: undefined,
+      definition: null,
+      definitionLoading: true,
+      rect,
+      range,
+    })
+    fetchWordBubble({
+      word, bookLanguage, targetLang,
+      lookup: lookupWord, vocabMap, updateTranslation,
+      signal: ctrl.signal,
+      patch: (fields) => setBubble((prev) => (prev && prev.word === word ? { ...prev, ...fields } : prev)),
+    })
+
+    // Auto-save. Guards: (1) already in vocab → user-delete flow; (2) already
+    // in-flight in this session → ref seals the race that vocabMap can't (state
+    // commit is async, so a second rapid tap would still see has(key)===false).
+    const key = normalizeVocabKey(word)
+    if (!vocabMap.has(key) && !autoSavedRef.current.has(key)) {
+      autoSavedRef.current.add(key)
+      handleSave(word, range).catch(() => {
+        autoSavedRef.current.delete(key)
+      })
+    }
+  }, [bookLanguage, targetLang, vocabMap, updateTranslation, lookupWord, handleSave])
+
+  // Translation patch after auto-save. `fetchWordBubble` captures vocabMap via
+  // closure at call time — BEFORE auto-save inserts the entry — so its built-in
+  // patch (wordBubbleFetch.ts:68-74) misses. We watch bubble.translation and apply
+  // the backend patch once per (id, translation) pair. Guest entries (isPending)
+  // are skipped: flushPendingIfAny reads mapRef translation at flush time.
+  useEffect(() => {
+    const word = bubble?.word
+    const translation = bubble?.translation
+    if (!word || !translation) return
+    const entry = vocabMap.get(normalizeVocabKey(word))
+    if (!entry?.id || entry.isPending) return
+    const patchKey = `${entry.id}:${translation}`
+    if (patchedTranslationRef.current.has(patchKey)) return
+    patchedTranslationRef.current.add(patchKey)
+    updateWord(entry.id, { translation }).catch(() => {})
+    updateTranslation(word, translation)
+  }, [bubble?.word, bubble?.translation, vocabMap, updateTranslation])
+
+  // Refetch translation when targetLang changes mid-popup (user opens lang picker
+  // in the popup and switches native language). openBubble fires the initial fetch
+  // — this effect handles every subsequent lang switch for the same word.
+  // Tracks (word, lang) pair so word changes (handled by openBubble) don't double-fetch.
+  const lastFetchedPairRef = useRef<string | null>(null)
+  useEffect(() => {
+    const word = bubble?.word
+    if (!word) {
+      lastFetchedPairRef.current = null
+      return
+    }
+    const pairKey = `${word}::${targetLang ?? ''}`
+    if (lastFetchedPairRef.current === null) {
+      // Initial open: openBubble already kicked off the fetch. Just record.
+      lastFetchedPairRef.current = pairKey
+      return
+    }
+    if (lastFetchedPairRef.current === pairKey) return
+
+    const [prevWord] = lastFetchedPairRef.current.split('::')
+    lastFetchedPairRef.current = pairKey
+    // Word changed → openBubble owns the fetch. Skip.
+    if (prevWord !== word) return
+
+    // Same word, lang flipped. Switched into definition mode (no targetLang) → clear translation.
+    if (!targetLang) {
+      setBubble((prev) => prev && prev.word === word ? { ...prev, translation: null, translationLoading: false } : prev)
+      return
+    }
+
+    // Refetch translation only — definition is language-independent (always in book lang).
+    bubbleAbortRef.current?.abort()
+    const ctrl = new AbortController()
+    bubbleAbortRef.current = ctrl
+    setBubble((prev) => prev && prev.word === word ? { ...prev, translation: null, translationLoading: true } : prev)
+    translateApi(word, bookLanguage, targetLang, ctrl.signal)
+      .then((res) => {
+        if (ctrl.signal.aborted) return
+        const translatedText = res?.translatedText ?? null
+        setBubble((prev) => prev && prev.word === word ? { ...prev, translation: translatedText, translationLoading: false } : prev)
+        if (translatedText) {
+          const existing = vocabMap.get(normalizeVocabKey(word))
+          if (existing?.id && !existing.isPending) {
+            updateWord(existing.id, { translation: translatedText }).catch(() => {})
+          }
+          if (existing) updateTranslation(word, translatedText)
+        }
+      })
+      .catch((err) => {
+        if (ctrl.signal.aborted) return
+        if ((err as { name?: string })?.name === 'AbortError') return
+        setBubble((prev) => prev && prev.word === word ? { ...prev, translationLoading: false } : prev)
+      })
+  }, [bubble?.word, targetLang, bookLanguage, vocabMap, updateTranslation])
+
   // Trigger popup when selection narrows to 1 word — with a short stabilization window
   // so transient selections (iOS auto-select, scroll-tap jitter) don't flash the popup.
   useEffect(() => {
     if (!isSingleWord || !selection.rect || !selection.text) {
-      // Selection cleared or grew → cancel any pending open + drop existing popup.
+      // Cancel any pending open.
       if (openTimerRef.current) { clearTimeout(openTimerRef.current); openTimerRef.current = null }
-      if (!isSingleWord) {
+      // Drop bubble ONLY when selection grew to multi-word (toolbar takes over).
+      // Empty selection must NOT close the popup: clicking a button inside the
+      // popup natively clears the document selection — we'd kill our own popup.
+      // Click-outside-popup is handled by WordPopup's own listener.
+      if (hasSelection && !isSingleWord) {
         bubbleAbortRef.current?.abort()
         setBubble(null)
       }
@@ -191,7 +287,7 @@ export function ReaderHighlights({
     return () => {
       if (openTimerRef.current) { clearTimeout(openTimerRef.current); openTimerRef.current = null }
     }
-  }, [isSingleWord, selection.text, selection.rect, selection.range, bubble?.word, openBubble])
+  }, [isSingleWord, hasSelection, selection.text, selection.rect, selection.range, bubble?.word, openBubble])
 
   // Clean abort + pending open timer on unmount
   useEffect(() => () => {
@@ -350,8 +446,12 @@ export function ReaderHighlights({
         />
       )}
 
-      {/* Single-word selection → WordPopup (phonetic, translation, definition, Save/Remove) */}
-      {bubble && isSingleWord && !showTranslation && (() => {
+      {/* Single-word selection → WordPopup (phonetic, translation, definition, Remove). Save is automatic. */}
+      {/* NOT gated on isSingleWord: clicking buttons inside the popup natively
+          clears the document selection — keeping the popup mounted lets the user
+          interact with it (lang picker, etc). Close paths: WordPopup's own
+          click-outside / Escape / × / auto-dismiss, or selection growing to multi-word. */}
+      {bubble && !showTranslation && (() => {
         const entry = vocabMap.get(normalizeVocabKey(bubble.word))
         const isSaved = !!entry
         return (
@@ -365,8 +465,12 @@ export function ReaderHighlights({
             rect={bubble.rect}
             containerRef={containerRef}
             onSpeak={() => handleSpeak(bubble.word)}
-            onSave={!isSaved ? () => handleSave(bubble.word, bubble.range) : undefined}
-            onRemove={entry?.id ? () => { removeWord(entry.id!, bubble.word); closeBubble() } : undefined}
+            onRemove={entry?.id ? () => {
+              removeWord(entry.id!, bubble.word)
+              // Clear dedup so a subsequent tap on the same word re-auto-saves.
+              autoSavedRef.current.delete(normalizeVocabKey(bubble.word))
+              closeBubble()
+            } : undefined}
             onClose={closeBubble}
             isSaved={isSaved}
             nativeLanguage={nativeLanguage}

--- a/apps/web/src/components/reader/SelectionToolbar.tsx
+++ b/apps/web/src/components/reader/SelectionToolbar.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useRef, useState } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 import type { HighlightColor } from '../../lib/offlineDb'
+import { useTranslation } from '../../hooks/useTranslation'
 
-const HIGHLIGHT_COLORS: { color: HighlightColor; label: string; hex: string }[] = [
-  { color: 'yellow', label: 'Yellow', hex: '#fef08a' },
-  { color: 'green', label: 'Green', hex: '#bbf7d0' },
-  { color: 'pink', label: 'Pink', hex: '#fbcfe8' },
-  { color: 'blue', label: 'Blue', hex: '#bfdbfe' },
+const HIGHLIGHT_COLORS: { color: HighlightColor; labelKey: string; hex: string }[] = [
+  { color: 'yellow', labelKey: 'reader.selectionToolbar.highlightYellow', hex: '#fef08a' },
+  { color: 'green', labelKey: 'reader.selectionToolbar.highlightGreen', hex: '#bbf7d0' },
+  { color: 'pink', labelKey: 'reader.selectionToolbar.highlightPink', hex: '#fbcfe8' },
+  { color: 'blue', labelKey: 'reader.selectionToolbar.highlightBlue', hex: '#bfdbfe' },
 ]
 
 interface SelectionToolbarProps {
@@ -27,10 +28,14 @@ export function SelectionToolbar({
   onSpeak,
   onCopy,
 }: SelectionToolbarProps) {
+  const { t } = useTranslation()
   const toolbarRef = useRef<HTMLDivElement>(null)
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null)
 
-  useEffect(() => {
+  // useLayoutEffect: reposition before paint, no flash when toolbar mounts or
+  // when re-measuring after the toolbar DOM first renders (it needs its own
+  // rect to compute position).
+  useLayoutEffect(() => {
     if (!rect || !containerRef.current || !toolbarRef.current) {
       setPosition(null)
       return
@@ -82,18 +87,21 @@ export function SelectionToolbar({
       }}
     >
       <div className="selection-toolbar__colors">
-        {HIGHLIGHT_COLORS.map(({ color, label, hex }) => (
-          <button
-            key={color}
-            className="selection-toolbar__color"
-            style={{ background: hex }}
-            onMouseDown={(e) => e.preventDefault()}
-            onTouchStart={(e) => e.preventDefault()}
-            onClick={() => onHighlight(color)}
-            title={`Highlight ${label}`}
-            aria-label={`Highlight ${label}`}
-          />
-        ))}
+        {HIGHLIGHT_COLORS.map(({ color, labelKey, hex }) => {
+          const label = t(labelKey)
+          return (
+            <button
+              key={color}
+              className="selection-toolbar__color"
+              style={{ background: hex }}
+              onMouseDown={(e) => e.preventDefault()}
+              onTouchStart={(e) => e.preventDefault()}
+              onClick={() => onHighlight(color)}
+              title={label}
+              aria-label={label}
+            />
+          )
+        })}
       </div>
       <div className="selection-toolbar__divider" />
       {onTranslate && (
@@ -102,8 +110,8 @@ export function SelectionToolbar({
           onMouseDown={(e) => e.preventDefault()}
           onTouchStart={(e) => e.preventDefault()}
           onClick={onTranslate}
-          title="Translate"
-          aria-label="Translate selected text"
+          title={t('reader.selectionToolbar.translate')}
+          aria-label={t('reader.selectionToolbar.translate')}
         >
           <TranslateIcon />
         </button>
@@ -114,8 +122,8 @@ export function SelectionToolbar({
           onMouseDown={(e) => e.preventDefault()}
           onTouchStart={(e) => e.preventDefault()}
           onClick={onSpeak}
-          title="Listen"
-          aria-label="Listen to pronunciation"
+          title={t('reader.selectionToolbar.listen')}
+          aria-label={t('reader.selectionToolbar.listen')}
         >
           <SpeakIcon />
         </button>
@@ -125,8 +133,8 @@ export function SelectionToolbar({
         onMouseDown={(e) => e.preventDefault()}
         onTouchStart={(e) => e.preventDefault()}
         onClick={handleCopy}
-        title="Copy"
-        aria-label="Copy selected text"
+        title={t('reader.selectionToolbar.copy')}
+        aria-label={t('reader.selectionToolbar.copy')}
       >
         <CopyIcon />
       </button>

--- a/apps/web/src/components/reader/TranslationPopup.tsx
+++ b/apps/web/src/components/reader/TranslationPopup.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type { LanguageInfo } from '../../api/translation'
 import { SpeakButton } from '../vocabulary/SpeakButton'
+import { useTranslation } from '../../hooks/useTranslation'
 
 interface TranslationPopupProps {
   text: string
@@ -33,10 +34,12 @@ export function TranslationPopup({
   onSpeak,
   onClose,
 }: TranslationPopupProps) {
+  const { t } = useTranslation()
   const popupRef = useRef<HTMLDivElement>(null)
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null)
 
-  useEffect(() => {
+  // useLayoutEffect: reposition before paint, no flash when translation arrives.
+  useLayoutEffect(() => {
     if (!rect || !containerRef.current || !popupRef.current) {
       setPosition(null)
       return
@@ -134,7 +137,7 @@ export function TranslationPopup({
         <button
           className="translation-popup__close"
           onClick={onClose}
-          aria-label="Close"
+          aria-label={t('reader.wordPopup.close')}
         >
           ×
         </button>

--- a/apps/web/src/components/reader/WordPopup.tsx
+++ b/apps/web/src/components/reader/WordPopup.tsx
@@ -1,10 +1,30 @@
-import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { SpeakButton } from '../vocabulary/SpeakButton'
 import { getFlagUrl } from '../../context/NativeLanguageContext'
 import { LANGUAGES, POPULAR_LANGUAGES, OTHER_LANGUAGES, getLanguage } from '../../data/languages'
 
-const AUTO_DISMISS_MS = 3000
+const AUTO_DISMISS_MS_MIN = 3000
+const AUTO_DISMISS_MS_MAX = 8000
+const AUTO_DISMISS_MS_PER_WORD = 350  // L2-reader pace, ~170 wpm
 const EXIT_DURATION_MS = 150
+
+// CJK (Hiragana, Katakana, CJK Unified, Hangul) — spaceless scripts where each
+// glyph carries ~word-level info. Counted as individual reading units so
+// Chinese/Japanese/Korean translations aren't flattened to 1 word.
+const CJK_RE = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF\uAC00-\uD7AF]/g
+
+// Scale dismiss timer to content length so a 16-word definition gets more
+// read-time than a 1-word translation. Min 3s (short content), max 8s (don't
+// keep popup open forever — user can always tap to extend).
+function computeDismissMs(translation: string | null, definition: string | null): number {
+  const text = `${translation ?? ''} ${definition ?? ''}`.trim()
+  if (!text) return AUTO_DISMISS_MS_MIN
+  const cjkChars = (text.match(CJK_RE) || []).length
+  const nonCjk = text.replace(CJK_RE, ' ')
+  const words = nonCjk.split(/\s+/).filter(Boolean).length
+  const units = words + cjkChars
+  return Math.min(AUTO_DISMISS_MS_MAX, Math.max(AUTO_DISMISS_MS_MIN, units * AUTO_DISMISS_MS_PER_WORD))
+}
 
 interface WordPopupProps {
   word: string
@@ -16,7 +36,6 @@ interface WordPopupProps {
   rect: DOMRect | null
   containerRef: React.RefObject<HTMLElement | null>
   onSpeak: () => void
-  onSave?: () => void | Promise<void>
   onRemove?: () => void
   onClose: () => void
   isSaved: boolean
@@ -36,7 +55,6 @@ export function WordPopup({
   rect,
   containerRef,
   onSpeak,
-  onSave,
   onRemove,
   onClose,
   isSaved,
@@ -51,7 +69,6 @@ export function WordPopup({
   const [showLangPicker, setShowLangPicker] = useState(false)
   const [langQuery, setLangQuery] = useState('')
   const [closing, setClosing] = useState(false)
-  const [isSaving, setIsSaving] = useState(false)
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout>>()
   const exitTimerRef = useRef<ReturnType<typeof setTimeout>>()
 
@@ -75,18 +92,15 @@ export function WordPopup({
     exitTimerRef.current = setTimeout(onClose, EXIT_DURATION_MS)
   }, [onClose, closing])
 
-  // Reset closing state on new word. Also cancel any pending exit timer from a previous
-  // close — otherwise it fires 150ms later on the NEW popup and unmounts it (re-tap glitch).
+  // Reset closing state on new word OR new rect (same word re-tapped elsewhere).
+  // Cancel any pending exit timer from a previous close — otherwise it fires 150ms
+  // later on the NEW popup and unmounts it (re-tap glitch). Keying on rect too
+  // catches same-word re-taps during the 150ms close animation.
   useEffect(() => {
     clearTimeout(exitTimerRef.current)
     setClosing(false)
-    setIsSaving(false)
-  }, [word])
+  }, [word, rect])
 
-  // Flip isSaving off when parent confirms save (isSaved becomes true).
-  useEffect(() => {
-    if (isSaved) setIsSaving(false)
-  }, [isSaved])
   useEffect(() => () => {
     clearTimeout(exitTimerRef.current)
     clearTimeout(dismissTimerRef.current)
@@ -98,29 +112,54 @@ export function WordPopup({
 
   const scheduleAutoDismiss = useCallback(() => {
     clearTimeout(dismissTimerRef.current)
-    dismissTimerRef.current = setTimeout(animatedClose, AUTO_DISMISS_MS)
-  }, [animatedClose])
+    const ms = computeDismissMs(translation, definition)
+    dismissTimerRef.current = setTimeout(animatedClose, ms)
+  }, [animatedClose, translation, definition])
 
-  // Start auto-dismiss timer on open / word change
+  // Start auto-dismiss timer on open / word change / same-word re-tap at new rect.
+  // Keying on rect ensures re-tapping the same word restarts the timer — otherwise
+  // the old timer (maybe about to fire) closes the popup right after the user re-engages.
   useEffect(() => {
     scheduleAutoDismiss()
     return () => clearTimeout(dismissTimerRef.current)
-  }, [word]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [word, rect]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Cancel auto-dismiss when lang picker is open + autofocus search
+  // Cancel auto-dismiss when lang picker is open + autofocus search.
+  // On close: clear query AND resume auto-dismiss — otherwise toggling the
+  // "Change" button to close the picker leaves the popup stuck open forever.
+  const didMountRef = useRef(false)
   useEffect(() => {
     if (showLangPicker) {
       cancelAutoDismiss()
       setTimeout(() => searchInputRef.current?.focus(), 0)
     } else {
       setLangQuery('')
+      if (didMountRef.current) scheduleAutoDismiss()
     }
-  }, [showLangPicker, cancelAutoDismiss])
+    didMountRef.current = true
+  }, [showLangPicker, cancelAutoDismiss, scheduleAutoDismiss])
+
+  // Restart auto-dismiss when translation finishes loading. Without this, the
+  // 3s timer scheduled at popup-open / lang-pick can fire BEFORE a slow
+  // translation arrives — user sees the popup vanish just as the result lands.
+  // Reset gives them a fresh 3s window from the moment the translation appears.
+  // Also covers definition: if dictionary lookup is the slow one, same logic applies.
+  const wasLoadingRef = useRef(false)
+  useEffect(() => {
+    const loading = translationLoading || definitionLoading
+    if (wasLoadingRef.current && !loading) {
+      scheduleAutoDismiss()
+    }
+    wasLoadingRef.current = loading
+  }, [translationLoading, definitionLoading, scheduleAutoDismiss])
 
   // Position popup relative to word rect.
+  // useLayoutEffect (not useEffect) so repositioning happens synchronously
+  // before paint — otherwise content changes (translation arriving, lang picker
+  // opening) cause a visible flash at the old position with new dimensions.
   // Skip while closing — re-positioning a fading popup causes visual jitter, especially
   // when async data (translation/definition) arrives mid-exit.
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (closing) return
     if (!rect || !containerRef.current || !popupRef.current) {
       setPosition(null)
@@ -161,14 +200,21 @@ export function WordPopup({
     return () => document.removeEventListener('mousedown', handleMouseDown)
   }, [animatedClose])
 
-  // Close on Escape
+  // Close on Escape — but if lang picker is open, close that first. Native
+  // listeners run regardless of React's preventDefault on synthetic events,
+  // so the picker's input handler alone can't stop the popup from closing.
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') animatedClose()
+      if (e.key !== 'Escape') return
+      if (showLangPicker) {
+        setShowLangPicker(false)
+      } else {
+        animatedClose()
+      }
     }
     document.addEventListener('keydown', handleKey)
     return () => document.removeEventListener('keydown', handleKey)
-  }, [animatedClose])
+  }, [animatedClose, showLangPicker])
 
   if (!rect) return null
 
@@ -200,20 +246,23 @@ export function WordPopup({
           className="word-popup__close"
           onClick={animatedClose}
           onMouseDown={(e) => e.preventDefault()}
-          aria-label="Close"
+          aria-label={t('reader.wordPopup.close')}
         >
           ×
         </button>
       </div>
 
-      {/* Translation - primary content */}
-      <div className="word-popup__translation">
-        {translationLoading ? (
-          <span className="word-popup__loading">{t('reader.wordPopup.loading')}</span>
-        ) : translation ? (
-          translation
-        ) : null}
-      </div>
+      {/* Translation - primary content. Skip entirely in same-language mode
+         (translation null + not loading) to avoid empty div with CSS padding. */}
+      {(translationLoading || translation) && (
+        <div className="word-popup__translation">
+          {translationLoading ? (
+            <span className="word-popup__loading">{t('reader.wordPopup.loading')}</span>
+          ) : (
+            translation
+          )}
+        </div>
+      )}
 
       {/* Definition - secondary, async */}
       {(definitionLoading || definition) && (
@@ -228,43 +277,16 @@ export function WordPopup({
 
       <div className="word-popup__actions">
         <SpeakButton onClick={onSpeak} size={16} />
-        {isSaved ? (
-          onRemove && (
-            <button
-              className="word-popup__btn word-popup__btn--remove"
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={onRemove}
-              aria-label={t('reader.wordPopup.remove')}
-            >
-              <span className="material-icons-outlined word-popup__btn-icon">delete_outline</span>
-              {t('reader.wordPopup.remove')}
-            </button>
-          )
-        ) : (
-          onSave && (
-            <button
-              className="word-popup__btn word-popup__btn--save"
-              onMouseDown={(e) => e.preventDefault()}
-              disabled={isSaving}
-              onClick={async () => {
-                if (isSaving) return
-                setIsSaving(true)
-                try {
-                  await onSave()
-                  // Smooth dismiss shortly after success — user sees Save→Remove swap briefly.
-                  clearTimeout(dismissTimerRef.current)
-                  dismissTimerRef.current = setTimeout(animatedClose, 700)
-                } catch {
-                  // Reset on failure so user can retry; otherwise stuck "Saving..."
-                  setIsSaving(false)
-                }
-              }}
-              aria-label={t('reader.wordPopup.save')}
-            >
-              <span className="material-icons-outlined word-popup__btn-icon">add</span>
-              {isSaving ? t('reader.wordPopup.saving') : t('reader.wordPopup.save')}
-            </button>
-          )
+        {isSaved && onRemove && (
+          <button
+            className="word-popup__btn word-popup__btn--remove"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={onRemove}
+            aria-label={t('reader.wordPopup.remove')}
+          >
+            <span className="material-icons-outlined word-popup__btn-icon" aria-hidden="true">delete_outline</span>
+            {t('reader.wordPopup.remove')}
+          </button>
         )}
       </div>
 
@@ -310,8 +332,11 @@ export function WordPopup({
                   scheduleAutoDismiss()
                 } else if (e.key === 'Enter') {
                   e.preventDefault()
-                  const list = filteredLangs ?? LANGUAGES.filter(l => l.code !== nativeLanguage)
-                  const first = list[0]
+                  // Only select on Enter when the user typed a query — otherwise a
+                  // bare Enter picks an arbitrary first language and silently
+                  // changes the user's native language.
+                  if (!filteredLangs) return
+                  const first = filteredLangs[0]
                   if (first) {
                     onChangeNativeLanguage(first.code)
                     setShowLangPicker(false)
@@ -326,7 +351,7 @@ export function WordPopup({
             <div className="word-popup__lang-list">
               {filteredLangs ? (
                 filteredLangs.length === 0 ? (
-                  <div className="word-popup__lang-empty">No results</div>
+                  <div className="word-popup__lang-empty">{t('reader.wordPopup.noResults') || 'No results'}</div>
                 ) : (
                   filteredLangs.map((l) => (
                     <button
@@ -349,7 +374,7 @@ export function WordPopup({
                 )
               ) : (
                 <>
-                  <div className="word-popup__lang-section">Popular</div>
+                  <div className="word-popup__lang-section">{t('reader.wordPopup.popularLanguages')}</div>
                   {POPULAR_LANGUAGES.filter(l => l.code !== nativeLanguage).map((l) => (
                     <button
                       key={l.code}
@@ -368,7 +393,7 @@ export function WordPopup({
                       )}
                     </button>
                   ))}
-                  <div className="word-popup__lang-section">All languages</div>
+                  <div className="word-popup__lang-section">{t('reader.wordPopup.allLanguages')}</div>
                   {OTHER_LANGUAGES.filter(l => l.code !== nativeLanguage).map((l) => (
                     <button
                       key={l.code}

--- a/apps/web/src/hooks/useTranslation.ts
+++ b/apps/web/src/hooks/useTranslation.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { useLanguage, SupportedLanguage } from '../context/LanguageContext'
 import en from '../locales/en.json'
 import uk from '../locales/uk.json'
@@ -22,23 +23,25 @@ function getNestedValue(obj: unknown, path: string): unknown {
 export function useTranslation() {
   const { language } = useLanguage()
 
-  function t(key: string): string {
+  // useCallback bound to [language] so t/tArray identities are stable across
+  // renders and only change when the language actually changes. Without this,
+  // every render returns new fn identities and any consumer using them in
+  // useEffect/useCallback deps re-fires on every parent re-render.
+  const t = useCallback((key: string): string => {
     const value = getNestedValue(translations[language], key)
     if (typeof value === 'string') return value
-    // fallback to EN
     const fallback = getNestedValue(translations.en, key)
     if (typeof fallback === 'string') return fallback
     return key
-  }
+  }, [language])
 
-  function tArray(key: string): string[] {
+  const tArray = useCallback((key: string): string[] => {
     const value = getNestedValue(translations[language], key)
     if (Array.isArray(value)) return value as string[]
-    // fallback to EN
     const fallback = getNestedValue(translations.en, key)
     if (Array.isArray(fallback)) return fallback as string[]
     return []
-  }
+  }, [language])
 
   return { t, tArray, language }
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -93,7 +93,27 @@
       "change": "Change",
       "definitionMode": "Definition",
       "translateTo": "Translate to...",
-      "searchLanguage": "Search language..."
+      "searchLanguage": "Search language...",
+      "noResults": "No results",
+      "popularLanguages": "Popular",
+      "allLanguages": "All languages",
+      "close": "Close"
+    },
+    "selectionToolbar": {
+      "highlightYellow": "Highlight yellow",
+      "highlightGreen": "Highlight green",
+      "highlightPink": "Highlight pink",
+      "highlightBlue": "Highlight blue",
+      "translate": "Translate selected text",
+      "listen": "Listen to pronunciation",
+      "copy": "Copy selected text"
+    },
+    "noteEditor": {
+      "close": "Close",
+      "placeholder": "Add a note...",
+      "deleteHighlight": "Delete highlight",
+      "cancel": "Cancel",
+      "save": "Save"
     }
   },
   "onboarding": {

--- a/apps/web/src/locales/uk.json
+++ b/apps/web/src/locales/uk.json
@@ -93,7 +93,27 @@
       "change": "Змінити",
       "definitionMode": "Визначення",
       "translateTo": "Перекласти на...",
-      "searchLanguage": "Пошук мови..."
+      "searchLanguage": "Пошук мови...",
+      "noResults": "Нічого не знайдено",
+      "popularLanguages": "Популярні",
+      "allLanguages": "Усі мови",
+      "close": "Закрити"
+    },
+    "selectionToolbar": {
+      "highlightYellow": "Виділити жовтим",
+      "highlightGreen": "Виділити зеленим",
+      "highlightPink": "Виділити рожевим",
+      "highlightBlue": "Виділити синім",
+      "translate": "Перекласти виділений текст",
+      "listen": "Прослухати вимову",
+      "copy": "Копіювати виділений текст"
+    },
+    "noteEditor": {
+      "close": "Закрити",
+      "placeholder": "Додати нотатку...",
+      "deleteHighlight": "Видалити виділення",
+      "cancel": "Скасувати",
+      "save": "Зберегти"
     }
   },
   "onboarding": {

--- a/apps/web/src/pages/FocusReaderPage.tsx
+++ b/apps/web/src/pages/FocusReaderPage.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from '../hooks/useTranslation'
 import { splitSentences, tokenizeWords } from '@textstack/shared'
 import { getUserBookChapter, getUserBook } from '../api/userBooks'
 import { updateWord as updateWordApi } from '../api/vocabulary'
+import { translate as translateApi } from '../api/translation'
 import { normalizeVocabKey, vocabStageClass } from '../lib/vocabKey'
 import { fetchWordBubble } from '../lib/wordBubbleFetch'
 import { WordPopup } from '../components/reader/WordPopup'
@@ -68,6 +69,10 @@ export function FocusReaderPage({ mode = 'public' }: Props) {
   const bubbleAbortRef = useRef<AbortController | null>(null)
   const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pressOriginRef = useRef<{ x: number; y: number } | null>(null)
+  // Auto-save dedup: word keys with an in-flight or completed auto-save in this session.
+  const autoSavedRef = useRef<Set<string>>(new Set())
+  // Translation-patch dedup: one backend patch per (wordId, translation) pair.
+  const patchedTranslationRef = useRef<Set<string>>(new Set())
 
   const targetLang = bookLanguage !== nativeLanguage ? nativeLanguage : null
 
@@ -228,8 +233,30 @@ export function FocusReaderPage({ mode = 'public' }: Props) {
     return () => window.removeEventListener('keydown', onKey)
   }, [next, prev, exit])
 
-  // Long-press a word → open full WordPopup (translation + definition + TTS + vocab save).
-  // Toggle-off: long-pressing the same word that's already open closes the popup.
+  // Auto-save handler — fired from openWordBubble on every long-press (once per word).
+  // Translation may be null at call time; translation-patch effect below forwards it
+  // to the backend once fetchWordBubble resolves.
+  const handleSaveWord = useCallback(async (word: string) => {
+    const currentTranslation = bubble?.word === word ? bubble?.translation : null
+    const saved = await addWord({
+      word,
+      language: bookLanguage,
+      editionId: mode === 'public' ? (editionId || undefined) : undefined,
+      chapterId: mode === 'public' ? (chapterId || undefined) : undefined,
+      userBookId: mode === 'userbook' ? (id || undefined) : undefined,
+      bookTitle: bookTitle || undefined,
+      nativeLanguage: targetLang || undefined,
+      translation: currentTranslation || null,
+    }).catch(() => null)
+    if (saved?.id && currentTranslation) {
+      updateWordApi(saved.id, { translation: currentTranslation }).catch(() => {})
+      updateTranslation(word, currentTranslation)
+    }
+  }, [addWord, bookLanguage, mode, editionId, chapterId, id, bookTitle, targetLang, updateTranslation, bubble?.word, bubble?.translation])
+
+  // Long-press a word → open full WordPopup (translation + definition + TTS).
+  // Also auto-saves the word to vocab (fire-and-forget). Long-pressing the same
+  // open word closes the popup (toggle-off).
   const openWordBubble = useCallback(
     (wordEl: HTMLElement, word: string) => {
       // Toggle off if same word is currently shown
@@ -258,28 +285,87 @@ export function FocusReaderPage({ mode = 'public' }: Props) {
         signal: ctrl.signal,
         patch: (fields) => setBubble((prev) => (prev && prev.word === word ? { ...prev, ...fields } : prev)),
       })
+
+      // Auto-save. Dedup via ref (synchronous) since vocabMap.has() reads stale
+      // state until re-render — rapid re-presses would otherwise double-save.
+      const key = normalizeVocabKey(word)
+      if (!vocabMap.has(key) && !autoSavedRef.current.has(key)) {
+        autoSavedRef.current.add(key)
+        handleSaveWord(word).catch(() => {
+          autoSavedRef.current.delete(key)
+        })
+      }
     },
-    [bubble?.word, closeBubble, bookLanguage, targetLang, lookupWord, vocabMap, updateTranslation],
+    [bubble?.word, closeBubble, bookLanguage, targetLang, lookupWord, vocabMap, updateTranslation, handleSaveWord],
   )
 
-  // Explicit save handler — called from WordPopup on Save click.
-  const handleSaveWord = useCallback(async (word: string) => {
-    const currentTranslation = bubble?.word === word ? bubble?.translation : null
-    const saved = await addWord({
-      word,
-      language: bookLanguage,
-      editionId: mode === 'public' ? (editionId || undefined) : undefined,
-      chapterId: mode === 'public' ? (chapterId || undefined) : undefined,
-      userBookId: mode === 'userbook' ? (id || undefined) : undefined,
-      bookTitle: bookTitle || undefined,
-      nativeLanguage: targetLang || undefined,
-      translation: currentTranslation || null,
-    }).catch(() => null)
-    if (saved?.id && currentTranslation) {
-      updateWordApi(saved.id, { translation: currentTranslation }).catch(() => {})
-      updateTranslation(word, currentTranslation)
+  // Translation patch after auto-save. fetchWordBubble's built-in patch
+  // (wordBubbleFetch.ts:68-74) captures vocabMap at call time — before auto-save
+  // inserts the entry — so it misses. Apply a dedicated patch once per (id, translation).
+  useEffect(() => {
+    const word = bubble?.word
+    const translation = bubble?.translation
+    if (!word || !translation) return
+    const entry = vocabMap.get(normalizeVocabKey(word))
+    if (!entry?.id || entry.isPending) return
+    const patchKey = `${entry.id}:${translation}`
+    if (patchedTranslationRef.current.has(patchKey)) return
+    patchedTranslationRef.current.add(patchKey)
+    updateWordApi(entry.id, { translation }).catch(() => {})
+    updateTranslation(word, translation)
+  }, [bubble?.word, bubble?.translation, vocabMap, updateTranslation])
+
+  // Refetch translation when targetLang changes mid-popup (user picks a new
+  // native language in the popup's lang picker). openWordBubble owns the initial
+  // fetch — this effect handles every subsequent lang switch for the same word.
+  // Tracks (word, lang) pair so word changes (handled by openWordBubble) don't double-fetch.
+  const lastFetchedPairRef = useRef<string | null>(null)
+  useEffect(() => {
+    const word = bubble?.word
+    if (!word) {
+      lastFetchedPairRef.current = null
+      return
     }
-  }, [addWord, bookLanguage, mode, editionId, chapterId, id, bookTitle, targetLang, updateTranslation, bubble?.word, bubble?.translation])
+    const pairKey = `${word}::${targetLang ?? ''}`
+    if (lastFetchedPairRef.current === null) {
+      lastFetchedPairRef.current = pairKey
+      return
+    }
+    if (lastFetchedPairRef.current === pairKey) return
+
+    const [prevWord] = lastFetchedPairRef.current.split('::')
+    lastFetchedPairRef.current = pairKey
+    if (prevWord !== word) return  // word changed → openWordBubble owns the fetch
+
+    if (!targetLang) {
+      // Switched into definition mode — clear translation field.
+      setBubble((prev) => prev && prev.word === word ? { ...prev, translation: null, translationLoading: false } : prev)
+      return
+    }
+
+    bubbleAbortRef.current?.abort()
+    const ctrl = new AbortController()
+    bubbleAbortRef.current = ctrl
+    setBubble((prev) => prev && prev.word === word ? { ...prev, translation: null, translationLoading: true } : prev)
+    translateApi(word, bookLanguage, targetLang, ctrl.signal)
+      .then((res) => {
+        if (ctrl.signal.aborted) return
+        const translatedText = res?.translatedText ?? null
+        setBubble((prev) => prev && prev.word === word ? { ...prev, translation: translatedText, translationLoading: false } : prev)
+        if (translatedText) {
+          const existing = vocabMap.get(normalizeVocabKey(word))
+          if (existing?.id && !existing.isPending) {
+            updateWordApi(existing.id, { translation: translatedText }).catch(() => {})
+          }
+          if (existing) updateTranslation(word, translatedText)
+        }
+      })
+      .catch((err) => {
+        if (ctrl.signal.aborted) return
+        if ((err as { name?: string })?.name === 'AbortError') return
+        setBubble((prev) => prev && prev.word === word ? { ...prev, translationLoading: false } : prev)
+      })
+  }, [bubble?.word, targetLang, bookLanguage, vocabMap, updateTranslation])
 
   // Abort in-flight + pending press on unmount
   useEffect(() => () => {
@@ -435,8 +521,11 @@ export function FocusReaderPage({ mode = 'public' }: Props) {
           rect={bubble.rect}
           containerRef={sentenceRef}
           onSpeak={() => handleSpeak(bubble.word)}
-          onSave={!vocabEntry ? () => handleSaveWord(bubble.word) : undefined}
-          onRemove={vocabEntry?.id ? () => { removeWord(vocabEntry.id!, bubble.word); closeBubble() } : undefined}
+          onRemove={vocabEntry?.id ? () => {
+            removeWord(vocabEntry.id!, bubble.word)
+            autoSavedRef.current.delete(normalizeVocabKey(bubble.word))
+            closeBubble()
+          } : undefined}
           onClose={closeBubble}
           isSaved={!!vocabEntry}
           nativeLanguage={nativeLanguage}


### PR DESCRIPTION
## Summary

- **Auto-save on word tap**: removes the Save button. Delete remains for recovery. Applies to both readers (scroll `ReaderHighlights` + paginated `FocusReaderPage`).
- **Race-safe**: `autoSavedRef` Set dedups in-flight saves before vocabMap re-renders. Failure rolls the entry back so next tap retries.
- **Translation patch effect**: `fetchWordBubble`'s built-in patch captures vocabMap pre-save → misses. Dedicated effect patches backend once per `(wordId, translation)`.
- **WordPopup polish**: CJK-aware dismiss timer, restarts when translation arrives, lang picker now refetches translation in place, `useLayoutEffect` for positioning (no flash).
- **i18n cleanup**: hardcoded strings in NoteEditor/SelectionToolbar/TranslationPopup moved to locales.
- **`useTranslation`**: `t`/`tArray` wrapped in `useCallback` so consumers' deps don't fire every render.
- **Selection-clear no longer closes popup**: clicking popup buttons natively clears document selection — keeping mounted lets the user interact with the lang picker, etc.

## Test plan

- [ ] Tap a word in the reader → popup opens → word silently saved → Delete button appears
- [ ] Translation/definition still arrive async; popup doesn't autoclose mid-fetch
- [ ] Tap the same word twice in 100ms → only one POST `/me/vocabulary/words`
- [ ] Tap Delete → word removed from vocab; tap same word again → re-saves
- [ ] Guest flow (incognito): tap 3+ words → threshold triggers `/auth/guest` + batch `POST /me/vocabulary/words`
- [ ] Open lang picker in popup, switch language → translation refetches without reopening
- [ ] Long popup content (16-word definition) gets longer dismiss window than short translation

🤖 Generated with [Claude Code](https://claude.com/claude-code)