### PR TITLE
fix(seo): noindex map uses $request_uri + og:image via /storage/

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           cd $PROJECT_DIR/apps/web
           pnpm install
-          VITE_API_URL=/api VITE_CANONICAL_URL=https://textstack.app pnpm build
+          VITE_API_URL=/api VITE_STORAGE_URL=https://textstack.app VITE_CANONICAL_URL=https://textstack.app pnpm build
 
       - name: Deploy containers
         run: |

--- a/infra/nginx/textstack.conf
+++ b/infra/nginx/textstack.conf
@@ -47,13 +47,12 @@ map $is_bot $seo_render_tag {
     default spa;
 }
 
-# Private/user routes — emit X-Robots-Tag noindex. Matched in the catch-all
-# location / (not the specific one below) because try_files in the specific
-# location does an internal redirect to /index.html, which re-evaluates to
-# location / and drops add_header directives from the original location
-# (nginx inheritance rule: child with its own add_header doesn't inherit).
+# Private/user routes — emit X-Robots-Tag noindex. Key on $request_uri (not
+# $uri) because try_files in location / does internal redirect to /index.html,
+# which rewrites $uri — $request_uri keeps the original. Matched in both
+# location / and location @spa (the two terminal branches).
 # Empty default → nginx omits the header.
-map $uri $private_route_robots {
+map $request_uri $private_route_robots {
     default                                                                                     "";
     "~*^/(en|uk)/(library/my|settings|profile|highlights|practice|stats|vocabulary|reader)"      "noindex, follow";
 }


### PR DESCRIPTION
## Summary

Two post-deploy regressions observed after #87 landed:

### 1. `X-Robots-Tag` still missing on private routes (P1a)
#87 introduced `map $uri $private_route_robots` but `try_files $uri /index.html` in `location /` performs an internal redirect that rewrites `$uri` → `/index.html`. Variables in `add_header` are evaluated at response generation time, by which point the map key has already changed — so it returns the empty default and nginx omits the header.

Fix: key the map on `$request_uri` (the original URI, never rewritten).

Verified locally: regex still anchors at `^/(en|uk)/...`, which matches the raw request URI the same way. Query strings tolerated by `~*^`.

### 2. `og:image` points to rate-limited `/api/storage/` (P2)
`apps/web/src/api/client.ts:5`:
```ts
const STORAGE_BASE = import.meta.env.VITE_STORAGE_URL || API_BASE
```
Deploy sets `VITE_API_URL=/api` but never set `VITE_STORAGE_URL` → `STORAGE_BASE = '/api'` → `og:image = https://textstack.app/api/storage/<id>/cover.jpg` (falls under `api_limit` zone 10r/s).

Fix: set `VITE_STORAGE_URL=https://textstack.app` in `deploy.yml` frontend build step. Storage URL now uses the canonical domain directly and hits nginx `location /storage/` (no rate limit).

Absolute URL is also what Open Graph requires — social scrapers won't resolve a path-relative `/storage/...`.

## Test plan
Post-deploy, origin + public:
```bash
ssh asus "curl -sI -H 'Host: textstack.app' http://localhost/en/reader/dracula/chapter-1/ | grep -i x-robots-tag"
# expect: X-Robots-Tag: noindex, follow

curl -s -A AhrefsBot https://textstack.app/en/books/dracula/ | grep -oE 'og:image" [^>]{0,150}'
# expect: og:image" ... content="https://textstack.app/storage/..."

curl -sI https://textstack.app/storage/<some-edition-id>/cover.jpg | head -1
# expect: HTTP/2 200 (no 429)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)