### PR TITLE
fix(seo): P1b — HTTP 404 for missing book/author/genre/blog slugs

### DIFF
--- a/infra/nginx/textstack.conf
+++ b/infra/nginx/textstack.conf
@@ -199,17 +199,17 @@ server {
 
     location ~ ^/(en|uk)/books/[^/]+/?$ {
         add_header X-SEO-Render $seo_render_tag always;
-        try_files $ssg_file @spa;
+        try_files $ssg_file @entity_404;
     }
 
     location ~ ^/(en|uk)/authors/[^/]+/?$ {
         add_header X-SEO-Render $seo_render_tag always;
-        try_files $ssg_file @spa;
+        try_files $ssg_file @entity_404;
     }
 
     location ~ ^/(en|uk)/genres/[^/]+/?$ {
         add_header X-SEO-Render $seo_render_tag always;
-        try_files $ssg_file @spa;
+        try_files $ssg_file @entity_404;
     }
 
     location ~ ^/(en|uk)/(books|authors|genres|about|blog)/?$ {
@@ -219,7 +219,7 @@ server {
 
     location ~ ^/(en|uk)/blog/[^/]+/?$ {
         add_header X-SEO-Render $seo_render_tag always;
-        try_files $ssg_file @spa;
+        try_files $ssg_file @entity_404;
     }
 
     # Country-targeted landing pages — English-only (SEO targets EN-learners)
@@ -247,6 +247,15 @@ server {
         }
         add_header X-SEO-Render "spa" always;
         try_files /index.html =404;
+    }
+
+    # Entity detail 404 — missing book/author/genre/blog slug.
+    # SSG rebuilds on every publish, so a missing SSG file ≈ missing entity.
+    # Returns real 404 to both users and bots, preventing soft-404s.
+    location @entity_404 {
+        add_header X-SEO-Render "404" always;
+        add_header X-Robots-Tag "noindex" always;
+        return 404 '<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="robots" content="noindex"><title>404 — Not Found</title></head><body><h1>404 — Page Not Found</h1><p><a href="/">Home</a></p></body></html>';
     }
 
     # Catch-all: SPA routes without SSG (no noindex — let Google decide)


### PR DESCRIPTION
## Summary

- Currently `/en/books/unknown-slug/` returns HTTP 200 + SPA shell to users — Google classifies as Soft 404.
- `@spa` already 404s for bots (commit 552e075) but users still see shell.
- Split 4 detail-route locations (books, authors, genres, blog) to fall back to new `@entity_404` named location that returns real 404 for everyone.
- List pages and homepage keep `@spa` behavior.

## Trade-off accepted per plan review

Newly-published book returns 404 for the brief window between publish and SSG rebuild. Acceptable — SSG rebuilds on every publish.

## ⚠️ Manual step after merge

Same as P0/P1a: `make nginx-setup && sudo nginx -t && sudo systemctl reload nginx` on prod.

## Test plan

- [ ] Deploy + sync nginx.
- [ ] `curl -sI https://textstack.app/en/books/totally-fake-slug-zzz/` → **HTTP 404**.
- [ ] `curl -sI https://textstack.app/en/authors/nope-zzz/` → **HTTP 404**.
- [ ] `curl -sI https://textstack.app/en/genres/zzz/` → **HTTP 404**.
- [ ] `curl -sI https://textstack.app/en/books/dracula/` → **HTTP 200** (still works).
- [ ] `curl -sI https://textstack.app/en/books/` → **HTTP 200** (list page unaffected).
- [ ] `curl -sI https://textstack.app/en/` → **HTTP 200** (homepage unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)