### PR TITLE
fix(seo): P0 — alias /ssg/ to data/ssg/ so nginx finds prerendered files

### DIFF
--- a/infra/nginx/textstack.conf
+++ b/infra/nginx/textstack.conf
@@ -188,6 +188,14 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # SSG files are written by ssg-worker container → host bind mount data/ssg/.
+    # nginx root is apps/web/dist, so $ssg_file (/ssg$uri/index.html) without this
+    # alias resolves to a non-existent path. `internal` blocks direct external access.
+    location /ssg/ {
+        internal;
+        alias /home/vasyl/projects/onlinelib/textstack/data/ssg/;
+    }
+
     # === SSG PAGES (bots get static HTML, real users get SPA) ===
     # $ssg_file map: bots → /ssg/<uri>/index.html, users → /nonexistent
     # try_files: if SSG file exists serve it, otherwise fall back to SPA


### PR DESCRIPTION
## Summary

- **Root cause of Ahrefs 1,161-page 4xx cluster.** ssg-worker writes 247 prerendered files to `data/ssg/` (via docker volume bind mount) but nginx `root` is `apps/web/dist/`, so `\$ssg_file` map (`/ssg\$uri/index.html`) pointed at a non-existent path. Every bot request fell through to `@spa` → HTTP 404.
- Fix: add `location /ssg/ { internal; alias /home/vasyl/.../data/ssg/; }` — unblocks all SSG files for crawlers.
- `internal;` blocks direct external `/ssg/...` access — only reachable via `try_files \$ssg_file`.

## Evidence (pre-fix, prod)

```
$ curl -sI -A "AhrefsBot" https://textstack.app/en/books/dracula/
HTTP/2 404
x-seo-render: spa

$ curl -s -A "AhrefsBot" https://textstack.app/en/books/dracula/ | wc -c
169
```

Yet the SSG file exists on host: `data/ssg/en/books/dracula/index.html`, and the ssg-worker log confirms 247 pages prerendered, atomic-swapped successfully.

## ⚠️ Manual step after merge

`deploy.yml` does **not** auto-sync `infra/nginx/textstack.conf` to `/etc/nginx/sites-available/textstack` (the `nginx-setup` Makefile target uses `sudo` and isn't called from CI). After merging, run on prod:

\`\`\`
ssh asus
cd ~/projects/onlinelib/textstack
make nginx-setup
sudo nginx -t && sudo systemctl reload nginx
\`\`\`

Follow-up ticket idea: wire \`nginx-setup\` into deploy.yml so future nginx changes ship automatically.

## Test plan

- [ ] Merge and deploy.
- [ ] On prod: \`make nginx-setup && sudo nginx -t && sudo systemctl reload nginx\`.
- [ ] \`curl -sI -A "AhrefsBot" https://textstack.app/en/books/dracula/\` → **HTTP 200**, \`x-seo-render: ssg\`.
- [ ] \`curl -s -A "AhrefsBot" https://textstack.app/en/books/dracula/ | wc -c\` → **30–100 KB** (was 169).
- [ ] \`curl -s -A "AhrefsBot" https://textstack.app/en/books/dracula/ | grep -E '<h1|og:title|canonical'\` → all present.
- [ ] \`curl -I https://textstack.app/ssg/en/books/dracula/index.html\` → **404** (internal blocks direct access).
- [ ] Spot-check 3 other entity types (author, genre, blog) — all return SSG HTML for bots.
- [ ] Trigger fresh Ahrefs crawl, observe Health Score delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)