### PR TITLE
fix(seo): P1a — noindex reader pages via nginx X-Robots-Tag header

### DIFF
--- a/infra/nginx/textstack.conf
+++ b/infra/nginx/textstack.conf
@@ -188,6 +188,15 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # Reader chapter pages — noindex via header so non-JS crawlers see it.
+    # Chapters are book text, not SEO-valuable, and have no canonical/OG/H1.
+    # Defense in depth: SeoHead in ReaderPage.tsx also emits <meta robots noindex>.
+    location ~ ^/(en|uk)/reader/ {
+        add_header X-SEO-Render "spa" always;
+        add_header X-Robots-Tag "noindex, follow" always;
+        try_files $uri /index.html;
+    }
+
     # === SSG PAGES (bots get static HTML, real users get SPA) ===
     # $ssg_file map: bots → /ssg/<uri>/index.html, users → /nonexistent
     # try_files: if SSG file exists serve it, otherwise fall back to SPA


### PR DESCRIPTION
## Summary

- Chapter reader pages have no canonical/OG/H1 and are book text — not SEO-valuable.
- Commit 7521f80 added `<meta robots noindex>` via React, invisible to non-JS crawlers → Ahrefs reports 795-page cluster as indexable.
- Add nginx location emitting `X-Robots-Tag: noindex, follow` header so crawlers see the directive without running JS.
- SeoHead noindex in `ReaderPage.tsx` kept as defense in depth.

## ⚠️ Manual step after merge

Same as P0: `make nginx-setup && sudo nginx -t && sudo systemctl reload nginx` on prod.

## Test plan

- [ ] Merge, deploy, sync nginx.
- [ ] `curl -sI https://textstack.app/en/reader/dracula/chapter-1/ | grep -i x-robots-tag` → `X-Robots-Tag: noindex, follow`.
- [ ] `curl -sI https://textstack.app/en/books/dracula/ | grep -i x-robots-tag` → empty (book detail not affected).
- [ ] Trigger Ahrefs recrawl, observe reader-cluster 4xx count drops to 0 after noindex propagates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)