### PR TITLE
refactor(reader): harden WordPopup + extract useBubbleTranslationSync

### DIFF
--- a/apps/web/src/components/reader/ReaderHighlights.tsx
+++ b/apps/web/src/components/reader/ReaderHighlights.tsx
@@ -7,8 +7,8 @@ import { useTts } from '../../hooks/useTts'
 import { useReaderVocabulary } from '../../hooks/useReaderVocabulary'
 import { useDictionary } from '../../hooks/useDictionary'
 import { useTranslation } from '../../hooks/useTranslation'
+import { useBubbleTranslationSync } from '../../hooks/useBubbleTranslationSync'
 import { updateWord } from '../../api/vocabulary'
-import { translate as translateApi } from '../../api/translation'
 import { extractSentence } from '../../lib/sentenceExtractor'
 import { createTextAnchor, findTextByAnchor } from '../../lib/textAnchor'
 import { tokenizeVocabWords, normalizeVocabKey, extractWordFromRange } from '../../lib/vocabKey'
@@ -94,12 +94,18 @@ export function ReaderHighlights({
   // selections fired by iOS tap-to-select / scroll-jitter / incidental taps.
   const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const STABILIZE_MS = 220
-  // Auto-save dedup: word keys that have an in-flight or completed save in this
-  // component instance. Prevents duplicate POST /me/vocabulary/words when two
-  // openBubble calls race (e.g. rapid re-tap before vocabMap re-renders).
-  const autoSavedRef = useRef<Set<string>>(new Set())
-  // Translation-patch dedup: one backend patch per (wordId, translation) pair.
-  const patchedTranslationRef = useRef<Set<string>>(new Set())
+
+  // Backend translation patch + mid-popup lang-switch refetch + auto-save dedup.
+  // Extracted hook — same shape is used in FocusReaderPage.
+  const { triggerAutoSave, clearAutoSave } = useBubbleTranslationSync({
+    bubble,
+    setBubble,
+    vocabMap,
+    updateTranslation,
+    targetLang,
+    bookLanguage,
+    abortRef: bubbleAbortRef,
+  })
 
   const closeBubble = useCallback(() => {
     if (openTimerRef.current) { clearTimeout(openTimerRef.current); openTimerRef.current = null }
@@ -163,90 +169,10 @@ export function ReaderHighlights({
       patch: (fields) => setBubble((prev) => (prev && prev.word === word ? { ...prev, ...fields } : prev)),
     })
 
-    // Auto-save. Guards: (1) already in vocab → user-delete flow; (2) already
-    // in-flight in this session → ref seals the race that vocabMap can't (state
-    // commit is async, so a second rapid tap would still see has(key)===false).
-    const key = normalizeVocabKey(word)
-    if (!vocabMap.has(key) && !autoSavedRef.current.has(key)) {
-      autoSavedRef.current.add(key)
-      handleSave(word, range).catch(() => {
-        autoSavedRef.current.delete(key)
-      })
-    }
-  }, [bookLanguage, targetLang, vocabMap, updateTranslation, lookupWord, handleSave])
-
-  // Translation patch after auto-save. `fetchWordBubble` captures vocabMap via
-  // closure at call time — BEFORE auto-save inserts the entry — so its built-in
-  // patch (wordBubbleFetch.ts:68-74) misses. We watch bubble.translation and apply
-  // the backend patch once per (id, translation) pair. Guest entries (isPending)
-  // are skipped: flushPendingIfAny reads mapRef translation at flush time.
-  useEffect(() => {
-    const word = bubble?.word
-    const translation = bubble?.translation
-    if (!word || !translation) return
-    const entry = vocabMap.get(normalizeVocabKey(word))
-    if (!entry?.id || entry.isPending) return
-    const patchKey = `${entry.id}:${translation}`
-    if (patchedTranslationRef.current.has(patchKey)) return
-    patchedTranslationRef.current.add(patchKey)
-    updateWord(entry.id, { translation }).catch(() => {})
-    updateTranslation(word, translation)
-  }, [bubble?.word, bubble?.translation, vocabMap, updateTranslation])
-
-  // Refetch translation when targetLang changes mid-popup (user opens lang picker
-  // in the popup and switches native language). openBubble fires the initial fetch
-  // — this effect handles every subsequent lang switch for the same word.
-  // Tracks (word, lang) pair so word changes (handled by openBubble) don't double-fetch.
-  const lastFetchedPairRef = useRef<string | null>(null)
-  useEffect(() => {
-    const word = bubble?.word
-    if (!word) {
-      lastFetchedPairRef.current = null
-      return
-    }
-    const pairKey = `${word}::${targetLang ?? ''}`
-    if (lastFetchedPairRef.current === null) {
-      // Initial open: openBubble already kicked off the fetch. Just record.
-      lastFetchedPairRef.current = pairKey
-      return
-    }
-    if (lastFetchedPairRef.current === pairKey) return
-
-    const [prevWord] = lastFetchedPairRef.current.split('::')
-    lastFetchedPairRef.current = pairKey
-    // Word changed → openBubble owns the fetch. Skip.
-    if (prevWord !== word) return
-
-    // Same word, lang flipped. Switched into definition mode (no targetLang) → clear translation.
-    if (!targetLang) {
-      setBubble((prev) => prev && prev.word === word ? { ...prev, translation: null, translationLoading: false } : prev)
-      return
-    }
-
-    // Refetch translation only — definition is language-independent (always in book lang).
-    bubbleAbortRef.current?.abort()
-    const ctrl = new AbortController()
-    bubbleAbortRef.current = ctrl
-    setBubble((prev) => prev && prev.word === word ? { ...prev, translation: null, translationLoading: true } : prev)
-    translateApi(word, bookLanguage, targetLang, ctrl.signal)
-      .then((res) => {
-        if (ctrl.signal.aborted) return
-        const translatedText = res?.translatedText ?? null
-        setBubble((prev) => prev && prev.word === word ? { ...prev, translation: translatedText, translationLoading: false } : prev)
-        if (translatedText) {
-          const existing = vocabMap.get(normalizeVocabKey(word))
-          if (existing?.id && !existing.isPending) {
-            updateWord(existing.id, { translation: translatedText }).catch(() => {})
-          }
-          if (existing) updateTranslation(word, translatedText)
-        }
-      })
-      .catch((err) => {
-        if (ctrl.signal.aborted) return
-        if ((err as { name?: string })?.name === 'AbortError') return
-        setBubble((prev) => prev && prev.word === word ? { ...prev, translationLoading: false } : prev)
-      })
-  }, [bubble?.word, targetLang, bookLanguage, vocabMap, updateTranslation])
+    // Auto-save via shared dedup hook (sync ref seals race that vocabMap can't —
+    // state commit is async, a second rapid tap would see has(key)===false).
+    triggerAutoSave(word, () => handleSave(word, range))
+  }, [bookLanguage, targetLang, vocabMap, updateTranslation, lookupWord, handleSave, triggerAutoSave])
 
   // Trigger popup when selection narrows to 1 word — with a short stabilization window
   // so transient selections (iOS auto-select, scroll-tap jitter) don't flash the popup.
@@ -468,7 +394,7 @@ export function ReaderHighlights({
             onRemove={entry?.id ? () => {
               removeWord(entry.id!, bubble.word)
               // Clear dedup so a subsequent tap on the same word re-auto-saves.
-              autoSavedRef.current.delete(normalizeVocabKey(bubble.word))
+              clearAutoSave(bubble.word)
               closeBubble()
             } : undefined}
             onClose={closeBubble}

--- a/apps/web/src/components/reader/WordPopup.tsx
+++ b/apps/web/src/components/reader/WordPopup.tsx
@@ -1,7 +1,23 @@
 import { useEffect, useLayoutEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { SpeakButton } from '../vocabulary/SpeakButton'
 import { getFlagUrl } from '../../context/NativeLanguageContext'
-import { LANGUAGES, POPULAR_LANGUAGES, OTHER_LANGUAGES, getLanguage } from '../../data/languages'
+import { LANGUAGES, POPULAR_LANGUAGES, OTHER_LANGUAGES, getLanguage, type LanguageEntry } from '../../data/languages'
+
+function LangOption({ lang, onSelect }: { lang: LanguageEntry; onSelect: (code: string) => void }) {
+  return (
+    <button
+      className="word-popup__lang-option"
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={() => onSelect(lang.code)}
+    >
+      <img src={getFlagUrl(lang.code)} alt="" width="16" height="12" />
+      <span className="word-popup__lang-native">{lang.nativeName}</span>
+      {lang.englishName !== lang.nativeName && (
+        <span className="word-popup__lang-english">{lang.englishName}</span>
+      )}
+    </button>
+  )
+}
 
 const AUTO_DISMISS_MS_MIN = 3000
 const AUTO_DISMISS_MS_MAX = 8000
@@ -69,6 +85,7 @@ export function WordPopup({
   const [showLangPicker, setShowLangPicker] = useState(false)
   const [langQuery, setLangQuery] = useState('')
   const [closing, setClosing] = useState(false)
+  const closingRef = useRef(false)
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout>>()
   const exitTimerRef = useRef<ReturnType<typeof setTimeout>>()
 
@@ -85,12 +102,14 @@ export function WordPopup({
     )
   }, [langQuery, nativeLanguage])
 
+  // Use ref-based guard (state lags behind batching → rapid calls leak timers + onClose×N).
   const animatedClose = useCallback(() => {
-    if (closing) return
+    if (closingRef.current) return
+    closingRef.current = true
     setClosing(true)
     clearTimeout(dismissTimerRef.current)
     exitTimerRef.current = setTimeout(onClose, EXIT_DURATION_MS)
-  }, [onClose, closing])
+  }, [onClose])
 
   // Reset closing state on new word OR new rect (same word re-tapped elsewhere).
   // Cancel any pending exit timer from a previous close — otherwise it fires 150ms
@@ -98,6 +117,7 @@ export function WordPopup({
   // catches same-word re-taps during the 150ms close animation.
   useEffect(() => {
     clearTimeout(exitTimerRef.current)
+    closingRef.current = false
     setClosing(false)
   }, [word, rect])
 
@@ -189,15 +209,38 @@ export function WordPopup({
     setPosition({ top, left })
   }, [rect, containerRef, translation, definition, translationLoading, definitionLoading, showLangPicker, closing])
 
-  // Close on click outside
+  // Close on click outside.
+  // Use pointerdown + drag threshold instead of mousedown — on touch devices a
+  // scroll gesture starts with pointerdown but shouldn't dismiss the popup.
+  // We only close if the pointer released within ~8px of where it started (real tap).
   useEffect(() => {
-    const handleMouseDown = (e: MouseEvent) => {
-      if (popupRef.current && !popupRef.current.contains(e.target as Node)) {
-        animatedClose()
+    let startX = 0
+    let startY = 0
+    let startedOutside = false
+
+    const handleDown = (e: PointerEvent) => {
+      if (!popupRef.current) return
+      if (popupRef.current.contains(e.target as Node)) {
+        startedOutside = false
+        return
       }
+      startedOutside = true
+      startX = e.clientX
+      startY = e.clientY
     }
-    document.addEventListener('mousedown', handleMouseDown)
-    return () => document.removeEventListener('mousedown', handleMouseDown)
+    const handleUp = (e: PointerEvent) => {
+      if (!startedOutside) return
+      startedOutside = false
+      const dx = Math.abs(e.clientX - startX)
+      const dy = Math.abs(e.clientY - startY)
+      if (dx < 8 && dy < 8) animatedClose()
+    }
+    document.addEventListener('pointerdown', handleDown)
+    document.addEventListener('pointerup', handleUp)
+    return () => {
+      document.removeEventListener('pointerdown', handleDown)
+      document.removeEventListener('pointerup', handleUp)
+    }
   }, [animatedClose])
 
   // Close on Escape — but if lang picker is open, close that first. Native
@@ -216,10 +259,59 @@ export function WordPopup({
     return () => document.removeEventListener('keydown', handleKey)
   }, [animatedClose, showLangPicker])
 
+  // Trap Tab inside popup — only when focus is already within it (don't hijack reader nav).
+  // Once user tabs into popup (or picker autofocuses search), Tab cycles within.
+  useEffect(() => {
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return
+      const popup = popupRef.current
+      const active = document.activeElement as HTMLElement | null
+      if (!popup || !active || !popup.contains(active)) return
+      const focusables = popup.querySelectorAll<HTMLElement>(
+        'button, input, [href], [tabindex]:not([tabindex="-1"])',
+      )
+      if (focusables.length === 0) return
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      if (e.shiftKey && active === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+    document.addEventListener('keydown', handleTab)
+    return () => document.removeEventListener('keydown', handleTab)
+  }, [showLangPicker]) // re-bind so focusable list refreshes when picker toggles
+
+  // setShowLangPicker(false) → showLangPicker effect reschedules auto-dismiss; no manual call needed.
+  const selectLang = useCallback((code: string) => {
+    onChangeNativeLanguage(code)
+    setShowLangPicker(false)
+  }, [onChangeNativeLanguage])
+
   if (!rect) return null
 
   const langLabel = getLanguage(nativeLanguage)?.nativeName || nativeLanguage
+  const isDefinitionMode = nativeLanguage === bookLanguage
+  const footerLabel = isDefinitionMode
+    ? t('reader.wordPopup.definitionMode')
+    : `${t('reader.wordPopup.translatingTo')} ${langLabel}`
+  const changeLabel = isDefinitionMode
+    ? t('reader.wordPopup.translateTo')
+    : t('reader.wordPopup.change')
 
+  // Conditional preventDefault: protect reader selection (mousedown on any
+  // non-input area moves selection anchor and collapses it → bubble dies).
+  // Skip for inputs/textareas so they keep native focus without per-child
+  // stopPropagation (the earlier "all children must remember to preventDefault"
+  // pattern was fragile — easy to break when adding a new text div).
+  const preventSelectionLoss = (e: React.MouseEvent | React.TouchEvent) => {
+    const t = e.target as HTMLElement
+    if (t.matches('input, textarea, [contenteditable="true"]')) return
+    e.preventDefault()
+  }
   return (
     <div
       ref={popupRef}
@@ -230,8 +322,8 @@ export function WordPopup({
         left: position?.left ?? -9999,
         visibility: position ? 'visible' : 'hidden',
       }}
-      onMouseDown={(e) => e.preventDefault()}
-      onTouchStart={(e) => e.preventDefault()}
+      onMouseDown={preventSelectionLoss}
+      onTouchStart={preventSelectionLoss}
       onMouseEnter={cancelAutoDismiss}
       onPointerEnter={cancelAutoDismiss}
       onClick={cancelAutoDismiss}
@@ -292,31 +384,14 @@ export function WordPopup({
 
       {/* Language footer */}
       <div className="word-popup__lang-footer">
-        {nativeLanguage === bookLanguage ? (
-          <>
-            <span className="word-popup__lang-label">{t('reader.wordPopup.definitionMode')}</span>
-            <button
-              className="word-popup__lang-change"
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={() => setShowLangPicker(!showLangPicker)}
-            >
-              {t('reader.wordPopup.translateTo')}
-            </button>
-          </>
-        ) : (
-          <>
-            <span className="word-popup__lang-label">
-              {t('reader.wordPopup.translatingTo')} {langLabel}
-            </span>
-            <button
-              className="word-popup__lang-change"
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={() => setShowLangPicker(!showLangPicker)}
-            >
-              {t('reader.wordPopup.change')}
-            </button>
-          </>
-        )}
+        <span className="word-popup__lang-label">{footerLabel}</span>
+        <button
+          className="word-popup__lang-change"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => setShowLangPicker(!showLangPicker)}
+        >
+          {changeLabel}
+        </button>
         {showLangPicker && (
           <div className="word-popup__lang-dropdown">
             <input
@@ -328,19 +403,22 @@ export function WordPopup({
               onKeyDown={(e) => {
                 if (e.key === 'Escape') {
                   e.preventDefault()
-                  setShowLangPicker(false)
-                  scheduleAutoDismiss()
+                  setShowLangPicker(false) // showLangPicker effect reschedules
                 } else if (e.key === 'Enter') {
                   e.preventDefault()
-                  // Only select on Enter when the user typed a query — otherwise a
-                  // bare Enter picks an arbitrary first language and silently
-                  // changes the user's native language.
-                  if (!filteredLangs) return
+                  // Enter selects only when the query unambiguously points at the first
+                  // result — either the only match, or first match's code/name STARTS WITH
+                  // the query. Otherwise a substring hit could silently swap the user's
+                  // native language to something they didn't mean (e.g. "en" → Slovenian).
+                  if (!filteredLangs || filteredLangs.length === 0) return
+                  const q = langQuery.trim().toLowerCase()
                   const first = filteredLangs[0]
-                  if (first) {
-                    onChangeNativeLanguage(first.code)
-                    setShowLangPicker(false)
-                    scheduleAutoDismiss()
+                  const startsWith =
+                    first.code.toLowerCase().startsWith(q) ||
+                    first.englishName.toLowerCase().startsWith(q) ||
+                    first.nativeName.toLowerCase().startsWith(q)
+                  if (filteredLangs.length === 1 || startsWith) {
+                    selectLang(first.code)
                   }
                 }
               }}
@@ -354,63 +432,18 @@ export function WordPopup({
                   <div className="word-popup__lang-empty">{t('reader.wordPopup.noResults') || 'No results'}</div>
                 ) : (
                   filteredLangs.map((l) => (
-                    <button
-                      key={l.code}
-                      className="word-popup__lang-option"
-                      onMouseDown={(e) => e.preventDefault()}
-                      onClick={() => {
-                        onChangeNativeLanguage(l.code)
-                        setShowLangPicker(false)
-                        scheduleAutoDismiss()
-                      }}
-                    >
-                      <img src={getFlagUrl(l.code)} alt="" width="16" height="12" />
-                      <span className="word-popup__lang-native">{l.nativeName}</span>
-                      {l.englishName !== l.nativeName && (
-                        <span className="word-popup__lang-english">{l.englishName}</span>
-                      )}
-                    </button>
+                    <LangOption key={l.code} lang={l} onSelect={selectLang} />
                   ))
                 )
               ) : (
                 <>
                   <div className="word-popup__lang-section">{t('reader.wordPopup.popularLanguages')}</div>
                   {POPULAR_LANGUAGES.filter(l => l.code !== nativeLanguage).map((l) => (
-                    <button
-                      key={l.code}
-                      className="word-popup__lang-option"
-                      onMouseDown={(e) => e.preventDefault()}
-                      onClick={() => {
-                        onChangeNativeLanguage(l.code)
-                        setShowLangPicker(false)
-                        scheduleAutoDismiss()
-                      }}
-                    >
-                      <img src={getFlagUrl(l.code)} alt="" width="16" height="12" />
-                      <span className="word-popup__lang-native">{l.nativeName}</span>
-                      {l.englishName !== l.nativeName && (
-                        <span className="word-popup__lang-english">{l.englishName}</span>
-                      )}
-                    </button>
+                    <LangOption key={l.code} lang={l} onSelect={selectLang} />
                   ))}
                   <div className="word-popup__lang-section">{t('reader.wordPopup.allLanguages')}</div>
                   {OTHER_LANGUAGES.filter(l => l.code !== nativeLanguage).map((l) => (
-                    <button
-                      key={l.code}
-                      className="word-popup__lang-option"
-                      onMouseDown={(e) => e.preventDefault()}
-                      onClick={() => {
-                        onChangeNativeLanguage(l.code)
-                        setShowLangPicker(false)
-                        scheduleAutoDismiss()
-                      }}
-                    >
-                      <img src={getFlagUrl(l.code)} alt="" width="16" height="12" />
-                      <span className="word-popup__lang-native">{l.nativeName}</span>
-                      {l.englishName !== l.nativeName && (
-                        <span className="word-popup__lang-english">{l.englishName}</span>
-                      )}
-                    </button>
+                    <LangOption key={l.code} lang={l} onSelect={selectLang} />
                   ))}
                 </>
               )}

--- a/apps/web/src/components/vocabulary/SpeakButton.tsx
+++ b/apps/web/src/components/vocabulary/SpeakButton.tsx
@@ -9,6 +9,7 @@ export function SpeakButton({ onClick, isPlaying, size = 16, className = '' }: S
   return (
     <button
       className={`speak-btn ${isPlaying ? 'speak-btn--playing' : ''} ${className}`}
+      onMouseDown={e => e.preventDefault()}
       onClick={e => { e.stopPropagation(); onClick() }}
       title="Listen"
       aria-label="Listen to pronunciation"

--- a/apps/web/src/hooks/useBubbleTranslationSync.ts
+++ b/apps/web/src/hooks/useBubbleTranslationSync.ts
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useRef } from 'react'
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
+import { updateWord } from '../api/vocabulary'
+import { translate as translateApi } from '../api/translation'
+import { normalizeVocabKey } from '../lib/vocabKey'
+import type { VocabMap } from './useReaderVocabulary'
+
+// Shared bubble shape required by both ReaderHighlights and FocusReaderPage.
+// Each caller extends this with their own extras (rect, range, phonetic, …).
+export interface BubbleLike {
+  word: string
+  translation: string | null
+  translationLoading: boolean
+}
+
+interface Options<B extends BubbleLike> {
+  bubble: B | null
+  setBubble: Dispatch<SetStateAction<B | null>>
+  vocabMap: VocabMap
+  updateTranslation: (word: string, translation: string) => void
+  targetLang: string | null
+  bookLanguage: string
+  abortRef: MutableRefObject<AbortController | null>
+}
+
+/**
+ * Two concerns shared by both readers:
+ *
+ * 1. **Backend translation patch** after auto-save: `fetchWordBubble`'s built-in
+ *    patch closes over `vocabMap` at call time — before auto-save inserts the
+ *    entry — so it misses. This effect watches `bubble.translation` + current
+ *    `vocabMap` and fires one PATCH per `(wordId, translation)` pair.
+ *
+ * 2. **Mid-popup lang switch**: when the user opens the popup's language picker
+ *    and chooses a different native language, `targetLang` changes while the
+ *    same word is visible. Refetch translation in place instead of forcing the
+ *    user to re-open the popup. Definition stays (always in book language).
+ *
+ * Returns `autoSavedRef` so consumers can dedup their own auto-save triggers
+ * synchronously (vocabMap state commit lags a render; a ref Set seals rapid
+ * re-tap races).
+ */
+export function useBubbleTranslationSync<B extends BubbleLike>({
+  bubble,
+  setBubble,
+  vocabMap,
+  updateTranslation,
+  targetLang,
+  bookLanguage,
+  abortRef,
+}: Options<B>) {
+  const autoSavedRef = useRef<Set<string>>(new Set())
+  const patchedRef = useRef<Set<string>>(new Set())
+
+  // (1) Backend translation patch — once per (wordId, translation).
+  useEffect(() => {
+    const word = bubble?.word
+    const translation = bubble?.translation
+    if (!word || !translation) return
+    const entry = vocabMap.get(normalizeVocabKey(word))
+    if (!entry?.id || entry.isPending) return
+    const patchKey = `${entry.id}:${translation}`
+    if (patchedRef.current.has(patchKey)) return
+    patchedRef.current.add(patchKey)
+    updateWord(entry.id, { translation }).catch(() => {})
+    updateTranslation(word, translation)
+  }, [bubble?.word, bubble?.translation, vocabMap, updateTranslation])
+
+  // (2) Lang-picker mid-popup refetch. Track (word, lang) pair — word changes
+  // are owned by the openBubble path, this effect only fires on lang flips for
+  // the same word. Stored as a tuple ref instead of a `word::lang` string so
+  // words containing `::` don't break the parse.
+  const lastPairRef = useRef<{ word: string; lang: string | null } | null>(null)
+
+  useEffect(() => {
+    const word = bubble?.word
+    if (!word) {
+      lastPairRef.current = null
+      return
+    }
+
+    const prev = lastPairRef.current
+    if (prev === null) {
+      // Initial open — openBubble already kicked off the fetch. Just record.
+      lastPairRef.current = { word, lang: targetLang }
+      return
+    }
+    if (prev.word === word && prev.lang === targetLang) return
+
+    lastPairRef.current = { word, lang: targetLang }
+    // Word changed → openBubble owns the fetch.
+    if (prev.word !== word) return
+
+    // Same word, lang flipped. Definition-mode switch (no targetLang) → clear translation.
+    if (!targetLang) {
+      setBubble((b) =>
+        b && b.word === word ? { ...b, translation: null, translationLoading: false } : b,
+      )
+      return
+    }
+
+    abortRef.current?.abort()
+    const ctrl = new AbortController()
+    abortRef.current = ctrl
+    setBubble((b) =>
+      b && b.word === word ? { ...b, translation: null, translationLoading: true } : b,
+    )
+
+    translateApi(word, bookLanguage, targetLang, ctrl.signal)
+      .then((res) => {
+        if (ctrl.signal.aborted) return
+        const translated = res?.translatedText ?? null
+        setBubble((b) =>
+          b && b.word === word
+            ? { ...b, translation: translated, translationLoading: false }
+            : b,
+        )
+        if (translated) {
+          const existing = vocabMap.get(normalizeVocabKey(word))
+          if (existing?.id && !existing.isPending) {
+            updateWord(existing.id, { translation: translated }).catch(() => {})
+          }
+          if (existing) updateTranslation(word, translated)
+        }
+      })
+      .catch((err) => {
+        if (ctrl.signal.aborted) return
+        if ((err as { name?: string })?.name === 'AbortError') return
+        setBubble((b) => (b && b.word === word ? { ...b, translationLoading: false } : b))
+      })
+  }, [bubble?.word, targetLang, bookLanguage, vocabMap, updateTranslation, setBubble, abortRef])
+
+  const triggerAutoSave = useCallback(
+    (word: string, save: () => Promise<unknown>) => {
+      const key = normalizeVocabKey(word)
+      if (vocabMap.has(key) || autoSavedRef.current.has(key)) return
+      autoSavedRef.current.add(key)
+      save().catch(() => {
+        autoSavedRef.current.delete(key)
+      })
+    },
+    [vocabMap],
+  )
+
+  const clearAutoSave = useCallback((word: string) => {
+    autoSavedRef.current.delete(normalizeVocabKey(word))
+  }, [])
+
+  return { triggerAutoSave, clearAutoSave }
+}

--- a/apps/web/src/pages/FocusReaderPage.tsx
+++ b/apps/web/src/pages/FocusReaderPage.tsx
@@ -9,10 +9,10 @@ import { useDictionary } from '../hooks/useDictionary'
 import { useReaderVocabulary } from '../hooks/useReaderVocabulary'
 import { useTts } from '../hooks/useTts'
 import { useTranslation } from '../hooks/useTranslation'
+import { useBubbleTranslationSync } from '../hooks/useBubbleTranslationSync'
 import { splitSentences, tokenizeWords } from '@textstack/shared'
 import { getUserBookChapter, getUserBook } from '../api/userBooks'
 import { updateWord as updateWordApi } from '../api/vocabulary'
-import { translate as translateApi } from '../api/translation'
 import { normalizeVocabKey, vocabStageClass } from '../lib/vocabKey'
 import { fetchWordBubble } from '../lib/wordBubbleFetch'
 import { WordPopup } from '../components/reader/WordPopup'
@@ -69,16 +69,24 @@ export function FocusReaderPage({ mode = 'public' }: Props) {
   const bubbleAbortRef = useRef<AbortController | null>(null)
   const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pressOriginRef = useRef<{ x: number; y: number } | null>(null)
-  // Auto-save dedup: word keys with an in-flight or completed auto-save in this session.
-  const autoSavedRef = useRef<Set<string>>(new Set())
-  // Translation-patch dedup: one backend patch per (wordId, translation) pair.
-  const patchedTranslationRef = useRef<Set<string>>(new Set())
 
   const targetLang = bookLanguage !== nativeLanguage ? nativeLanguage : null
 
   // Shared services for the word popup
   const { lookup: lookupWord } = useDictionary()
   const { vocabMap, addWord, removeWord, updateTranslation } = useReaderVocabulary(bookLanguage, targetLang)
+
+  // Backend translation patch + mid-popup lang-switch refetch + auto-save dedup.
+  // Extracted hook — same shape is used in ReaderHighlights.
+  const { triggerAutoSave, clearAutoSave } = useBubbleTranslationSync({
+    bubble,
+    setBubble,
+    vocabMap,
+    updateTranslation,
+    targetLang,
+    bookLanguage,
+    abortRef: bubbleAbortRef,
+  })
   const { speak } = useTts()
   const handleSpeak = useCallback((word: string) => {
     speak(word, bookLanguage)
@@ -286,86 +294,13 @@ export function FocusReaderPage({ mode = 'public' }: Props) {
         patch: (fields) => setBubble((prev) => (prev && prev.word === word ? { ...prev, ...fields } : prev)),
       })
 
-      // Auto-save. Dedup via ref (synchronous) since vocabMap.has() reads stale
-      // state until re-render — rapid re-presses would otherwise double-save.
-      const key = normalizeVocabKey(word)
-      if (!vocabMap.has(key) && !autoSavedRef.current.has(key)) {
-        autoSavedRef.current.add(key)
-        handleSaveWord(word).catch(() => {
-          autoSavedRef.current.delete(key)
-        })
-      }
+      // Auto-save via shared dedup hook.
+      triggerAutoSave(word, () => handleSaveWord(word))
     },
-    [bubble?.word, closeBubble, bookLanguage, targetLang, lookupWord, vocabMap, updateTranslation, handleSaveWord],
+    [bubble?.word, closeBubble, bookLanguage, targetLang, lookupWord, vocabMap, updateTranslation, handleSaveWord, triggerAutoSave],
   )
 
-  // Translation patch after auto-save. fetchWordBubble's built-in patch
-  // (wordBubbleFetch.ts:68-74) captures vocabMap at call time — before auto-save
-  // inserts the entry — so it misses. Apply a dedicated patch once per (id, translation).
-  useEffect(() => {
-    const word = bubble?.word
-    const translation = bubble?.translation
-    if (!word || !translation) return
-    const entry = vocabMap.get(normalizeVocabKey(word))
-    if (!entry?.id || entry.isPending) return
-    const patchKey = `${entry.id}:${translation}`
-    if (patchedTranslationRef.current.has(patchKey)) return
-    patchedTranslationRef.current.add(patchKey)
-    updateWordApi(entry.id, { translation }).catch(() => {})
-    updateTranslation(word, translation)
-  }, [bubble?.word, bubble?.translation, vocabMap, updateTranslation])
-
-  // Refetch translation when targetLang changes mid-popup (user picks a new
-  // native language in the popup's lang picker). openWordBubble owns the initial
-  // fetch — this effect handles every subsequent lang switch for the same word.
-  // Tracks (word, lang) pair so word changes (handled by openWordBubble) don't double-fetch.
-  const lastFetchedPairRef = useRef<string | null>(null)
-  useEffect(() => {
-    const word = bubble?.word
-    if (!word) {
-      lastFetchedPairRef.current = null
-      return
-    }
-    const pairKey = `${word}::${targetLang ?? ''}`
-    if (lastFetchedPairRef.current === null) {
-      lastFetchedPairRef.current = pairKey
-      return
-    }
-    if (lastFetchedPairRef.current === pairKey) return
-
-    const [prevWord] = lastFetchedPairRef.current.split('::')
-    lastFetchedPairRef.current = pairKey
-    if (prevWord !== word) return  // word changed → openWordBubble owns the fetch
-
-    if (!targetLang) {
-      // Switched into definition mode — clear translation field.
-      setBubble((prev) => prev && prev.word === word ? { ...prev, translation: null, translationLoading: false } : prev)
-      return
-    }
-
-    bubbleAbortRef.current?.abort()
-    const ctrl = new AbortController()
-    bubbleAbortRef.current = ctrl
-    setBubble((prev) => prev && prev.word === word ? { ...prev, translation: null, translationLoading: true } : prev)
-    translateApi(word, bookLanguage, targetLang, ctrl.signal)
-      .then((res) => {
-        if (ctrl.signal.aborted) return
-        const translatedText = res?.translatedText ?? null
-        setBubble((prev) => prev && prev.word === word ? { ...prev, translation: translatedText, translationLoading: false } : prev)
-        if (translatedText) {
-          const existing = vocabMap.get(normalizeVocabKey(word))
-          if (existing?.id && !existing.isPending) {
-            updateWordApi(existing.id, { translation: translatedText }).catch(() => {})
-          }
-          if (existing) updateTranslation(word, translatedText)
-        }
-      })
-      .catch((err) => {
-        if (ctrl.signal.aborted) return
-        if ((err as { name?: string })?.name === 'AbortError') return
-        setBubble((prev) => prev && prev.word === word ? { ...prev, translationLoading: false } : prev)
-      })
-  }, [bubble?.word, targetLang, bookLanguage, vocabMap, updateTranslation])
+  // Translation patch + mid-popup lang-switch refetch live in useBubbleTranslationSync.
 
   // Abort in-flight + pending press on unmount
   useEffect(() => () => {
@@ -523,7 +458,7 @@ export function FocusReaderPage({ mode = 'public' }: Props) {
           onSpeak={() => handleSpeak(bubble.word)}
           onRemove={vocabEntry?.id ? () => {
             removeWord(vocabEntry.id!, bubble.word)
-            autoSavedRef.current.delete(normalizeVocabKey(bubble.word))
+            clearAutoSave(bubble.word)
             closeBubble()
           } : undefined}
           onClose={closeBubble}

--- a/apps/web/src/styles/reader.css
+++ b/apps/web/src/styles/reader.css
@@ -2009,9 +2009,12 @@ html[data-theme="dark"] .reader-search-drawer__context mark {
 }
 
 
-/* Vocab word underlines in reader */
+/* Vocab word underlines in reader.
+   Uses native text-decoration (not border-bottom) so the underline sits at
+   descender level with skip-ink — keeps letter shapes clean AND leaves a
+   predictable gap above for inline translations on the next line. */
 @keyframes vocab-underline-in {
-  from { border-bottom-color: transparent; }
+  from { text-decoration-color: transparent; }
 }
 
 .vocab-underline {
@@ -2019,26 +2022,29 @@ html[data-theme="dark"] .reader-search-drawer__context mark {
   border-radius: 0;
   padding: 0;
   color: inherit;
-  text-decoration: none;
-  border-bottom: 2px solid transparent;
-  transition: border-color 0.2s;
+  text-decoration-line: underline;
+  text-decoration-thickness: 2px;
+  text-decoration-skip-ink: auto;
+  text-underline-offset: 3px;
+  text-decoration-color: transparent;
+  transition: text-decoration-color 0.2s;
   animation: vocab-underline-in 0.4s ease-out;
   position: relative;
 }
 .vocab-underline--new {
-  border-bottom-color: rgba(59, 130, 246, 0.5); /* blue */
+  text-decoration-color: rgba(59, 130, 246, 0.5); /* blue */
 }
 .vocab-underline--recognition {
-  border-bottom-color: rgba(234, 179, 8, 0.5); /* yellow */
+  text-decoration-color: rgba(234, 179, 8, 0.5); /* yellow */
 }
 .vocab-underline--recall {
-  border-bottom-color: rgba(234, 179, 8, 0.4);
+  text-decoration-color: rgba(234, 179, 8, 0.4);
 }
 .vocab-underline--context {
-  border-bottom-color: rgba(34, 197, 94, 0.4); /* green */
+  text-decoration-color: rgba(34, 197, 94, 0.4); /* green */
 }
 .vocab-underline--mastered {
-  border-bottom-color: rgba(34, 197, 94, 0.25); /* faint green */
+  text-decoration-color: rgba(34, 197, 94, 0.25); /* faint green */
 }
 
 @keyframes vocab-fade-in {
@@ -2046,10 +2052,14 @@ html[data-theme="dark"] .reader-search-drawer__context mark {
   to { opacity: 0.5; }
 }
 
+/* Inline translation above the word.
+   bottom: calc(100% + 4px) guarantees a real gap from the word's top, so it
+   can't visually collide with underlines / descenders of the line above even
+   at tight line-heights. */
 .vocab-inline-translation {
   position: absolute;
   left: 50%;
-  bottom: 100%;
+  bottom: calc(100% + 4px);
   transform: translateX(-50%);
   white-space: nowrap;
   font-size: 0.5em;


### PR DESCRIPTION
## Summary
- Extract `useBubbleTranslationSync` hook out of WordPopup for separation of concerns.
- Harden WordPopup: dedupe lang picker (`LangOption`), `selectLang` callback, fix race in `animatedClose` via `closingRef`, focus-trap on Tab cycling.
- Replace `mousedown` outside-click with `pointerdown`/`pointerup` + 8px movement threshold (touch scroll no longer accidentally closes popup).
- Conditional root `preventDefault` — inputs/textareas keep native focus, but reader text selection still protected for non-input clicks inside popup.
- Enter in lang search requires `startsWith` match or single result.
- Vocab underline migrated from `border-bottom` to `text-decoration` (`skip-ink: auto`, `underline-offset: 3px`) and inline translation gets a 4px gap so it no longer overlaps the underline of the line above.

## Test plan
- [x] `pnpm -C apps/web build` — clean
- [x] `pnpm -C apps/web exec tsc --noEmit` — clean
- [x] `pnpm -C apps/web test` — 89/89 pass
- [x] Playwright: smoke 5/5, reader-progress 6/6, focus-mode 7/7
- [x] Manual: 2.5x zoom screenshot confirms no underline collision

🤖 Generated with [Claude Code](https://claude.com/claude-code)