### PR TITLE
chore(book): hide Download EPUB button on public page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,7 @@ Upload EPUB/PDF/FB2 → BookFile (stored) → IngestionJob (queued)
 **Export**: EPUB export of user highlights and notes.
 - EpubExportService (`Application/Export/EpubExportService.cs`)
 - ExportEndpoints (`Api/Endpoints/ExportEndpoints.cs`)
+- **Deprecated 2026-04-15**: public book EPUB download (route `GET /{lang}/books/{slug}/export/epub` + UI anchor on `BookDetailPage`) hidden from UI; may be fully removed. Backend route + `EpubExportService` still live but unreachable from the app.
 
 **Highlights Review**: Spaced review of saved highlights.
 - HighlightReviewPage — review highlights with spaced repetition

--- a/apps/web/src/pages/BookDetailPage.tsx
+++ b/apps/web/src/pages/BookDetailPage.tsx
@@ -326,19 +326,6 @@ export function BookDetailPage() {
               </button>
             )}
 
-            <a
-              href={`${import.meta.env.VITE_API_URL || 'http://localhost:8080'}/${language}/books/${book.slug}/export/epub`}
-              className="book-detail__download-btn"
-              download
-            >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                <polyline points="7 10 12 15 17 10" />
-                <line x1="12" y1="15" x2="12" y2="3" />
-              </svg>
-              {t('bookDetail.downloadEpub')}
-            </a>
-
             <ShareButtons
               url={`${canonicalOrigin}/${language}/books/${book.slug}`}
               title={book.title}


### PR DESCRIPTION
## Summary
- Remove "Download EPUB" `<a>` on `BookDetailPage.tsx:329-340`. SEO/copyright — don't want to distribute full book files via UI right now.
- Backend route `GET /{lang}/books/{slug}/export/epub` + `EpubExportService` stay live (orphaned). Doc flag added to CLAUDE.md Export section — may be fully removed in follow-up.
- `UserBookDetailPage` download untouched — user's own uploaded file.
- Locale keys `bookDetail.downloadEpub` kept as orphans (trivial to drop once backend removed).

## Test plan
- [x] `pnpm -C apps/web build` passes
- [x] `rg downloadEpub apps/web/src` → only locale orphans remain
- [ ] Post-deploy: verify `/en/books/<slug>` renders without the button, ShareButtons + Download-for-offline intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)