### PR TITLE
fix(seo): detect AhrefsSiteAudit UA; noindex chapter reader routes

### DIFF
--- a/infra/nginx/textstack.conf
+++ b/infra/nginx/textstack.conf
@@ -9,6 +9,9 @@ limit_req_zone $binary_remote_addr zone=upload_limit:10m rate=1r/s;
 limit_req_zone $binary_remote_addr zone=translate_limit:10m rate=5r/m;
 
 # Bot detection — serve SSG only to crawlers, SPA to real users
+# NOTE: ~*ahrefs intentionally broad — covers AhrefsBot AND AhrefsSiteAudit/X.X
+# (the latter does NOT contain "bot" substring, so the generic ~*bot fallback
+# below misses it). Same reasoning for ~*siteaudit / ~*audit.
 map $http_user_agent $is_bot {
     default                     0;
     ~*googlebot                 1;
@@ -22,13 +25,21 @@ map $http_user_agent $is_bot {
     ~*slurp                     1;
     ~*applebot                  1;
     ~*semrushbot                1;
-    ~*ahrefsbot                 1;
+    ~*ahrefs                    1;
+    ~*siteaudit                 1;
+    ~*screaming.?frog           1;
+    ~*bytespider                1;
+    ~*pingdom                   1;
+    ~*gtmetrix                  1;
+    ~*lighthouse                1;
     ~*mj12bot                   1;
     ~*dotbot                    1;
     ~*petalbot                  1;
     ~*sogou                     1;
     ~*crawl                     1;
     ~*spider                    1;
+    ~*scanner                   1;
+    ~*audit                     1;
     ~*bot                       1;
     ~*Google-InspectionTool     1;
 }
@@ -52,9 +63,15 @@ map $is_bot $seo_render_tag {
 # which rewrites $uri — $request_uri keeps the original. Matched in both
 # location / and location @spa (the two terminal branches).
 # Empty default → nginx omits the header.
+#
+# Chapter reader routes (/books/{slug}/{chapter}, /books/{slug}/focus/{chapter})
+# are SPA-only (no SSG) and would otherwise be indexed as thin-content duplicates.
+# Pattern `[^/]+/[^/?#]+` requires a second non-root segment so it does NOT
+# match book detail pages (`/books/{slug}/`) which ARE SSG-rendered.
 map $request_uri $private_route_robots {
     default                                                                                     "";
     "~*^/(en|uk)/(library/my|settings|profile|highlights|practice|stats|vocabulary|reader)"      "noindex, follow";
+    "~*^/(en|uk)/books/[^/]+/[^/?#]+"                                                            "noindex, follow";
 }
 
 # Upstream for API (Docker container on localhost only)


### PR DESCRIPTION
## Summary

Two Ahrefs Site Audit findings reproduced in `main` and fixed in `infra/nginx/textstack.conf`:

- **Bot UA miss:** `AhrefsSiteAudit/7.0` wasn't detected as bot (no "bot" substring). Widened `~*ahrefsbot` → `~*ahrefs` and added `~*siteaudit`, `~*audit`, plus common SEO scanners (Screaming Frog, Bytespider, Pingdom, GTmetrix, Lighthouse)
- **Chapter URLs indexable:** `/books/{slug}/{chapter}` fell through to catch-all `location /` without noindex. ~844 thin-content SPA shells in Google index (matches Ahrefs H1-missing count). Added `^/(en|uk)/books/[^/]+/[^/?#]+` to `\$private_route_robots` map → `X-Robots-Tag: noindex, follow`

Book detail pages (`/books/{slug}/`) remain SSG-rendered — pattern requires second path segment.

## Test plan

- [ ] After deploy, `curl -sI -H "User-Agent: AhrefsSiteAudit/7.0" https://textstack.app/en/books/dracula/ | grep X-SEO-Render` → `ssg`
- [ ] `curl -sI https://textstack.app/en/books/dracula/chapter-1/ | grep X-Robots-Tag` → `noindex, follow`
- [ ] `curl -sI "https://textstack.app/en/books/dracula/chapter-1/?direct=1" | grep X-Robots-Tag` → `noindex, follow`
- [ ] `curl -sI https://textstack.app/en/books/dracula/ | grep X-Robots-Tag` → no header (book detail stays indexable)
- [ ] Trigger Ahrefs re-crawl; expect ~844 "H1 missing" errors drop
