### PR TITLE
fix(ssg): detect BlogPostPage H1 so prerender doesn't timeout

### DIFF
--- a/apps/web/scripts/prerender.mjs
+++ b/apps/web/scripts/prerender.mjs
@@ -298,11 +298,12 @@ async function renderRoute(browser, routeObj) {
       const booksList = document.querySelector('.books-grid .book-card:not(.book-card--skeleton)');
       const authorDetail = document.querySelector('h1.author-detail__name');
       const genreDetail = document.querySelector('h1.genre-detail__title, .genre-detail__title');
+      const blogDetail = document.querySelector('h1.blog-post__title');
       const staticPage = document.querySelector('.about-page, .static-content, main h1');
       const homePage = document.querySelector('.home-hero__title');
       const listPage = document.querySelector('.authors-page h1, .genres-page h1, .blog-page h1');
 
-      if (bookDetail || booksList || authorDetail || genreDetail || staticPage || homePage || listPage) {
+      if (bookDetail || booksList || authorDetail || genreDetail || blogDetail || staticPage || homePage || listPage) {
         return 'content';
       }
 


### PR DESCRIPTION
## Summary

4 blog detail routes were failing every SSG rebuild with \`renderState=timeout\`:
- \`/en/blog/learn-english-through-reading/\`
- \`/en/blog/how-to-read-books-in-a-language-youre-learning/\`
- \`/uk/blog/...\` (×2)

Root cause: \`prerender.mjs\` \`waitForFunction\` checked for book/author/genre/home/list/static content selectors but had nothing for blog detail. The H1 on \`BlogPostPage\` is \`h1.blog-post__title\`, not covered by any existing selector, so the page loaded successfully but the detector returned \`null\` forever → 5s timeout → \`throw\` → failure logged.

Fix: add \`h1.blog-post__title\` as a content signal alongside the others.

## Test plan
- [ ] CI green
- [ ] After deploy + SSG rebuild, all blog routes render:
  ```bash
  curl -s -A AhrefsBot https://textstack.app/en/blog/learn-english-through-reading/ | grep -c blog-post__title
  # expect: >= 1
  ```
- [ ] SSG rebuild job shows 0 blog failures (check admin SSG Rebuild page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)