### PR TITLE
hotfix(deploy): fix SSG path, auto-sync nginx, extend noindex

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,22 @@ jobs:
           cd $PROJECT_DIR
           docker compose up -d --build
 
+      - name: Sync nginx config
+        run: |
+          cd $PROJECT_DIR
+          # /etc/nginx/sites-available/textstack is vasyl:vasyl 664, so cp works
+          # without sudo. Only nginx -t and reload need sudo (passwordless via
+          # sudoers for nginx/systemctl).
+          if ! diff -q infra/nginx/textstack.conf /etc/nginx/sites-available/textstack > /dev/null 2>&1; then
+            echo "nginx config changed — syncing"
+            cp infra/nginx/textstack.conf /etc/nginx/sites-available/textstack
+            sudo nginx -t
+            sudo systemctl reload nginx
+            echo "nginx reloaded"
+          else
+            echo "nginx config unchanged — skip reload"
+          fi
+
       - name: Wait for services
         run: sleep 30
 
@@ -94,11 +110,21 @@ jobs:
           grep -q 'map.*is_bot' /etc/nginx/sites-available/textstack || { echo "FAIL: bot map missing from nginx"; exit 1; }
           echo "Bot map found in nginx config"
 
+      - name: Remove stale data/ssg directory
+        run: |
+          # Old SSG output location (Jan 2026) — mount moved to apps/web/dist/ssg
+          # but orphaned files remained and confused validation. One-time cleanup.
+          if [ -d "$PROJECT_DIR/data/ssg" ]; then
+            echo "Removing stale $PROJECT_DIR/data/ssg"
+            rm -rf "$PROJECT_DIR/data/ssg"
+          fi
+
       - name: Wait for SSG rebuild to complete
         run: |
-          # Queue SSG rebuild step is async. Poll until the job finishes
-          # (files get atomic-swapped by ssg-worker into $PROJECT_DIR/data/ssg).
-          SSG_DIR=$PROJECT_DIR/data/ssg
+          # Queue SSG rebuild step is async. Poll until the job finishes.
+          # ssg-worker bind mount: ./apps/web/dist:/app/dist, so files atomic-swapped
+          # by worker appear at $PROJECT_DIR/apps/web/dist/ssg on host.
+          SSG_DIR=$PROJECT_DIR/apps/web/dist/ssg
           [ -d "$SSG_DIR" ] || { echo "No SSG dir yet — skipping wait"; exit 0; }
 
           DEADLINE=$(( $(date +%s) + 600 ))  # 10 min max
@@ -114,7 +140,7 @@ jobs:
         run: |
           # Catch skeleton-only SSG files (empty <h1>, only skeleton divs). Silent-save bug
           # from before P0.5 left 247 stale shells on disk for 3 months.
-          SSG_DIR=$PROJECT_DIR/data/ssg
+          SSG_DIR=$PROJECT_DIR/apps/web/dist/ssg
           [ -d "$SSG_DIR" ] || { echo "SSG dir missing: $SSG_DIR (skipping — first deploy)"; exit 0; }
 
           TOTAL=$(find "$SSG_DIR" -name index.html | wc -l)

--- a/infra/nginx/textstack.conf
+++ b/infra/nginx/textstack.conf
@@ -237,7 +237,7 @@ server {
     }
 
     # Private/user routes — noindex
-    location ~ ^/(en|uk)/(library/my|settings) {
+    location ~ ^/(en|uk)/(library/my|settings|profile|highlights|practice|stats|vocabulary|reader) {
         add_header X-SEO-Render "spa" always;
         add_header X-Robots-Tag "noindex, follow" always;
         try_files $uri /index.html;


### PR DESCRIPTION
Hotfix for broken deploy pipeline + nginx drift.

## Changes

### 1. deploy.yml — SSG path correction
- \`Wait for SSG rebuild\` and \`Validate SSG content\` were looking at \`\$PROJECT_DIR/data/ssg\` — stale dir from Jan 22 with 174 skeleton shells (Jan 22, root:root).
- Real ssg-worker output lives in \`\$PROJECT_DIR/apps/web/dist/ssg\` (mount: \`./apps/web/dist:/app/dist\`).
- One-time \`rm -rf data/ssg\` step to clean up the confusing orphan.

### 2. deploy.yml — nginx auto-sync
Root cause of 3-month drift: nginx config copies to \`/etc/nginx/sites-available/textstack\` only via manual \`make nginx-setup\`. Merged PRs (P0/P1a/P1b) never landed on prod nginx.
- New step: \`diff\` repo vs installed, if drift → \`cp\` + \`sudo nginx -t\` + \`sudo systemctl reload nginx\`.
- File is vasyl:vasyl 664, so \`cp\` works without sudo. Sudoers on prod already allows passwordless \`nginx\` + \`systemctl\` (verified).

### 3. nginx — extend private-routes noindex
- Was: \`^/(en|uk)/(library/my|settings)\`
- Now: \`^/(en|uk)/(library/my|settings|profile|highlights|practice|stats|vocabulary|reader)\`
- Closes P1a (reader noindex via header — JS-only previously) + covers profile/highlights/practice/stats/vocabulary.

## Test plan (post-merge)

- [ ] deploy.yml Wait + Validate passes green
- [ ] \`curl -A "AhrefsBot/7.0" -I https://textstack.app/en/books/zzz-nonexistent/\` → HTTP/2 404 (P1b bot path)
- [ ] \`curl -I https://textstack.app/en/reader/dracula/chapter-1/\` → \`X-Robots-Tag: noindex, follow\`
- [ ] Same for /en/profile, /en/stats, /en/vocabulary, /en/highlights, /en/practice
- [ ] \`curl -I https://textstack.app/en/books/dracula/\` → empty X-Robots-Tag (public, unaffected)
- [ ] \`curl -A "AhrefsBot/7.0" -s https://textstack.app/en/books/dracula/ | grep -c Dracula\` → >0

## Out of scope
- 4 blog prerender fails (en+uk × \`learn-english-through-reading\`, \`how-to-read-books-in-a-language-youre-learning\`) — separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)