### PR TITLE
fix(mobile/reader): word tap on Android + add expo-updates

### DIFF
--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -30,6 +30,7 @@
         "expo-splash-screen": "~55.0.13",
         "expo-sqlite": "~55.0.11",
         "expo-status-bar": "~55.0.4",
+        "expo-updates": "~55.0.20",
         "react": "19.2.0",
         "react-dom": "^19.2.0",
         "react-native": "0.83.2",
@@ -4665,6 +4666,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "55.0.5",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-55.0.5.tgz",
+      "integrity": "sha512-wRagCeSbSnSGVXgP7V+qiGfXzZ9hTVKWvKIOP7lwrX3MIEenNmNlO4D3RVC3aNU2GhmO3ZCZIIEre80KZoUUHA==",
+      "license": "MIT"
+    },
     "node_modules/expo-file-system": {
       "version": "55.0.12",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-55.0.12.tgz",
@@ -4751,9 +4758,9 @@
       }
     },
     "node_modules/expo-json-utils": {
-      "version": "55.0.0",
-      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-55.0.0.tgz",
-      "integrity": "sha512-aupt/o5PDAb8dXDCb0JcRdkqnTLxe/F+La7jrnyd/sXlYFfRgBJLFOa1SqVFXm1E/Xam1SE/yw6eAb+DGY7Arg==",
+      "version": "55.0.2",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-55.0.2.tgz",
+      "integrity": "sha512-QJMOZOPOG7CTnKcrdVaiummn2va1MCO56z++eyWkDv3GBRODldM6MFMDf/jTREWthFc2Nxo6TuyWRrEV9S6n/Q==",
       "license": "MIT"
     },
     "node_modules/expo-linking": {
@@ -4771,13 +4778,13 @@
       }
     },
     "node_modules/expo-manifests": {
-      "version": "55.0.11",
-      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-55.0.11.tgz",
-      "integrity": "sha512-3+pFun4C9F/eFMVpwZgOBrBWq5sfu7rS1uxTrcg9G7jUFatNe5W6hr+M7z7aQPDf0J1afaSudUZPawx1LLf15w==",
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-55.0.15.tgz",
+      "integrity": "sha512-p40ftXpgLTFGddFy35MYZMyjm/E6IQdn3l6fBZZ6zeraEzYLt+VLHYsplOL9ccTYvUSWKN9aOWRpoEYpyGVBVw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~55.0.10",
-        "expo-json-utils": "~55.0.0"
+        "@expo/config": "~55.0.14",
+        "expo-json-utils": "~55.0.2"
       },
       "peerDependencies": {
         "expo": "*"
@@ -5012,6 +5019,12 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-structured-headers": {
+      "version": "55.0.2",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-55.0.2.tgz",
+      "integrity": "sha512-KITovrWigTOtsII5hRQ9/3ydaNcxCux5g6O+eTPLyjnye9dpkDKl5GmCLVPVKIL/d7253OtbGtWMD4m0gha5pw==",
+      "license": "MIT"
+    },
     "node_modules/expo-symbols": {
       "version": "55.0.5",
       "resolved": "https://registry.npmjs.org/expo-symbols/-/expo-symbols-55.0.5.tgz",
@@ -5028,14 +5041,50 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-updates": {
+      "version": "55.0.20",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-55.0.20.tgz",
+      "integrity": "sha512-bRVsm+2ax3rQkErV+YX9uw+2N5DJ7C2S4ETPZPFbnLubSCJtlPuMHZ2SDQvmh3mAOl0yURKkbIMWVCvT89GmIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "^0.0.6",
+        "@expo/plist": "^0.5.2",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "^4.1.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "expo-eas-client": "~55.0.5",
+        "expo-manifests": "~55.0.15",
+        "expo-structured-headers": "~55.0.2",
+        "expo-updates-interface": "~55.1.5",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-updates-interface": {
-      "version": "55.1.3",
-      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-55.1.3.tgz",
-      "integrity": "sha512-UVVIiZqymQZJL+o/jh65kXOI97xdkbqBJJM0LMabaPMNLFnc6/WvOMOzmQs7SPyKb8+0PeBaFd7tj5DzF6JeQg==",
+      "version": "55.1.5",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-55.1.5.tgz",
+      "integrity": "sha512-YOk9vhplWi0djoeqxMlEQgcDFeOGhnj4dWU0v1QvF5RqpqwLGdx780E0k3zL85xw6LXljVN78d6g8z51qIZu5g==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
       }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "license": "MIT"
     },
     "node_modules/expo/node_modules/@expo/cli": {
       "version": "55.0.19",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -44,6 +44,7 @@
     "expo-splash-screen": "~55.0.13",
     "expo-sqlite": "~55.0.11",
     "expo-status-bar": "~55.0.4",
+    "expo-updates": "~55.0.20",
     "react": "19.2.0",
     "react-dom": "^19.2.0",
     "react-native": "0.83.2",

--- a/apps/mobile/src/lib/readerHtml.ts
+++ b/apps/mobile/src/lib/readerHtml.ts
@@ -312,7 +312,32 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
       if (!sel) return false;
       sel.removeAllRanges();
       sel.addRange(range);
+      // Android WebView does not fire selectionchange for programmatic
+      // selection — push the message directly. iOS fires it twice (once
+      // here, once from the listener), but the second emit is a no-op
+      // because the popup re-renders to the same state.
+      dispatchSelection();
       return true;
+    }
+
+    var _suppressNextSelectionChange = false;
+    function dispatchSelection() {
+      var sel = window.getSelection();
+      if (!sel || sel.isCollapsed) return;
+      var text = sel.toString().trim();
+      if (!text || text.length > 300) return;
+      if (!text.includes(' ') && text.length <= 50) applyTapPulse(sel);
+      var sentence = '';
+      try { sentence = extractSentence(sel.anchorNode); } catch(e) {}
+      var anchor = null;
+      try { anchor = getSelectionAnchor(); } catch(e) {}
+      _suppressNextSelectionChange = true;
+      window.ReactNativeWebView.postMessage(JSON.stringify({
+        type: 'selection',
+        text: text,
+        sentence: sentence,
+        anchor: anchor
+      }));
     }
 
     // Tap detection for immersive mode (touchend, not click — click unreliable in RN WebView)
@@ -551,6 +576,10 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
     }
 
     document.addEventListener('selectionchange', function() {
+      if (_suppressNextSelectionChange) {
+        _suppressNextSelectionChange = false;
+        return;
+      }
       var sel = window.getSelection();
       if (!sel || sel.isCollapsed || !sel.toString().trim()) {
         window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'selection', text: '' }));


### PR DESCRIPTION
## Summary
- **Android reader bug:** word tap silently did nothing because Android WebView does not fire `selectionchange` for programmatic selection. Now `selectWordAtPoint` dispatches the message inline; iOS suppresses the duplicate.
- Add `expo-updates` dep for upcoming OTA setup.

## Test plan
- [ ] Android APK: tap a word in reader → WordCard popup + tap-pulse + (if signed in) underline appears
- [ ] iOS simulator: same flow still works, no double-pulse