### PR TITLE
seo: Ahrefs bot detection + chapter noindex + reusable Breadcrumbs

### DIFF
--- a/apps/web/src/components/Breadcrumbs.tsx
+++ b/apps/web/src/components/Breadcrumbs.tsx
@@ -1,0 +1,105 @@
+import { LocalizedLink } from './LocalizedLink'
+import { JsonLd } from './JsonLd'
+import { useLanguage } from '../context/LanguageContext'
+import { useSite } from '../context/SiteContext'
+import { useTranslation } from '../hooks/useTranslation'
+import { getCanonicalOrigin, buildCanonicalUrl } from '../lib/canonicalUrl'
+
+export interface BreadcrumbItem {
+  /** Display label */
+  label: string
+  /**
+   * Path WITHOUT language prefix (e.g. "/books", "/authors/tolstoy").
+   * Omit for the current-page item (always the last one) — it will render
+   * as plain text with aria-current="page".
+   */
+  to?: string
+}
+
+interface BreadcrumbsProps {
+  /** Items between Home and the current page. Order: parent → child. */
+  items: BreadcrumbItem[]
+  /** Auto-prepend a Home root item. Default: true. */
+  includeHome?: boolean
+}
+
+/**
+ * Renders visual breadcrumb nav AND emits BreadcrumbList JSON-LD for SEO.
+ *
+ * - Visual uses the existing `.breadcrumbs` styles (apps/web/src/styles/books.css).
+ * - JSON-LD omits `item` on the last entry per schema.org BreadcrumbList spec
+ *   (last item is the current page and doesn't need a URL).
+ * - URLs in JSON-LD are absolute (origin + lang prefix + path) so Google can
+ *   resolve them regardless of where the page is crawled from.
+ *
+ * Usage:
+ *   <Breadcrumbs items={[
+ *     { label: t('breadcrumbs.books'), to: '/books' },
+ *     { label: 'Horror', to: '/genres/horror' },
+ *     { label: book.title }, // no `to` → current page
+ *   ]} />
+ */
+export function Breadcrumbs({ items, includeHome = true }: BreadcrumbsProps) {
+  const { language } = useLanguage()
+  const { site } = useSite()
+  const { t } = useTranslation()
+  const canonicalOrigin = getCanonicalOrigin(site?.primaryDomain)
+
+  const allItems: BreadcrumbItem[] = includeHome
+    ? [{ label: t('breadcrumbs.home'), to: '/' }, ...items]
+    : items
+
+  const buildItemUrl = (to: string): string => {
+    // Home: "/" → "/{lang}"; other paths: "/{lang}{to}"
+    const pathname = to === '/' ? `/${language}` : `/${language}${to}`
+    return buildCanonicalUrl({ origin: canonicalOrigin, pathname })
+  }
+
+  return (
+    <>
+      <nav className="breadcrumbs" aria-label="Breadcrumb">
+        <ol>
+          {allItems.map((item, idx) => {
+            const isLast = idx === allItems.length - 1
+            if (isLast) {
+              return (
+                <li key={idx} aria-current="page">
+                  {item.label}
+                </li>
+              )
+            }
+            return (
+              <li key={idx}>
+                {item.to ? (
+                  <LocalizedLink to={item.to}>{item.label}</LocalizedLink>
+                ) : (
+                  <span>{item.label}</span>
+                )}
+              </li>
+            )
+          })}
+        </ol>
+      </nav>
+      <JsonLd
+        data={{
+          '@context': 'https://schema.org',
+          '@type': 'BreadcrumbList',
+          itemListElement: allItems.map((item, idx) => {
+            const isLast = idx === allItems.length - 1
+            const entry: Record<string, unknown> = {
+              '@type': 'ListItem',
+              position: idx + 1,
+              name: item.label,
+            }
+            // Per schema.org spec, the last item (current page) may omit `item`.
+            // For others, include the absolute URL so Google can follow.
+            if (!isLast && item.to) {
+              entry.item = buildItemUrl(item.to)
+            }
+            return entry
+          }),
+        }}
+      />
+    </>
+  )
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -760,7 +760,10 @@
   },
   "breadcrumbs": {
     "home": "Home",
-    "books": "Books"
+    "books": "Books",
+    "authors": "Authors",
+    "genres": "Genres",
+    "blog": "Blog"
   },
   "tts": {
     "listen": "Listen",

--- a/apps/web/src/locales/uk.json
+++ b/apps/web/src/locales/uk.json
@@ -760,7 +760,10 @@
   },
   "breadcrumbs": {
     "home": "Головна",
-    "books": "Книги"
+    "books": "Книги",
+    "authors": "Автори",
+    "genres": "Жанри",
+    "blog": "Блог"
   },
   "tts": {
     "listen": "Прослухати",

--- a/apps/web/src/pages/AuthorDetailPage.tsx
+++ b/apps/web/src/pages/AuthorDetailPage.tsx
@@ -5,10 +5,12 @@ import { getStorageUrl } from '../api/client'
 import { LocalizedLink } from '../components/LocalizedLink'
 import { SeoHead } from '../components/SeoHead'
 import { JsonLd } from '../components/JsonLd'
+import { Breadcrumbs } from '../components/Breadcrumbs'
 import { Footer } from '../components/Footer'
 import { useLanguage } from '../context/LanguageContext'
 import { useSite } from '../context/SiteContext'
-import { getCanonicalOrigin } from '../lib/canonicalUrl'
+import { useTranslation } from '../hooks/useTranslation'
+import { getCanonicalOrigin, buildCanonicalUrl } from '../lib/canonicalUrl'
 import { ShareButtons } from '../components/ShareButtons'
 import {
   generateAboutText,
@@ -24,6 +26,7 @@ export function AuthorDetailPage() {
   const { slug } = useParams<{ slug: string }>()
   const { language } = useLanguage()
   const { site } = useSite()
+  const { t } = useTranslation()
   const canonicalOrigin = getCanonicalOrigin(site?.primaryDomain)
   const api = useApi()
   const [author, setAuthor] = useState<AuthorDetail | null>(null)
@@ -122,9 +125,20 @@ export function AuthorDetailPage() {
           '@type': 'Person',
           name: author.name,
           description: author.bio || undefined,
-          image: author.photoPath ? getStorageUrl(author.photoPath) : undefined,
-          url: window.location.href,
+          image: author.photoPath ? (() => {
+            const url = getStorageUrl(author.photoPath)
+            return url?.startsWith('http') ? url : `${canonicalOrigin}${url}`
+          })() : undefined,
+          url: buildCanonicalUrl({ origin: canonicalOrigin, pathname: `/${language}/authors/${author.slug}` }),
         }}
+      />
+
+      {/* Breadcrumbs: Home → Authors → Author Name */}
+      <Breadcrumbs
+        items={[
+          { label: t('breadcrumbs.authors'), to: '/authors' },
+          { label: author.name },
+        ]}
       />
 
       <div className="author-detail__header">

--- a/apps/web/src/pages/BlogPostPage.tsx
+++ b/apps/web/src/pages/BlogPostPage.tsx
@@ -4,6 +4,7 @@ import { getBlogPost, likeBlogPost, unlikeBlogPost, type BlogPostDetailDto } fro
 import { getStorageUrl } from '../api/client'
 import { SeoHead } from '../components/SeoHead'
 import { JsonLd } from '../components/JsonLd'
+import { Breadcrumbs } from '../components/Breadcrumbs'
 import { Footer } from '../components/Footer'
 import { ShareButtons } from '../components/blog/ShareButtons'
 import { BlogComments } from '../components/blog/BlogComments'
@@ -143,6 +144,14 @@ export function BlogPostPage() {
             datePublished: post.publishedAt || undefined,
             inLanguage: post.language,
           }}
+        />
+
+        {/* Breadcrumbs: Home → Blog → Post Title */}
+        <Breadcrumbs
+          items={[
+            { label: t('breadcrumbs.blog'), to: '/blog' },
+            { label: post.title },
+          ]}
         />
 
         <LocalizedLink to="/blog" className="blog-post__back">

--- a/apps/web/src/pages/BookDetailPage.tsx
+++ b/apps/web/src/pages/BookDetailPage.tsx
@@ -10,6 +10,7 @@ import { useSite } from '../context/SiteContext'
 import { LocalizedLink } from '../components/LocalizedLink'
 import { SeoHead } from '../components/SeoHead'
 import { JsonLd } from '../components/JsonLd'
+import { Breadcrumbs } from '../components/Breadcrumbs'
 import { Footer } from '../components/Footer'
 import { stringToColor } from '../utils/colors'
 import { getCachedBookMeta } from '../lib/offlineDb'
@@ -211,28 +212,15 @@ export function BookDetailPage() {
         }}
       />
 
-      {/* Breadcrumbs */}
-      <nav className="breadcrumbs" aria-label="Breadcrumb">
-        <ol>
-          <li><LocalizedLink to="/">{t('breadcrumbs.home')}</LocalizedLink></li>
-          <li><LocalizedLink to="/books">{t('breadcrumbs.books')}</LocalizedLink></li>
-          {genres.length > 0 && (
-            <li><LocalizedLink to={`/genres/${genres[0].slug}`}>{genres[0].name}</LocalizedLink></li>
-          )}
-          <li aria-current="page">{book.title}</li>
-        </ol>
-      </nav>
-      <JsonLd
-        data={{
-          '@context': 'https://schema.org',
-          '@type': 'BreadcrumbList',
-          itemListElement: [
-            { '@type': 'ListItem', position: 1, name: t('breadcrumbs.home'), item: buildCanonicalUrl({ origin: canonicalOrigin, pathname: `/${language}` }) },
-            { '@type': 'ListItem', position: 2, name: t('breadcrumbs.books'), item: buildCanonicalUrl({ origin: canonicalOrigin, pathname: `/${language}/books` }) },
-            ...(genres.length > 0 ? [{ '@type': 'ListItem', position: 3, name: genres[0].name, item: buildCanonicalUrl({ origin: canonicalOrigin, pathname: `/${language}/genres/${genres[0].slug}` }) }] : []),
-            { '@type': 'ListItem', position: genres.length > 0 ? 4 : 3, name: book.title },
-          ],
-        }}
+      {/* Breadcrumbs: Home → Books → [Genre if present] → Book Title */}
+      <Breadcrumbs
+        items={[
+          { label: t('breadcrumbs.books'), to: '/books' },
+          ...(genres.length > 0
+            ? [{ label: genres[0].name, to: `/genres/${genres[0].slug}` }]
+            : []),
+          { label: book.title },
+        ]}
       />
 
       {/* Hero Section */}

--- a/apps/web/src/pages/GenreDetailPage.tsx
+++ b/apps/web/src/pages/GenreDetailPage.tsx
@@ -4,14 +4,17 @@ import { useApi } from '../hooks/useApi'
 import { getStorageUrl } from '../api/client'
 import { LocalizedLink } from '../components/LocalizedLink'
 import { SeoHead } from '../components/SeoHead'
+import { Breadcrumbs } from '../components/Breadcrumbs'
 import { Footer } from '../components/Footer'
 import { useLanguage } from '../context/LanguageContext'
+import { useTranslation } from '../hooks/useTranslation'
 import { isNotFoundError } from '../lib/errorUtils'
 import type { GenreDetail } from '../types/api'
 
 export function GenreDetailPage() {
   const { slug } = useParams<{ slug: string }>()
   const { language } = useLanguage()
+  const { t } = useTranslation()
   const api = useApi()
   const [genre, setGenre] = useState<GenreDetail | null>(null)
   const [loading, setLoading] = useState(true)
@@ -82,6 +85,14 @@ export function GenreDetailPage() {
     <>
     <div className="genre-detail">
       <SeoHead title={seoTitle} description={seoDescription} />
+
+      {/* Breadcrumbs: Home → Genres → Genre Name */}
+      <Breadcrumbs
+        items={[
+          { label: t('breadcrumbs.genres'), to: '/genres' },
+          { label: genre.name },
+        ]}
+      />
 
       <div className="genre-detail__header">
         <h1 className="genre-detail__name">{genre.name}</h1>

--- a/infra/nginx/textstack.conf
+++ b/infra/nginx/textstack.conf
@@ -9,6 +9,9 @@ limit_req_zone $binary_remote_addr zone=upload_limit:10m rate=1r/s;
 limit_req_zone $binary_remote_addr zone=translate_limit:10m rate=5r/m;
 
 # Bot detection — serve SSG only to crawlers, SPA to real users
+# NOTE: ~*ahrefs intentionally broad — covers AhrefsBot AND AhrefsSiteAudit/X.X
+# (the latter does NOT contain "bot" substring, so the generic ~*bot fallback
+# below misses it). Same reasoning for ~*siteaudit / ~*audit.
 map $http_user_agent $is_bot {
     default                     0;
     ~*googlebot                 1;
@@ -22,13 +25,21 @@ map $http_user_agent $is_bot {
     ~*slurp                     1;
     ~*applebot                  1;
     ~*semrushbot                1;
-    ~*ahrefsbot                 1;
+    ~*ahrefs                    1;
+    ~*siteaudit                 1;
+    ~*screaming.?frog           1;
+    ~*bytespider                1;
+    ~*pingdom                   1;
+    ~*gtmetrix                  1;
+    ~*lighthouse                1;
     ~*mj12bot                   1;
     ~*dotbot                    1;
     ~*petalbot                  1;
     ~*sogou                     1;
     ~*crawl                     1;
     ~*spider                    1;
+    ~*scanner                   1;
+    ~*audit                     1;
     ~*bot                       1;
     ~*Google-InspectionTool     1;
 }
@@ -52,9 +63,15 @@ map $is_bot $seo_render_tag {
 # which rewrites $uri — $request_uri keeps the original. Matched in both
 # location / and location @spa (the two terminal branches).
 # Empty default → nginx omits the header.
+#
+# Chapter reader routes (/books/{slug}/{chapter}, /books/{slug}/focus/{chapter})
+# are SPA-only (no SSG) and would otherwise be indexed as thin-content duplicates.
+# Pattern `[^/]+/[^/?#]+` requires a second non-root segment so it does NOT
+# match book detail pages (`/books/{slug}/`) which ARE SSG-rendered.
 map $request_uri $private_route_robots {
     default                                                                                     "";
     "~*^/(en|uk)/(library/my|settings|profile|highlights|practice|stats|vocabulary|reader)"      "noindex, follow";
+    "~*^/(en|uk)/books/[^/]+/[^/?#]+"                                                            "noindex, follow";
 }
 
 # Upstream for API (Docker container on localhost only)


### PR DESCRIPTION
## Summary

Two SEO wins bundled:

### 1. Fix Ahrefs Site Audit false-positives + chapter URL indexing (nginx)
- `AhrefsSiteAudit/7.0` UA wasn't detected → got SPA shell → reported 500+ "empty H1/title" false positives. Widened `~*ahrefsbot` → `~*ahrefs`, added `~*siteaudit`, `~*audit`, plus other SEO scanners
- Chapter URLs (`/books/{slug}/{chapter}`, ~844 total) fell through to catch-all without noindex. Added regex to `$private_route_robots` → `X-Robots-Tag: noindex, follow`. Book detail pages unaffected (pattern requires second path segment)

### 2. Reusable Breadcrumbs component + BreadcrumbList JSON-LD
- Extracted breadcrumb logic from BookDetailPage into `components/Breadcrumbs.tsx`
- Added visible breadcrumbs + structured data to Author, Genre, Blog detail pages (previously only BookDetailPage had them)
- Fixed AuthorDetailPage Person JSON-LD `window.location.href` → `buildCanonicalUrl` (prerender safety)
- All 4 detail page types now emit BreadcrumbList → Google renders clickable hierarchy in SERP

## Test plan

### nginx (after deploy)
- [ ] `curl -sI -H "User-Agent: AhrefsSiteAudit/7.0" https://textstack.app/en/books/dracula/ | grep X-SEO-Render` → `ssg`
- [ ] `curl -sI https://textstack.app/en/books/dracula/chapter-1/ | grep X-Robots-Tag` → `noindex, follow`
- [ ] `curl -sI https://textstack.app/en/books/dracula/ | grep X-Robots-Tag` → no header (book detail stays indexable)

### Breadcrumbs
- [ ] Visit book/author/genre/blog detail pages → see breadcrumb nav above content
- [ ] View-source → find `"@type":"BreadcrumbList"` JSON-LD script
- [ ] Validate structured data: https://search.google.com/test/rich-results
- [ ] Switch between EN/UK → labels translate correctly
- [ ] `pnpm -C apps/web tsc --noEmit` → 0 errors (already verified locally)

### Post-deploy
- [ ] Trigger Ahrefs re-crawl → expect ~844 "H1 missing" errors to drop
- [ ] Submit sitemap to GSC → expect reduction in "Crawled, not indexed" for chapter URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)