### PR TITLE
fix(seo): noindex private routes via map, drop UK sitemap, bump crypto.xml

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,6 +45,8 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.11.2" />
+    <!-- Security (override transitive for CVE fix) -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <!-- Testing -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="xunit.v3" Version="2.0.2" />

--- a/backend/src/Api/Endpoints/SeoEndpoints.cs
+++ b/backend/src/Api/Endpoints/SeoEndpoints.cs
@@ -10,6 +10,11 @@ namespace Api.Endpoints;
 
 public static class SeoEndpoints
 {
+    // Single source of truth for sitemap language filter. UK pages exist in routing
+    // but have no published content yet — excluding them prevents Google indexing
+    // near-empty pages and counting them as thin content.
+    private static readonly string[] SupportedSitemapLanguages = { "en" };
+
     public static void MapSeoEndpoints(this WebApplication app)
     {
         app.MapGet("/robots.txt", GetRobots).WithName("GetRobots").WithTags("SEO");
@@ -107,7 +112,7 @@ public static class SeoEndpoints
         sb.AppendLine("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">");
 
         // Only individual book detail pages - no homepage or list pages
-        foreach (var book in books)
+        foreach (var book in books.Where(b => SupportedSitemapLanguages.Contains(b.Language)))
         {
             var loc = CanonicalUrlBuilder.BuildSitemapUrl(site.PrimaryDomain, $"/{book.Language}/books/{book.Slug}");
             sb.AppendLine("  <url>");
@@ -211,6 +216,7 @@ public static class SeoEndpoints
 
         var posts = await db.BlogPosts
             .Where(p => p.SiteId == site.SiteId && p.Status == BlogPostStatus.Published)
+            .Where(p => SupportedSitemapLanguages.Contains(p.Language))
             .OrderByDescending(p => p.PublishedAt)
             .Select(p => new { p.Slug, p.Language, p.UpdatedAt })
             .ToListAsync(ct);
@@ -244,8 +250,8 @@ public static class SeoEndpoints
         var baseUrl = CanonicalUrlBuilder.GetCanonicalBase(site.PrimaryDomain);
         var today = DateTime.UtcNow.ToString("yyyy-MM-dd");
 
-        // Static pages for each supported language
-        var languages = new[] { "en", "uk" };
+        // Static pages for each supported language (UK dropped: no content yet)
+        var languages = SupportedSitemapLanguages;
         var listPages = new[] { "books", "authors", "genres", "about", "blog" };
 
         var sb = new StringBuilder();

--- a/backend/src/Infrastructure/Infrastructure.csproj
+++ b/backend/src/Infrastructure/Infrastructure.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/infra/nginx/textstack.conf
+++ b/infra/nginx/textstack.conf
@@ -47,6 +47,17 @@ map $is_bot $seo_render_tag {
     default spa;
 }
 
+# Private/user routes — emit X-Robots-Tag noindex. Matched in the catch-all
+# location / (not the specific one below) because try_files in the specific
+# location does an internal redirect to /index.html, which re-evaluates to
+# location / and drops add_header directives from the original location
+# (nginx inheritance rule: child with its own add_header doesn't inherit).
+# Empty default → nginx omits the header.
+map $uri $private_route_robots {
+    default                                                                                     "";
+    "~*^/(en|uk)/(library/my|settings|profile|highlights|practice|stats|vocabulary|reader)"      "noindex, follow";
+}
+
 # Upstream for API (Docker container on localhost only)
 upstream textstack_api {
     server 127.0.0.1:8080;
@@ -236,13 +247,6 @@ server {
         try_files $ssg_file @spa;
     }
 
-    # Private/user routes — noindex
-    location ~ ^/(en|uk)/(library/my|settings|profile|highlights|practice|stats|vocabulary|reader) {
-        add_header X-SEO-Render "spa" always;
-        add_header X-Robots-Tag "noindex, follow" always;
-        try_files $uri /index.html;
-    }
-
     # SPA fallback for SSG blocks
     # When SSG file missing: users get SPA, bots get proper HTTP 404.
     # This prevents Google "Soft 404" — bots were getting SPA shell (HTTP 200)
@@ -254,12 +258,15 @@ server {
             return 404 '<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="robots" content="noindex"><title>Not Found</title></head><body><h1>404 — Page Not Found</h1></body></html>';
         }
         add_header X-SEO-Render "spa" always;
+        add_header X-Robots-Tag $private_route_robots always;
         try_files /index.html =404;
     }
 
-    # Catch-all: SPA routes without SSG (no noindex — let Google decide)
+    # Catch-all: SPA routes without SSG. Private/user routes (reader, stats, …)
+    # land here and pick up X-Robots-Tag via the $private_route_robots map.
     location / {
         add_header X-SEO-Render "spa" always;
+        add_header X-Robots-Tag $private_route_robots always;
         try_files $uri /index.html;
     }
 

--- a/tests/TextStack.IntegrationTests/SitemapEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/SitemapEndpointTests.cs
@@ -461,7 +461,8 @@ public class SitemapEndpointTests : IClassFixture<LiveApiFixture>
         var locs = doc.Descendants(SitemapNs + "loc").Select(e => e.Value).ToList();
 
         Assert.Contains(locs, loc => loc.EndsWith("/en/"));
-        Assert.Contains(locs, loc => loc.EndsWith("/uk/"));
+        // UK dropped from pages sitemap until UK has real content — SupportedSitemapLanguages filter
+        Assert.DoesNotContain(locs, loc => loc.EndsWith("/uk/"));
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Three-in-one hotfix closing the P1a + P1c gaps on prod and patching a high-severity CVE.

### 1. nginx `X-Robots-Tag` actually fires for private routes
Prior block `location ~ ^/(en|uk)/(library/my|...|reader)` emitted `X-Robots-Tag` but it was dropped on every request because `try_files $uri /index.html` performs an internal redirect → nginx re-evaluates the location → lands in `location /` → per nginx inheritance rule, the child's own `add_header` replaces (not merges with) the parent's, so our header vanished.

Fix:
- New `map $uri $private_route_robots` (empty default, `"noindex, follow"` for private URIs).
- `add_header X-Robots-Tag $private_route_robots always` in `location /` and `location @spa`.
- Removed the broken standalone block.
Empty map value → nginx omits the header entirely for non-matching URIs.

### 2. P1c — drop UK from all sitemaps
New `SupportedSitemapLanguages = ["en"]` as single source of truth, applied to:
- `GetPagesSitemap` — homepage + list-pages loops
- `GetBooksSitemap` — `.Where(b => Supported.Contains(b.Language))`
- `GetBlogSitemap` — SQL filter at the EF level
Prevents Google from indexing near-empty UK pages and flagging as thin content. Re-enable by adding `"uk"` to the array when UK has real content.

### 3. CVE: `System.Security.Cryptography.Xml` 9.0.0 → 10.0.6
Transitive dep via `Microsoft.EntityFrameworkCore.Design` 10.0.0 → `Microsoft.Build.Tasks.Core`. High-sev advisories GHSA-37gx-xxp4-5rgx + GHSA-w3x6-4m5h-cxqf. Override by adding top-level `PackageVersion` (Directory.Packages.props) and direct `PackageReference` in `Infrastructure.csproj` (Worker inherits via project reference).

Verified `dotnet list ... --vulnerable` now reports "no vulnerable packages".

## Test plan

- [ ] CI green (backend build + format + migrations + integration + e2e)
- [ ] Post-deploy (origin, bypass CF):
  ```bash
  ssh asus "curl -sI -H 'Host: textstack.app' http://localhost/en/reader/dracula/chapter-1/ | grep -i x-robots-tag"
  # expect: X-Robots-Tag: noindex, follow
  ```
- [ ] Post-deploy public:
  ```bash
  curl -s https://textstack.app/sitemaps/pages.xml | grep -c '/uk/'    # expect 0
  curl -s https://textstack.app/sitemaps/books.xml | grep -c '/uk/'    # expect 0
  curl -s https://textstack.app/sitemaps/blog.xml | grep -c '/uk/'     # expect 0
  curl -sI https://textstack.app/en/books/dracula/ -A AhrefsBot | grep -i x-seo-render  # expect: ssg (regression check)
  ```
- [ ] `dotnet list backend/src/Infrastructure package --include-transitive --vulnerable` on deployed runner → "no vulnerable packages"

🤖 Generated with [Claude Code](https://claude.com/claude-code)