### PR TITLE
feat(tts): word-level highlighting + rename Discover→Books

### DIFF
--- a/apps/web/src/api/tts.ts
+++ b/apps/web/src/api/tts.ts
@@ -50,3 +50,33 @@ export async function fetchTtsVoices(lang?: string): Promise<TtsVoiceInfo[]> {
   if (!res.ok) throw new Error(`Failed to fetch voices: ${res.status}`)
   return res.json()
 }
+
+// ASP.NET's default JSON serializer camelCases record properties, so the
+// wire format already matches our idiomatic WordTimestamp shape — no mapping
+// needed. (If the server ever flips to PascalCase we'd re-introduce a
+// normalizer here.)
+export interface WordTimestamp {
+  word: string
+  startMs: number
+  durationMs: number
+}
+
+export async function fetchTtsTimestamps(
+  text: string,
+  lang: string,
+  voice?: string,
+  speed?: number,
+  signal?: AbortSignal,
+): Promise<WordTimestamp[]> {
+  const params = new URLSearchParams({ text, lang })
+  if (voice) params.set('voice', voice)
+  if (speed && speed !== 1.0) params.set('speed', String(speed))
+  const res = await fetch(`${API_BASE}/tts/timestamps?${params}`, { signal })
+  if (res.status === 429) {
+    const header = res.headers.get('Retry-After')
+    const seconds = header ? parseInt(header, 10) : NaN
+    throw new TtsRateLimitError(Number.isFinite(seconds) && seconds > 0 ? seconds : 60)
+  }
+  if (!res.ok) throw new Error(`TTS timestamps error: ${res.status}`)
+  return res.json() as Promise<WordTimestamp[]>
+}

--- a/apps/web/src/components/DiscoverMenu.tsx
+++ b/apps/web/src/components/DiscoverMenu.tsx
@@ -103,7 +103,7 @@ export function DiscoverMenu() {
         aria-expanded={open}
         aria-haspopup="true"
       >
-        {t('nav.discover')}
+        {t('nav.books')}
         <span className="discover-menu__chevron" aria-hidden="true">
           <svg width="10" height="6" viewBox="0 0 10 6" fill="none">
             <path d="M1 1L5 5L9 1" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>

--- a/apps/web/src/components/reader/ReaderHighlights.tsx
+++ b/apps/web/src/components/reader/ReaderHighlights.tsx
@@ -20,6 +20,7 @@ import { VocabWordLayer } from './VocabWordLayer'
 import { TranslationPopup } from './TranslationPopup'
 import { WordPopup } from './WordPopup'
 import { NoteEditor } from './NoteEditor'
+import { TtsHighlightOverlay } from './TtsHighlightOverlay'
 import { Toast } from '../Toast'
 import { useAuth } from '../../context/AuthContext'
 
@@ -316,10 +317,19 @@ export function ReaderHighlights({
   }, [editingHighlight, removeHighlight, closeNoteEditor])
 
   // --- TTS ---
-  const { speak } = useTts()
+  const { speak, stop: stopTts, isPlaying: ttsPlaying, timestamps: ttsTimestamps, currentWordIndex: ttsCurrentWord } = useTts()
+  // Captured at speak() time so the overlay has text to split + highlight even
+  // after the selection is cleared. Cleared explicitly on stop() — relying on
+  // `isPlaying` alone would leave the last text flashing between playbacks.
+  const [ttsSpokenText, setTtsSpokenText] = useState<string | null>(null)
   const handleSpeak = useCallback((text: string, lang?: string) => {
+    setTtsSpokenText(text)
     speak(text, lang || bookLanguage, undefined, ttsSpeed)
   }, [speak, bookLanguage, ttsSpeed])
+  const handleStopTts = useCallback(() => {
+    stopTts()
+    setTtsSpokenText(null)
+  }, [stopTts])
 
   // Auto-play TTS when popup opens on a new word (not on every translation/definition update).
   useEffect(() => {
@@ -485,6 +495,17 @@ export function ReaderHighlights({
           onClick={() => { dismissIdbUnavailable(); openAuthModal() }}
         />
       )}
+
+      {/* Floating overlay with per-word highlighting during multi-word TTS.
+          Skip single-word playback (handled by WordPopup's own speaker icon)
+          so a word tap doesn't pop a redundant bar at the bottom. */}
+      <TtsHighlightOverlay
+        text={ttsSpokenText ?? ''}
+        timestamps={ttsTimestamps}
+        currentWordIndex={ttsCurrentWord}
+        visible={ttsPlaying && !!ttsSpokenText && countWords(ttsSpokenText) > 1}
+        onStop={handleStopTts}
+      />
     </div>
   )
 }

--- a/apps/web/src/components/reader/TtsHighlightOverlay.tsx
+++ b/apps/web/src/components/reader/TtsHighlightOverlay.tsx
@@ -1,0 +1,85 @@
+import { useMemo } from 'react'
+import type { WordTimestamp } from '../../api/tts'
+
+interface TtsHighlightOverlayProps {
+  text: string
+  timestamps: WordTimestamp[]
+  currentWordIndex: number
+  visible: boolean
+  onStop: () => void
+}
+
+type Span =
+  | { kind: 'word'; idx: number; value: string }
+  | { kind: 'gap'; value: string }
+
+// Splits the source text the same way Edge TTS's WordBoundary events carve it
+// up, so each span maps to exactly one timestamp entry. Timestamps arrive
+// AFTER audio decode starts, so during the leading frames we render the raw
+// text with no spans (no highlight). Once timestamps land we switch to span
+// mode — the first highlight fires on the first rAF tick past ts[0].startMs.
+//
+// Matching strategy: walk the text left-to-right, greedily consuming each
+// timestamp's `word` literal (whitespace-tolerant). Edge TTS emits words as
+// they appear in the SSML, including punctuation attached or not depending on
+// voice — we can't assume `text.split(/\s+/)[i] === timestamps[i].word`. The
+// greedy walker stays robust to that and to occasional Unicode normalization
+// differences.
+function buildSpans(text: string, ts: WordTimestamp[]): Span[] {
+  if (ts.length === 0) return [{ kind: 'gap', value: text }]
+  const out: Span[] = []
+  let cursor = 0
+  for (let i = 0; i < ts.length; i++) {
+    const word = ts[i].word
+    const found = text.indexOf(word, cursor)
+    if (found < 0) {
+      // Fallback: word not found past cursor — emit as synthetic word span so
+      // indices still line up with the highlight ticker. Visual gap if any
+      // remaining text won't be assigned to any word.
+      out.push({ kind: 'word', idx: i, value: word })
+      continue
+    }
+    if (found > cursor) out.push({ kind: 'gap', value: text.slice(cursor, found) })
+    out.push({ kind: 'word', idx: i, value: word })
+    cursor = found + word.length
+  }
+  if (cursor < text.length) out.push({ kind: 'gap', value: text.slice(cursor) })
+  return out
+}
+
+export function TtsHighlightOverlay({ text, timestamps, currentWordIndex, visible, onStop }: TtsHighlightOverlayProps) {
+  const spans = useMemo(() => buildSpans(text, timestamps), [text, timestamps])
+
+  if (!visible) return null
+
+  return (
+    <div className="tts-highlight-overlay" role="status" aria-live="polite">
+      <div className="tts-highlight-overlay__text">
+        {spans.map((s, i) =>
+          s.kind === 'gap' ? (
+            <span key={i} className="tts-highlight-overlay__gap">{s.value}</span>
+          ) : (
+            <span
+              key={i}
+              className={
+                s.idx === currentWordIndex
+                  ? 'tts-highlight-overlay__word tts-highlight-overlay__word--active'
+                  : 'tts-highlight-overlay__word'
+              }
+            >
+              {s.value}
+            </span>
+          ),
+        )}
+      </div>
+      <button
+        type="button"
+        className="tts-highlight-overlay__stop"
+        onClick={onStop}
+        aria-label="Stop playback"
+      >
+        <span className="material-icons-outlined">stop</span>
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/hooks/useTts.ts
+++ b/apps/web/src/hooks/useTts.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { fetchTtsAudio, TtsRateLimitError } from '../api/tts'
+import { fetchTtsAudio, fetchTtsTimestamps, TtsRateLimitError, WordTimestamp } from '../api/tts'
 import { getCachedTtsAudio, cacheTtsAudio } from '../lib/offlineDb'
 
 // Shared playback element + blob URL — a single TTS stream at a time.
@@ -94,7 +94,14 @@ export function useTts() {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<TtsError>(null)
   const [retryAfterSeconds, setRetryAfterSeconds] = useState<number | null>(null)
+  const [timestamps, setTimestamps] = useState<WordTimestamp[]>([])
+  const [currentWordIndex, setCurrentWordIndex] = useState(-1)
   const abortRef = useRef<AbortController | null>(null)
+  const rafRef = useRef<number | null>(null)
+  // Timestamps kept on a ref so the rAF tick doesn't re-close over stale
+  // state. State is still surfaced via `timestamps` for consumers that want
+  // to render the word list.
+  const timestampsRef = useRef<WordTimestamp[]>([])
 
   // Stable per-instance callback — used as identity to tell owner-me apart
   // from owner-other-instance in currentOwnerReset.
@@ -104,6 +111,14 @@ export function useTts() {
     setIsLoading(false)
   }
   const localReset = useCallback(() => localResetRef.current(), [])
+
+  const stopTracking = useCallback(() => {
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
+    }
+    setCurrentWordIndex(-1)
+  }, [])
 
   const stop = useCallback(() => {
     abortRef.current?.abort()
@@ -117,10 +132,11 @@ export function useTts() {
     audio.onerror = null
     audio.src = ''
     cleanup()
+    stopTracking()
     setIsPlaying(false)
     setIsLoading(false)
     if (currentOwnerReset === localReset) currentOwnerReset = null
-  }, [localReset])
+  }, [localReset, stopTracking])
 
   // On unmount, release ownership so we don't leak a stale reset callback
   // that closes over dead React state.
@@ -143,6 +159,8 @@ export function useTts() {
     }
     setError(null)
     setRetryAfterSeconds(null)
+    setTimestamps([])
+    timestampsRef.current = []
 
     const controller = new AbortController()
     abortRef.current = controller
@@ -168,6 +186,19 @@ export function useTts() {
         try { await cacheTtsAudio(lang, text, audioData) } catch { /* ignore */ }
       }
 
+      // Timestamps are cheap on cache hit (same key as audio) — fetch in
+      // parallel-ish with audio decode. Failure here is non-fatal: if the
+      // timestamps endpoint fails we still play audio without highlighting.
+      // IndexedDB is NOT used for timestamps today — the HTTP ETag/304 path
+      // is sufficient given the small JSON payload.
+      fetchTtsTimestamps(text, lang, voice, speed, controller.signal)
+        .then(ts => {
+          if (controller.signal.aborted) return
+          timestampsRef.current = ts
+          setTimestamps(ts)
+        })
+        .catch(() => { /* non-fatal */ })
+
       if (controller.signal.aborted) return
 
       // Play
@@ -180,6 +211,7 @@ export function useTts() {
       audio.onended = () => {
         setIsPlaying(false)
         cleanup()
+        stopTracking()
         if (currentOwnerReset === localReset) currentOwnerReset = null
       }
       audio.onerror = () => {
@@ -187,6 +219,7 @@ export function useTts() {
         // just goes silent with no indicator — user thinks it worked.
         setIsPlaying(false)
         cleanup()
+        stopTracking()
         setError('failed')
         if (currentOwnerReset === localReset) currentOwnerReset = null
       }
@@ -197,6 +230,31 @@ export function useTts() {
       currentOwnerReset = localReset
       setIsLoading(false)
       setIsPlaying(true)
+
+      // Track currentWordIndex via rAF. Linear scan from `lastIndex` rather
+      // than bisecting — audio plays forward, so the scan is O(1) per frame.
+      // We don't tick from `timeupdate`: that fires at only ~4Hz in Chrome
+      // and would lag behind visible word changes.
+      let lastIndex = -1
+      const tick = () => {
+        const nowMs = audio.currentTime * 1000
+        const ts = timestampsRef.current
+        if (ts.length > 0) {
+          let idx = lastIndex < 0 ? 0 : lastIndex
+          // Advance while next words are due.
+          while (idx < ts.length - 1 && ts[idx + 1].startMs <= nowMs) idx++
+          // Before first word starts → -1 so nothing is highlighted during
+          // the leading silence.
+          if (nowMs < ts[0].startMs) idx = -1
+          if (idx !== lastIndex) {
+            lastIndex = idx
+            setCurrentWordIndex(idx)
+          }
+        }
+        rafRef.current = requestAnimationFrame(tick)
+      }
+      rafRef.current = requestAnimationFrame(tick)
+
       try {
         await audio.play()
       } catch (err) {
@@ -204,6 +262,7 @@ export function useTts() {
         const name = (err as { name?: string })?.name
         setIsPlaying(false)
         cleanup()
+        stopTracking()
         setError(name === 'NotAllowedError' ? 'blocked' : 'failed')
         // Re-arm the unlock path so the next user gesture tries again. Without
         // this, audioUnlocked stays true after a permission revoke and every
@@ -216,6 +275,7 @@ export function useTts() {
         console.error('TTS error:', err)
         setIsLoading(false)
         setIsPlaying(false)
+        stopTracking()
         if (err instanceof TtsRateLimitError) {
           setRetryAfterSeconds(err.retryAfterSeconds)
           setError('rate_limited')
@@ -224,7 +284,7 @@ export function useTts() {
         }
       }
     }
-  }, [stop, localReset])
+  }, [stop, localReset, stopTracking])
 
-  return { speak, stop, isPlaying, isLoading, error, retryAfterSeconds }
+  return { speak, stop, isPlaying, isLoading, error, retryAfterSeconds, timestamps, currentWordIndex }
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -236,7 +236,7 @@
   },
   "nav": {
     "catalog": "Catalog",
-    "discover": "Discover",
+    "books": "Books",
     "vocabulary": "Vocabulary",
     "highlights": "Highlights",
     "about": "About",

--- a/apps/web/src/locales/uk.json
+++ b/apps/web/src/locales/uk.json
@@ -236,7 +236,7 @@
   },
   "nav": {
     "catalog": "Каталог",
-    "discover": "Огляд",
+    "books": "Книги",
     "vocabulary": "Словник",
     "highlights": "Виділення",
     "about": "Про нас",

--- a/apps/web/src/styles/reader.css
+++ b/apps/web/src/styles/reader.css
@@ -2024,3 +2024,70 @@ html[data-theme="dark"] .reader-search-drawer__context mark {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/* --- TTS word-highlight overlay (Phase 2.1) --- */
+.tts-highlight-overlay {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  max-width: min(720px, calc(100vw - 32px));
+  padding: 12px 16px;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+  font-size: 0.95rem;
+  line-height: 1.55;
+  animation: tts-overlay-in 0.15s ease-out;
+}
+
+@keyframes tts-overlay-in {
+  from { opacity: 0; transform: translate(-50%, 8px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+
+.tts-highlight-overlay__text {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-height: 4.5em;
+  overflow-y: auto;
+  color: var(--color-text);
+  /* Keep word spans inline so highlighting flows with text reflow. */
+  word-break: break-word;
+}
+
+.tts-highlight-overlay__word {
+  transition: background-color 0.12s ease-out, color 0.12s ease-out;
+  border-radius: 3px;
+  padding: 0 1px;
+}
+
+.tts-highlight-overlay__word--active {
+  background: var(--color-brand);
+  color: #fff;
+}
+
+.tts-highlight-overlay__stop {
+  flex: 0 0 auto;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.tts-highlight-overlay__stop:hover {
+  background: var(--color-bg-secondary);
+  color: var(--color-text);
+}

--- a/backend/src/Api/Endpoints/TtsEndpoints.cs
+++ b/backend/src/Api/Endpoints/TtsEndpoints.cs
@@ -16,6 +16,11 @@ public static class TtsEndpoints
         var group = app.MapGroup("/tts").WithTags("TTS");
 
         group.MapGet("", Synthesize).WithName("Synthesize").RequireRateLimiting("tts");
+        // Timestamps share the synth rate budget — the first call typically
+        // triggers synthesis (same cache key as the audio), subsequent calls
+        // are pure cache reads. Giving them a separate bucket would let a
+        // client burst through by alternating audio + timestamps requests.
+        group.MapGet("/timestamps", GetTimestamps).WithName("GetTimestamps").RequireRateLimiting("tts");
         // Voices list is cheap (cached, no synthesis) — separate bucket so a
         // burst of voice-list polls doesn't starve the synth budget and vice versa.
         group.MapGet("/voices", GetVoices).WithName("GetTtsVoices").RequireRateLimiting("tts-voices");
@@ -31,27 +36,84 @@ public static class TtsEndpoints
         IOptions<TtsConfiguration> options,
         CancellationToken ct)
     {
-        // Bind once via Options instead of `IConfiguration.GetValue` per call.
-        // `GetValue` walks the config providers and re-parses the string on
-        // every request — Options is cached + already strongly typed, so the
-        // hot path is a property read instead of a string lookup + Convert.
-        var cfg = options.Value;
+        if (TryPreprocess(http, text, lang, voice, speed, options.Value, out var req, out var shortCircuit))
+            return shortCircuit!;
 
-        if (string.IsNullOrWhiteSpace(text))
-            return Results.BadRequest("Text is required");
+        try
+        {
+            var audio = await tts.SynthesizeAsync(req.Text, req.Lang, req.Voice, req.Speed, ct);
+            WriteCacheHeaders(http, req.Etag, req.ResponseCacheSeconds);
+            return Results.File(audio, "audio/mpeg", enableRangeProcessing: true);
+        }
+        catch (TaskCanceledException) { return Results.Problem("TTS request timed out", statusCode: 504); }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return Results.Problem(detail: $"TTS service error: {ex.Message}", statusCode: 502);
+        }
+    }
 
-        if (text.Length > cfg.MaxTextLength)
-            return Results.BadRequest($"Text exceeds maximum length of {cfg.MaxTextLength} characters");
+    private static async Task<IResult> GetTimestamps(
+        HttpContext http,
+        string? text,
+        string? lang,
+        string? voice,
+        double? speed,
+        ITtsService tts,
+        IOptions<TtsConfiguration> options,
+        CancellationToken ct)
+    {
+        if (TryPreprocess(http, text, lang, voice, speed, options.Value, out var req, out var shortCircuit))
+            return shortCircuit!;
 
-        if (string.IsNullOrWhiteSpace(lang))
-            return Results.BadRequest("Language is required");
+        try
+        {
+            var result = await tts.SynthesizeWithTimestampsAsync(req.Text, req.Lang, req.Voice, req.Speed, ct);
+            WriteCacheHeaders(http, req.Etag, req.ResponseCacheSeconds);
+            return Results.Ok(result.Timestamps);
+        }
+        catch (TaskCanceledException) { return Results.Problem("TTS request timed out", statusCode: 504); }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return Results.Problem(detail: $"TTS service error: {ex.Message}", statusCode: 502);
+        }
+    }
+
+    // Parsed + validated request shared between /tts and /tts/timestamps.
+    // Etag is derived from the same inputs on both endpoints so a client that
+    // already has the audio cached can 304 the timestamps cheaply (same key).
+    private readonly record struct TtsRequest(string Text, string Lang, string? Voice, double Speed, string Etag, int ResponseCacheSeconds);
+
+    // Shared validation + 304 short-circuit. Returns true when the caller
+    // should return `shortCircuit` (BadRequest or 304). When false, `req` is
+    // populated with the validated inputs + etag.
+    //
+    // Bind once via Options instead of `IConfiguration.GetValue` per call.
+    // `GetValue` walks the config providers and re-parses the string on
+    // every request — Options is cached + already strongly typed, so the
+    // hot path is a property read instead of a string lookup + Convert.
+    private static bool TryPreprocess(
+        HttpContext http,
+        string? text,
+        string? lang,
+        string? voice,
+        double? speed,
+        TtsConfiguration cfg,
+        out TtsRequest req,
+        out IResult? shortCircuit)
+    {
+        req = default;
+
+        if (string.IsNullOrWhiteSpace(text)) { shortCircuit = Results.BadRequest("Text is required"); return true; }
+        if (text.Length > cfg.MaxTextLength) { shortCircuit = Results.BadRequest($"Text exceeds maximum length of {cfg.MaxTextLength} characters"); return true; }
+        if (string.IsNullOrWhiteSpace(lang)) { shortCircuit = Results.BadRequest("Language is required"); return true; }
 
         // Deterministic ETag from inputs — same (text, lang, voice, speed) always
         // yields the same MP3, so a 304 short-circuit saves both bandwidth and a
         // disk read. Browsers / CDNs can honor this even when IndexedDB cache
         // is cleared.
         var etag = ComputeEtag(text, lang, voice, speed ?? 1.0);
-        var responseCacheSeconds = cfg.ResponseCacheSeconds;
+        req = new TtsRequest(text, lang, voice, speed ?? 1.0, etag, cfg.ResponseCacheSeconds);
+
         // RFC 9110: If-None-Match may carry a comma-separated list of validators
         // ("a", "b", W/"c") or the wildcard "*". Raw `inm == etag` only matched
         // a single-value header verbatim — multi-value clients (CDNs, fetch-with-
@@ -59,33 +121,24 @@ public static class TtsEndpoints
         if (http.Request.Headers.TryGetValue("If-None-Match", out var inm) && IfNoneMatchMatches(inm, etag))
         {
             http.Response.StatusCode = StatusCodes.Status304NotModified;
-            http.Response.Headers.ETag = etag;
             // RFC 9111 §4.3.4: a 304 SHOULD generate the same Cache-Control,
             // Content-Location, Date, ETag, Expires, and Vary as the 200 would
             // — so intermediaries can refresh stored freshness metadata. Without
             // it, a CDN's cached entry's max-age may not be re-extended on a
             // successful revalidation, forcing a full GET on next request.
-            http.Response.Headers.CacheControl = new StringValues($"public, max-age={responseCacheSeconds}, immutable");
-            return Results.Empty;
+            WriteCacheHeaders(http, etag, cfg.ResponseCacheSeconds);
+            shortCircuit = Results.Empty;
+            return true;
         }
 
-        try
-        {
-            var audio = await tts.SynthesizeAsync(text, lang, voice, speed ?? 1.0, ct);
-            http.Response.Headers.ETag = etag;
-            http.Response.Headers.CacheControl = new StringValues($"public, max-age={responseCacheSeconds}, immutable");
-            return Results.File(audio, "audio/mpeg", enableRangeProcessing: true);
-        }
-        catch (TaskCanceledException)
-        {
-            return Results.Problem("TTS request timed out", statusCode: 504);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            return Results.Problem(
-                detail: $"TTS service error: {ex.Message}",
-                statusCode: 502);
-        }
+        shortCircuit = null;
+        return false;
+    }
+
+    private static void WriteCacheHeaders(HttpContext http, string etag, int maxAgeSeconds)
+    {
+        http.Response.Headers.ETag = etag;
+        http.Response.Headers.CacheControl = new StringValues($"public, max-age={maxAgeSeconds}, immutable");
     }
 
     private static string ComputeEtag(string text, string lang, string? voice, double speed)

--- a/backend/src/Tts/TextStack.Tts/EdgeTtsClient.cs
+++ b/backend/src/Tts/TextStack.Tts/EdgeTtsClient.cs
@@ -29,7 +29,7 @@ internal static class EdgeTtsClient
         Timeout = TimeSpan.FromSeconds(15)
     };
 
-    public static async Task<byte[]> SynthesizeAsync(string text, string voice, string rate, string volume, string pitch, string lang, CancellationToken ct, long maxAudioBytes = 5L * 1024 * 1024)
+    public static async Task<(byte[] Audio, List<WordTimestamp> Timestamps)> SynthesizeAsync(string text, string voice, string rate, string volume, string pitch, string lang, CancellationToken ct, long maxAudioBytes = 5L * 1024 * 1024)
     {
         var connectionId = Guid.NewGuid().ToString("N");
         var secGec = GenerateSecMsGec();
@@ -89,6 +89,7 @@ internal static class EdgeTtsClient
 
         // 3. Receive audio chunks
         using var audioStream = new MemoryStream();
+        var timestamps = new List<WordTimestamp>();
         var buffer = new byte[8192];
         // Reuse one MemoryStream across messages — `using var msgStream = new
         // MemoryStream()` inside the loop allocated a fresh stream per WS
@@ -141,6 +142,8 @@ internal static class EdgeTtsClient
                     var text_ = Encoding.UTF8.GetString(msgStream.GetBuffer(), 0, (int)msgStream.Length);
                     if (text_.Contains("Path:turn.end"))
                         break;
+                    if (text_.Contains("Path:audio.metadata"))
+                        ParseWordBoundaries(text_, timestamps);
                 }
             }
         }
@@ -163,7 +166,55 @@ internal static class EdgeTtsClient
             }
         }
 
-        return audioStream.ToArray();
+        return (audioStream.ToArray(), timestamps);
+    }
+
+    // Parses an Edge TTS text frame carrying Path:audio.metadata. Header and
+    // JSON body are separated by \r\n\r\n (same wire format as the outgoing
+    // config/ssml frames we send).
+    //
+    // Body JSON (observed): {"Metadata":[{"Type":"WordBoundary","Data":{
+    //   "Offset":2000000,"Duration":500000,
+    //   "text":{"Text":"hello","Length":5,"BoundaryType":"WordBoundary"}}}]}
+    //
+    // Offset/Duration are 100-ns ticks (1 ms = 10_000 ticks). They already
+    // account for the "rate" parameter we sent, so client-side playback matches
+    // timestamps directly — no post-scaling.
+    //
+    // Best-effort: any malformed body is silently skipped (empty timestamps
+    // list is valid — caller should fall back to no-highlight playback).
+    private static void ParseWordBoundaries(string text, List<WordTimestamp> output)
+    {
+        var bodyStart = text.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+        if (bodyStart < 0) return;
+        var body = text[(bodyStart + 4)..];
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (!doc.RootElement.TryGetProperty("Metadata", out var meta) || meta.ValueKind != JsonValueKind.Array)
+                return;
+            foreach (var entry in meta.EnumerateArray())
+            {
+                if (!entry.TryGetProperty("Type", out var type) || type.GetString() != "WordBoundary")
+                    continue;
+                if (!entry.TryGetProperty("Data", out var data)) continue;
+                if (!data.TryGetProperty("Offset", out var offsetEl) || !data.TryGetProperty("Duration", out var durationEl))
+                    continue;
+                if (!data.TryGetProperty("text", out var textEl) || !textEl.TryGetProperty("Text", out var wordEl))
+                    continue;
+
+                var offsetTicks = offsetEl.GetInt64();
+                var durationTicks = durationEl.GetInt64();
+                var word = wordEl.GetString();
+                if (string.IsNullOrEmpty(word)) continue;
+
+                output.Add(new WordTimestamp(
+                    word,
+                    offsetTicks / 10_000.0,
+                    durationTicks / 10_000.0));
+            }
+        }
+        catch (JsonException) { /* swallow — no highlighting is better than a broken synth */ }
     }
 
     public static async Task<List<EdgeVoiceData>> GetVoicesAsync(CancellationToken ct)

--- a/backend/src/Tts/TextStack.Tts/EdgeTtsService.cs
+++ b/backend/src/Tts/TextStack.Tts/EdgeTtsService.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -94,72 +95,113 @@ public class EdgeTtsService : ITtsService, IHostedService, IDisposable
 
     public async Task<byte[]> SynthesizeAsync(string text, string lang, string? voice, double speed, CancellationToken ct)
     {
+        var result = await SynthesizeWithTimestampsAsync(text, lang, voice, speed, ct);
+        return result.Audio;
+    }
+
+    public async Task<TtsSynthesisResult> SynthesizeWithTimestampsAsync(string text, string lang, string? voice, double speed, CancellationToken ct)
+    {
         voice ??= ResolveDefaultVoice(lang);
         var rate = SpeedToRate(speed);
 
         var cacheKey = ComputeCacheKey(text, voice, rate);
-        var cachePath = _cacheAvailable ? Path.Combine(_config.CachePath, $"{cacheKey}.mp3") : null;
+        var (audioPath, tsPath) = _cacheAvailable
+            ? (Path.Combine(_config.CachePath, $"{cacheKey}.mp3"), Path.Combine(_config.CachePath, $"{cacheKey}.ts.json"))
+            : (null, null);
 
-        // Cache hit
-        if (cachePath != null && File.Exists(cachePath))
+        // Cache hit — require BOTH files to exist, otherwise re-synthesize.
+        // Old mp3-only entries from before the timestamps feature will miss
+        // here and be regenerated, which is correct: we need timestamps to
+        // serve the new /tts/timestamps endpoint.
+        if (await TryReadPairedCacheAsync(audioPath, tsPath, ct) is { } firstHit)
         {
             _logger.LogDebug("TTS cache hit: {Key}", cacheKey);
-            TouchCacheFile(cachePath);
-            return await File.ReadAllBytesAsync(cachePath, ct);
+            return firstHit;
         }
 
-        // Cache miss — synthesize
         await _synthLock.WaitAsync(ct);
         try
         {
             // Double-check after acquiring lock
-            if (cachePath != null && File.Exists(cachePath))
-            {
-                TouchCacheFile(cachePath);
-                return await File.ReadAllBytesAsync(cachePath, ct);
-            }
+            if (await TryReadPairedCacheAsync(audioPath, tsPath, ct) is { } raceHit)
+                return raceHit;
 
             _logger.LogInformation("TTS synthesizing: voice={Voice}, text={Text}", voice, text[..Math.Min(50, text.Length)]);
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             cts.CancelAfter(TimeSpan.FromSeconds(_config.TimeoutSeconds));
 
-            var audio = await EdgeTtsClient.SynthesizeAsync(text, voice, rate, "+0%", "+0Hz", lang, cts.Token, _config.MaxAudioBytes);
+            var (audio, timestamps) = await EdgeTtsClient.SynthesizeAsync(text, voice, rate, "+0%", "+0Hz", lang, cts.Token, _config.MaxAudioBytes);
 
             if (audio.Length == 0)
                 throw new InvalidOperationException("TTS returned empty audio");
 
-            if (cachePath != null)
+            if (audioPath != null && tsPath != null)
             {
-                // Atomic write: tmp file + rename. Direct WriteAllBytesAsync to
-                // the final path leaves a partial/corrupt .mp3 if the process is
-                // killed mid-write — and File.Exists() on next call would treat
-                // it as a cache hit, serving broken audio forever (TTL won't
-                // help since mtime is fresh). Tmp+Move ensures the final path
-                // either contains the complete payload or doesn't exist.
-                // Per-call random suffix avoids collisions when two callers race
-                // on the same key (lock above prevents that today, but the file
-                // op is safe regardless).
-                var tmpPath = cachePath + "." + Guid.NewGuid().ToString("N")[..8] + ".tmp";
+                // Atomic write for both files via tmp + rename. Partial writes
+                // on kill leave orphan .tmp that the sweep eventually reaps.
+                // We intentionally write timestamps FIRST: if the audio rename
+                // succeeds but the timestamp write fails, the next cache lookup
+                // will require both files and re-synthesize — no stale-partial
+                // hit. (Atomic-across-two-files is not achievable on posix;
+                // the "both required" check on read is the fallback.)
+                var audioTmp = audioPath + "." + Guid.NewGuid().ToString("N")[..8] + ".tmp";
+                var tsTmp = tsPath + "." + Guid.NewGuid().ToString("N")[..8] + ".tmp";
                 try
                 {
-                    await File.WriteAllBytesAsync(tmpPath, audio, ct);
-                    File.Move(tmpPath, cachePath, overwrite: true);
-                    _logger.LogInformation("TTS cached: {Key} ({Size}KB)", cacheKey, audio.Length / 1024);
+                    var tsJson = JsonSerializer.SerializeToUtf8Bytes(timestamps);
+                    await File.WriteAllBytesAsync(tsTmp, tsJson, ct);
+                    File.Move(tsTmp, tsPath, overwrite: true);
+
+                    await File.WriteAllBytesAsync(audioTmp, audio, ct);
+                    File.Move(audioTmp, audioPath, overwrite: true);
+                    _logger.LogInformation("TTS cached: {Key} ({Size}KB, {Words} words)", cacheKey, audio.Length / 1024, timestamps.Count);
                 }
                 catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
                 {
-                    _logger.LogWarning(ex, "TTS cache write failed for {Key}, returning audio without caching", cacheKey);
-                    try { if (File.Exists(tmpPath)) File.Delete(tmpPath); }
-                    catch (Exception cleanupEx) when (cleanupEx is UnauthorizedAccessException or IOException) { }
+                    _logger.LogWarning(ex, "TTS cache write failed for {Key}, returning without caching", cacheKey);
+                    foreach (var tmp in new[] { audioTmp, tsTmp })
+                    {
+                        try { if (File.Exists(tmp)) File.Delete(tmp); }
+                        catch (Exception cleanupEx) when (cleanupEx is UnauthorizedAccessException or IOException) { }
+                    }
                 }
             }
 
-            return audio;
+            return new TtsSynthesisResult(audio, timestamps);
         }
         finally
         {
             _synthLock.Release();
+        }
+    }
+
+    // Paired cache read: both .mp3 and .ts.json must be present. Returns null
+    // on any miss (including when cache is disabled). Touches both files on
+    // hit so LRU sweep treats them as recently used.
+    private static async Task<TtsSynthesisResult?> TryReadPairedCacheAsync(string? audioPath, string? tsPath, CancellationToken ct)
+    {
+        if (audioPath == null || tsPath == null) return null;
+        if (!File.Exists(audioPath) || !File.Exists(tsPath)) return null;
+        TouchCacheFile(audioPath);
+        TouchCacheFile(tsPath);
+        return new TtsSynthesisResult(
+            await File.ReadAllBytesAsync(audioPath, ct),
+            await ReadTimestampsAsync(tsPath, ct));
+    }
+
+    private static async Task<IReadOnlyList<WordTimestamp>> ReadTimestampsAsync(string path, CancellationToken ct)
+    {
+        try
+        {
+            await using var fs = File.OpenRead(path);
+            var list = await JsonSerializer.DeserializeAsync<List<WordTimestamp>>(fs, cancellationToken: ct);
+            return list ?? new List<WordTimestamp>();
+        }
+        catch (Exception) when (!ct.IsCancellationRequested)
+        {
+            // Corrupt cache file — serve empty; next synth will overwrite.
+            return Array.Empty<WordTimestamp>();
         }
     }
 
@@ -282,6 +324,18 @@ public class EdgeTtsService : ITtsService, IHostedService, IDisposable
     // loss is at most TouchCoalesceWindow, which is << TTL and << sweep
     // interval, so LRU ordering stays correct.
     private static readonly TimeSpan TouchCoalesceWindow = TimeSpan.FromHours(1);
+    // Delete the .ts.json sibling for an .mp3 path we just deleted. Best-effort:
+    // the sweep's orphan-reaper catches anything we miss here.
+    private static void TryDeletePair(string mp3Path)
+    {
+        try
+        {
+            var tsPath = mp3Path[..^".mp3".Length] + ".ts.json";
+            if (File.Exists(tsPath)) File.Delete(tsPath);
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException) { }
+    }
+
     private static void TouchCacheFile(string path)
     {
         try
@@ -362,6 +416,8 @@ public class EdgeTtsService : ITtsService, IHostedService, IDisposable
         }
 
         // Pass 1: TTL expiry — survivors collected for potential pass 2.
+        // Each .mp3 is paired with a .ts.json; delete both together so we
+        // never leave an orphan timestamps file with no audio (or vice versa).
         var survivors = new List<FileInfo>();
         foreach (var file in dir.EnumerateFiles("*.mp3"))
         {
@@ -369,11 +425,25 @@ public class EdgeTtsService : ITtsService, IHostedService, IDisposable
             {
                 try { file.Delete(); deleted++; }
                 catch (Exception ex) when (ex is UnauthorizedAccessException or IOException) { failed++; lastFailure = ex; }
+                TryDeletePair(file.FullName);
             }
             else
             {
                 survivors.Add(file);
                 totalBytes += file.Length;
+            }
+        }
+
+        // Separately reap orphan .ts.json files whose .mp3 is gone (e.g.
+        // crash between the two atomic renames, or manual cache edits).
+        foreach (var ts in dir.EnumerateFiles("*.ts.json"))
+        {
+            var key = ts.Name[..^".ts.json".Length];
+            var mp3 = Path.Combine(dir.FullName, key + ".mp3");
+            if (!File.Exists(mp3) && ts.LastWriteTimeUtc < tmpCutoff)
+            {
+                try { ts.Delete(); deleted++; }
+                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException) { failed++; lastFailure = ex; }
             }
         }
 
@@ -393,6 +463,7 @@ public class EdgeTtsService : ITtsService, IHostedService, IDisposable
                     deleted++;
                 }
                 catch (Exception ex) when (ex is UnauthorizedAccessException or IOException) { failed++; lastFailure = ex; }
+                TryDeletePair(file.FullName);
             }
         }
 

--- a/backend/src/Tts/TextStack.Tts/ITtsService.cs
+++ b/backend/src/Tts/TextStack.Tts/ITtsService.cs
@@ -3,7 +3,14 @@ namespace TextStack.Tts;
 public interface ITtsService
 {
     Task<byte[]> SynthesizeAsync(string text, string lang, string? voice = null, double speed = 1.0, CancellationToken ct = default);
+    Task<TtsSynthesisResult> SynthesizeWithTimestampsAsync(string text, string lang, string? voice = null, double speed = 1.0, CancellationToken ct = default);
     Task<IReadOnlyList<TtsVoiceInfo>> GetVoicesAsync(string? lang = null, CancellationToken ct = default);
 }
 
 public record TtsVoiceInfo(string Name, string ShortName, string Gender, string Locale, string Language);
+
+// Offsets already account for the speed/rate parameter — use them as-is against
+// audio currentTime on the client (no post-scaling needed).
+public record WordTimestamp(string Word, double StartMs, double DurationMs);
+
+public record TtsSynthesisResult(byte[] Audio, IReadOnlyList<WordTimestamp> Timestamps);

--- a/tests/TextStack.UnitTests/EdgeTtsServiceTests.cs
+++ b/tests/TextStack.UnitTests/EdgeTtsServiceTests.cs
@@ -206,20 +206,23 @@ public class EdgeTtsServiceTests
         var service = CreateService(tmpDir);
         await service.StartAsync(CancellationToken.None);
 
-        // Pre-seed the cache with a known file
+        // Pre-seed BOTH files — paired cache requires .mp3 + .ts.json to hit.
         var method = typeof(EdgeTtsService).GetMethod(
             "ComputeCacheKey",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
         var key = (string)method.Invoke(null, ["cached-word", "en-US-AriaNeural", "+0%"])!;
-        var cachePath = Path.Combine(tmpDir, $"{key}.mp3");
+        var audioPath = Path.Combine(tmpDir, $"{key}.mp3");
+        var tsPath = Path.Combine(tmpDir, $"{key}.ts.json");
         var fakeAudio = new byte[] { 0xFF, 0xFB, 0x90, 0x00 }; // fake MP3 header
-        await File.WriteAllBytesAsync(cachePath, fakeAudio);
+        await File.WriteAllBytesAsync(audioPath, fakeAudio);
+        await File.WriteAllTextAsync(tsPath, "[]");
 
         var result = await service.SynthesizeAsync("cached-word", "en", null, 1.0, CancellationToken.None);
 
         Assert.Equal(fakeAudio, result);
         Directory.Delete(tmpDir, true);
     }
+
 
     private static string GetCachePath(EdgeTtsService service)
     {


### PR DESCRIPTION
## Summary
- **Phase 2.1 Word Highlighting**: Edge TTS WordBoundary parsing → frontend highlights each word in sync with audio playback (ElevenReader-style)
- **Paired disk cache**: `{sha256key}.mp3` + `{sha256key}.ts.json` (both required for hit; atomic tmp+rename)
- **New endpoint** `GET /tts/timestamps` — shares ETag with `/tts` so client gets 304 on either endpoint once cached
- **Rename** nav `Discover` → `Books` (en/uk)
- **Refactor** (behavior-preserving): extracted `TryPreprocess`/`WriteCacheHeaders` in `TtsEndpoints`, `TryReadPairedCacheAsync` in `EdgeTtsService`, `type Span` in overlay

## Test plan
- [x] `dotnet build` — 0 warn/0 err
- [x] `dotnet test EdgeTtsServiceTests` — 27/28 (1 pre-existing flake, unrelated)
- [x] `tsc --noEmit` + `vite build` — clean
- [x] Browser `/en/` shows "Books", `/uk/` shows "Книги", no console errors
- [x] `/tts?text=hello+world&lang=en` → 200 mp3 + ETag
- [x] `/tts/timestamps?text=hello+world&lang=en` → 200 JSON, same ETag as /tts
- [x] 304 on exact ETag + multi-value If-None-Match
- [x] 400 on missing text / lang / text > MaxLength
- [x] Paired cache on disk: `.mp3` + `.ts.json` written together
- [x] Cache hit MD5 equality across two calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)