### PR TITLE
fix(seo): P1c — drop UK from sitemaps (no UK content yet)

### DIFF
--- a/backend/src/Api/Endpoints/SeoEndpoints.cs
+++ b/backend/src/Api/Endpoints/SeoEndpoints.cs
@@ -209,8 +209,9 @@ public static class SeoEndpoints
         if (!site.SitemapEnabled)
             return Results.NotFound();
 
+        // UK blog posts excluded until UK content ships (see GetPagesSitemap note).
         var posts = await db.BlogPosts
-            .Where(p => p.SiteId == site.SiteId && p.Status == BlogPostStatus.Published)
+            .Where(p => p.SiteId == site.SiteId && p.Status == BlogPostStatus.Published && p.Language == "en")
             .OrderByDescending(p => p.PublishedAt)
             .Select(p => new { p.Slug, p.Language, p.UpdatedAt })
             .ToListAsync(ct);
@@ -244,8 +245,10 @@ public static class SeoEndpoints
         var baseUrl = CanonicalUrlBuilder.GetCanonicalBase(site.PrimaryDomain);
         var today = DateTime.UtcNow.ToString("yyyy-MM-dd");
 
-        // Static pages for each supported language
-        var languages = new[] { "en", "uk" };
+        // Static pages for each supported language.
+        // UK dropped until UK content ships — sitemap advertising empty /uk/ pages
+        // caused Ahrefs to report thin-content warnings.
+        var languages = new[] { "en" };
         var listPages = new[] { "books", "authors", "genres", "about", "blog" };
 
         var sb = new StringBuilder();

--- a/backend/src/Application/Seo/SeoService.cs
+++ b/backend/src/Application/Seo/SeoService.cs
@@ -10,9 +10,10 @@ public class SeoService(IAppDbContext db)
 {
     public async Task<List<SitemapBookDto>> GetBooksForSitemapAsync(Guid siteId, CancellationToken ct)
     {
-        // Get all published, indexable editions with their Work's other editions
+        // Get all published, indexable editions with their Work's other editions.
+        // UK excluded until UK content ships (see GetPagesSitemap).
         var editions = await db.Editions
-            .Where(e => e.SiteId == siteId && e.Status == EditionStatus.Published && e.Indexable)
+            .Where(e => e.SiteId == siteId && e.Status == EditionStatus.Published && e.Indexable && e.Language == "en")
             .Include(e => e.Work)
                 .ThenInclude(w => w.Editions.Where(oe => oe.Status == EditionStatus.Published && oe.Indexable))
             .OrderByDescending(e => e.UpdatedAt)


### PR DESCRIPTION
## Summary

Ahrefs reported thin-content warnings on `/uk/*` — sitemap advertised UK homepage + list pages + books + blog posts but the locale has zero real content. Zombie pages hurt site authority.

Changes:
- `SeoEndpoints.GetPagesSitemap`: `languages` array `["en", "uk"]` → `["en"]`
- `SeoEndpoints.GetBlogSitemap`: filter `p.Language == "en"`
- `SeoService.GetBooksForSitemapAsync`: filter `e.Language == "en"`

Authors/Genres sitemaps untouched — they already use `site.DefaultLanguage` (single language).

## Revert plan

When UK content lands, flip the three filters (`"en"` → in-locale array) and add a `SupportedSitemapLanguages` constant if more locales follow.

## Test plan

- [ ] `dotnet test tests/TextStack.IntegrationTests --filter Sitemap` stays green.
- [ ] After deploy: `curl -s https://textstack.app/sitemaps/pages.xml | grep -c '/uk/'` → **0**.
- [ ] `curl -s https://textstack.app/sitemaps/books.xml | grep -c '/uk/'` → **0**.
- [ ] `curl -s https://textstack.app/sitemaps/blog.xml | grep -c '/uk/'` → **0**.
- [ ] Book count in sitemap drops from 159 → possibly 156 (P3 may be auto-resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)