### PR TITLE
fix(seo): P0.5 — prerender diagnostics + SSG validation + selector fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,6 +94,49 @@ jobs:
           grep -q 'map.*is_bot' /etc/nginx/sites-available/textstack || { echo "FAIL: bot map missing from nginx"; exit 1; }
           echo "Bot map found in nginx config"
 
+      - name: Wait for SSG rebuild to complete
+        run: |
+          # Queue SSG rebuild step is async. Poll until the job finishes
+          # (files get atomic-swapped by ssg-worker into $PROJECT_DIR/data/ssg).
+          SSG_DIR=$PROJECT_DIR/data/ssg
+          [ -d "$SSG_DIR" ] || { echo "No SSG dir yet — skipping wait"; exit 0; }
+
+          DEADLINE=$(( $(date +%s) + 600 ))  # 10 min max
+          SENTINEL="$SSG_DIR/en/books/dracula/index.html"
+          until [ -f "$SENTINEL" ] && [ "$(find "$SENTINEL" -mmin -15)" ]; do
+            [ "$(date +%s)" -ge "$DEADLINE" ] && { echo "Timeout waiting for SSG rebuild"; exit 0; }
+            echo "Waiting for SSG rebuild… ($(date))"
+            sleep 30
+          done
+          echo "SSG rebuild complete"
+
+      - name: Validate SSG content
+        run: |
+          # Catch skeleton-only SSG files (empty <h1>, only skeleton divs). Silent-save bug
+          # from before P0.5 left 247 stale shells on disk for 3 months.
+          SSG_DIR=$PROJECT_DIR/data/ssg
+          [ -d "$SSG_DIR" ] || { echo "SSG dir missing: $SSG_DIR (skipping — first deploy)"; exit 0; }
+
+          TOTAL=$(find "$SSG_DIR" -name index.html | wc -l)
+          [ "$TOTAL" -eq 0 ] && { echo "No SSG files yet (rebuild pending) — skip"; exit 0; }
+
+          BAD=0
+          SAMPLES=""
+          while IFS= read -r f; do
+            # Must have a real H1, and must not end with a bare skeleton div
+            if ! grep -q '<h1' "$f" || grep -q '__skeleton"></div></div></div>$' "$f"; then
+              BAD=$((BAD + 1))
+              [ "$BAD" -le 3 ] && SAMPLES="$SAMPLES\n  $f"
+            fi
+          done < <(find "$SSG_DIR" -name index.html)
+
+          echo "SSG files: $TOTAL, bad: $BAD"
+          if [ "$BAD" -gt 0 ]; then
+            printf "FAIL: %d SSG files lack <h1> or are skeleton-only. Samples:%b\n" "$BAD" "$SAMPLES"
+            exit 1
+          fi
+          echo "SSG content validation passed"
+
           echo "All SEO checks passed"
 
       - name: Restart systemd pollers

--- a/apps/web/scripts/prerender.mjs
+++ b/apps/web/scripts/prerender.mjs
@@ -235,6 +235,21 @@ async function renderRoute(browser, routeObj) {
   const page = await browser.newPage();
   const startTime = Date.now();
 
+  // Capture diagnostics for timeout reporting
+  const consoleMessages = [];
+  const failedRequests = [];
+  page.on('console', msg => {
+    const type = msg.type();
+    if (type === 'error' || type === 'warning') {
+      consoleMessages.push(`[${type}] ${msg.text()}`);
+    }
+  });
+  page.on('pageerror', err => consoleMessages.push(`[pageerror] ${err.message}`));
+  page.on('requestfailed', req => failedRequests.push(`${req.method()} ${req.url()} — ${req.failure()?.errorText || 'unknown'}`));
+  page.on('response', res => {
+    if (res.status() >= 400) failedRequests.push(`HTTP ${res.status()} ${res.url()}`);
+  });
+
   try {
     // Set viewport for consistent rendering
     await page.setViewport({ width: 1280, height: 800 });
@@ -275,22 +290,40 @@ async function renderRoute(browser, routeObj) {
       }
 
       // Check if still loading (skeleton visible)
-      const skeleton = document.querySelector('.book-detail__skeleton, .books-grid__skeleton, .author-detail__skeleton, .genre-detail__skeleton');
+      const skeleton = document.querySelector('.book-detail__skeleton, .books-grid__skeleton, .author-detail__skeleton, .author-detail__header--skeleton, .genre-detail__skeleton');
       if (skeleton) return 'skeleton';
 
-      // Check for loaded content
-      const bookDetail = document.querySelector('.book-detail__header h1');
+      // Check for loaded content (match H1 tags specifically, not shared skeleton classes)
+      const bookDetail = document.querySelector('h1.book-hero__title, .book-detail__header h1');
       const booksList = document.querySelector('.books-grid .book-card:not(.book-card--skeleton)');
-      const authorDetail = document.querySelector('.author-detail__name');
-      const genreDetail = document.querySelector('.genre-detail__title');
+      const authorDetail = document.querySelector('h1.author-detail__name');
+      const genreDetail = document.querySelector('h1.genre-detail__title, .genre-detail__title');
       const staticPage = document.querySelector('.about-page, .static-content, main h1');
+      const homePage = document.querySelector('.home-hero__title');
+      const listPage = document.querySelector('.authors-page h1, .genres-page h1, .blog-page h1');
 
-      if (bookDetail || booksList || authorDetail || genreDetail || staticPage) {
+      if (bookDetail || booksList || authorDetail || genreDetail || staticPage || homePage || listPage) {
         return 'content';
       }
 
       return null; // Keep waiting
     }, { timeout: 5000 }).then(h => h?.jsonValue()).catch(() => 'timeout');
+
+    // Fail loudly on timeout or skeleton — previously we silently saved empty shells,
+    // producing 247 SSG files with no H1, canonical, or og:image. Bots got nothing.
+    if (renderState === 'timeout' || renderState === 'skeleton') {
+      const bodySnippet = await page.evaluate(() => {
+        const root = document.querySelector('#root');
+        return (root?.innerHTML || document.body?.innerHTML || '').slice(0, 500);
+      }).catch(() => '<unavailable>');
+      const diag = [
+        `renderState=${renderState}`,
+        `console: ${consoleMessages.slice(-10).join(' | ') || '<none>'}`,
+        `failedRequests: ${failedRequests.slice(-10).join(' | ') || '<none>'}`,
+        `bodySnippet: ${bodySnippet.replace(/\s+/g, ' ')}`,
+      ].join('\n    ');
+      throw new Error(`prerender failed for ${route}\n    ${diag}`);
+    }
 
     // Small stabilization delay for successful content
     if (renderState === 'content') {


### PR DESCRIPTION
## Summary
- **Root cause**: `prerender.mjs` swallowed its 5s `waitForFunction` timeout (`.catch(() => 'timeout')`) and silently wrote skeleton HTML. 247 SSG files on prod stale from **Jan 22, 2026** (3 months).
- **Selector drift**: `waitForFunction` looked for `.book-detail__header h1` which no longer exists (React uses `.book-hero__title`). List pages (homepage, authors, genres, blog) had no matching selectors at all.
- **Silent-save fixed**: throw on timeout with console, failed requests, and `#root` body snippet diagnostics. Pages that can't render don't get written.
- **Selectors updated**: `.book-hero__title`, `.home-hero__title`, `.authors-page h1`, `.genres-page h1`, `.blog-page h1`, tightened to H1 tags to avoid matching skeleton divs sharing class names.
- **Deploy validation**: new steps wait for the async SSG rebuild (polls up to 10 min) then fail the deploy if any SSG file lacks `<h1>` or ends with a bare skeleton div.

## Local verification
- `make rebuild-ssg`: **204/204 routes succeed** (was 196/204 before the list-page selector fix, 0/204 before the `.book-hero__title` fix).
- `grep -c "Dracula" apps/web/dist/ssg/en/books/dracula/index.html` = **5** (was 0).
- SSG file size 28 KB (was ~14 KB skeleton shell).
- `og:title`, canonical, `h1.book-hero__title` all present.

## Depends on
- #81 (P0 nginx alias) — already merged.

## Test plan
- [x] Run `make rebuild-ssg` locally → 204/204 success
- [x] Verify `grep -c "Dracula"` > 0 on local dracula SSG
- [x] Verify canonical + og:title + H1 in output
- [x] Confirm prerender throws (doesn't write) when selectors fail
- [ ] After merge + deploy: watch Ahrefs crawl recover
- [ ] After deploy: verify `curl -A AhrefsBot https://textstack.app/en/books/dracula/` returns 200 with real content

🤖 Generated with [Claude Code](https://claude.com/claude-code)