### PR TITLE
seo: Author sameAs + ItemList JSON-LD on listing pages

### DIFF
--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -197,6 +197,7 @@ export interface AuthorDetail {
   seoRelevanceText: string | null
   seoThemesJson: string | null
   seoFaqsJson: string | null
+  externalLinksJson: string | null
   bookCount: number
   createdAt: string
   books: AuthorBook[]
@@ -811,6 +812,7 @@ export const adminApi = {
     seoRelevanceText?: string | null
     seoThemesJson?: string | null
     seoFaqsJson?: string | null
+    externalLinksJson?: string | null
   }): Promise<void> => {
     await fetchVoid(`/admin/authors/${id}`, {
       method: 'PUT',

--- a/apps/admin/src/pages/EditAuthorPage.tsx
+++ b/apps/admin/src/pages/EditAuthorPage.tsx
@@ -29,6 +29,12 @@ export function EditAuthorPage() {
   const [seoRelevanceText, setSeoRelevanceText] = useState('')
   const [seoThemes, setSeoThemes] = useState<string[]>([])
   const [seoFaqs, setSeoFaqs] = useState<FAQItem[]>([])
+  // External authority links (schema.org sameAs)
+  const [linkWikipedia, setLinkWikipedia] = useState('')
+  const [linkGoodreads, setLinkGoodreads] = useState('')
+  const [linkGutenberg, setLinkGutenberg] = useState('')
+  const [linkWebsite, setLinkWebsite] = useState('')
+  const [linkTwitter, setLinkTwitter] = useState('')
 
   useEffect(() => {
     if (!id) return
@@ -45,6 +51,18 @@ export function EditAuthorPage() {
         setSeoRelevanceText(data.seoRelevanceText || '')
         setSeoThemes(data.seoThemesJson ? JSON.parse(data.seoThemesJson) : [])
         setSeoFaqs(data.seoFaqsJson ? JSON.parse(data.seoFaqsJson) : [])
+        if (data.externalLinksJson) {
+          try {
+            const links = JSON.parse(data.externalLinksJson) as Record<string, string | undefined>
+            setLinkWikipedia(links.wikipedia || '')
+            setLinkGoodreads(links.goodreads || '')
+            setLinkGutenberg(links.gutenberg || '')
+            setLinkWebsite(links.website || '')
+            setLinkTwitter(links.twitter || '')
+          } catch {
+            // ignore malformed
+          }
+        }
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load author')
       } finally {
@@ -59,6 +77,15 @@ export function EditAuthorPage() {
     if (!id) return
     setSaving(true)
     try {
+      const externalLinks: Record<string, string> = {}
+      if (linkWikipedia.trim()) externalLinks.wikipedia = linkWikipedia.trim()
+      if (linkGoodreads.trim()) externalLinks.goodreads = linkGoodreads.trim()
+      if (linkGutenberg.trim()) externalLinks.gutenberg = linkGutenberg.trim()
+      if (linkWebsite.trim()) externalLinks.website = linkWebsite.trim()
+      if (linkTwitter.trim()) externalLinks.twitter = linkTwitter.trim()
+      const externalLinksJson = Object.keys(externalLinks).length > 0
+        ? JSON.stringify(externalLinks)
+        : null
       await adminApi.updateAuthor(id, {
         name,
         bio: bio || null,
@@ -69,6 +96,7 @@ export function EditAuthorPage() {
         seoRelevanceText: seoRelevanceText || null,
         seoThemesJson: seoThemes.length > 0 ? JSON.stringify(seoThemes) : null,
         seoFaqsJson: seoFaqs.length > 0 ? JSON.stringify(seoFaqs) : null,
+        externalLinksJson,
       })
       const updated = await adminApi.getAuthor(id)
       setAuthor(updated)
@@ -277,6 +305,68 @@ export function EditAuthorPage() {
             faqs={seoFaqs}
             onFaqsChange={setSeoFaqs}
           />
+        </div>
+
+        <div className="form-section">
+          <h2>External Links</h2>
+          <p className="text-muted" style={{ marginTop: 0 }}>
+            Authority links for schema.org <code>sameAs</code>. Leave empty fields blank.
+          </p>
+
+          <div className="form-group">
+            <label htmlFor="linkWikipedia">Wikipedia URL</label>
+            <input
+              id="linkWikipedia"
+              type="url"
+              value={linkWikipedia}
+              onChange={(e) => setLinkWikipedia(e.target.value)}
+              placeholder="https://en.wikipedia.org/wiki/..."
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="linkGoodreads">Goodreads URL</label>
+            <input
+              id="linkGoodreads"
+              type="url"
+              value={linkGoodreads}
+              onChange={(e) => setLinkGoodreads(e.target.value)}
+              placeholder="https://www.goodreads.com/author/show/..."
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="linkGutenberg">Project Gutenberg URL</label>
+            <input
+              id="linkGutenberg"
+              type="url"
+              value={linkGutenberg}
+              onChange={(e) => setLinkGutenberg(e.target.value)}
+              placeholder="https://www.gutenberg.org/ebooks/author/..."
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="linkWebsite">Official Website</label>
+            <input
+              id="linkWebsite"
+              type="url"
+              value={linkWebsite}
+              onChange={(e) => setLinkWebsite(e.target.value)}
+              placeholder="https://..."
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="linkTwitter">Twitter / X URL</label>
+            <input
+              id="linkTwitter"
+              type="url"
+              value={linkTwitter}
+              onChange={(e) => setLinkTwitter(e.target.value)}
+              placeholder="https://twitter.com/..."
+            />
+          </div>
         </div>
 
         <div className="form-actions">

--- a/apps/web/src/lib/itemListSchema.ts
+++ b/apps/web/src/lib/itemListSchema.ts
@@ -1,0 +1,39 @@
+/**
+ * Helpers for building Schema.org ItemList JSON-LD for listing pages.
+ * Only emit on the canonical indexable version of a list (page=1, no filters),
+ * otherwise we're just feeding crawlers structured duplicates.
+ */
+
+export interface ItemListEntry {
+  url: string
+  name: string
+  image?: string | null
+}
+
+interface BuildItemListParams {
+  origin: string
+  items: ItemListEntry[]
+  name?: string
+  description?: string
+}
+
+function absolutize(origin: string, pathOrUrl: string): string {
+  return pathOrUrl.startsWith('http') ? pathOrUrl : `${origin}${pathOrUrl}`
+}
+
+export function buildItemListSchema({ origin, items, name, description }: BuildItemListParams) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    ...(name ? { name } : {}),
+    ...(description ? { description } : {}),
+    numberOfItems: items.length,
+    itemListElement: items.map((it, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      url: absolutize(origin, it.url),
+      name: it.name,
+      ...(it.image ? { image: absolutize(origin, it.image) } : {}),
+    })),
+  }
+}

--- a/apps/web/src/pages/AuthorDetailPage.tsx
+++ b/apps/web/src/pages/AuthorDetailPage.tsx
@@ -124,6 +124,20 @@ export function AuthorDetailPage() {
 
   if (!author) return null
 
+  // Parse external authority links for schema.org sameAs.
+  // Shape stored in DB: { wikipedia?, goodreads?, gutenberg?, website?, twitter? }.
+  // Invalid JSON or non-http values are silently dropped so the JSON-LD stays clean.
+  const sameAs = (() => {
+    if (!author.externalLinksJson) return [] as string[]
+    try {
+      const parsed = JSON.parse(author.externalLinksJson) as Record<string, unknown>
+      return Object.values(parsed)
+        .filter((v): v is string => typeof v === 'string' && /^https?:\/\//.test(v))
+    } catch {
+      return [] as string[]
+    }
+  })()
+
   const seoTitle = language === 'uk'
     ? `${author.name} — книги автора`
     : `${author.name} — books by author`
@@ -164,6 +178,7 @@ export function AuthorDetailPage() {
             return url?.startsWith('http') ? url : `${canonicalOrigin}${url}`
           })() : undefined,
           url: buildCanonicalUrl({ origin: canonicalOrigin, pathname: `/${language}/authors/${author.slug}` }),
+          sameAs: sameAs.length > 0 ? sameAs : undefined,
         }}
       />
 

--- a/apps/web/src/pages/AuthorsPage.tsx
+++ b/apps/web/src/pages/AuthorsPage.tsx
@@ -5,14 +5,21 @@ import { useDebounce } from '../hooks/useDebounce'
 import { getStorageUrl } from '../api/client'
 import { LocalizedLink } from '../components/LocalizedLink'
 import { SeoHead } from '../components/SeoHead'
+import { JsonLd } from '../components/JsonLd'
 import { Footer } from '../components/Footer'
 import { useTranslation } from '../hooks/useTranslation'
+import { useLanguage } from '../context/LanguageContext'
+import { useSite } from '../context/SiteContext'
+import { getCanonicalOrigin } from '../lib/canonicalUrl'
+import { buildItemListSchema } from '../lib/itemListSchema'
 import type { Author } from '../types/api'
 
 const AUTHORS_PER_PAGE = 12
 
 export function AuthorsPage() {
   const { t } = useTranslation()
+  const { language } = useLanguage()
+  const { site } = useSite()
   const api = useApi()
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -77,6 +84,8 @@ export function AuthorsPage() {
 
   const totalPages = Math.ceil(total / AUTHORS_PER_PAGE)
   const hasFilters = !!(q || sort)
+  const isIndexable = page === 1 && !hasFilters
+  const canonicalOrigin = getCanonicalOrigin(site?.primaryDomain)
 
   return (
     <>
@@ -90,6 +99,20 @@ export function AuthorsPage() {
         description={t('authors.seoDesc')}
         noindex={page > 1 || hasFilters}
       />
+      {isIndexable && authors.length > 0 && (
+        <JsonLd
+          data={buildItemListSchema({
+            origin: canonicalOrigin,
+            name: t('authors.title'),
+            description: t('authors.seoDesc'),
+            items: authors.map((a) => ({
+              url: `/${language}/authors/${a.slug}`,
+              name: a.name,
+              image: a.photoPath ? getStorageUrl(a.photoPath) : null,
+            })),
+          })}
+        />
+      )}
       <h1>{t('authors.title')}</h1>
 
       {/* Filters */}

--- a/apps/web/src/pages/BooksPage.tsx
+++ b/apps/web/src/pages/BooksPage.tsx
@@ -5,10 +5,14 @@ import { useDebounce } from '../hooks/useDebounce'
 import { getStorageUrl } from '../api/client'
 import { LocalizedLink } from '../components/LocalizedLink'
 import { SeoHead } from '../components/SeoHead'
+import { JsonLd } from '../components/JsonLd'
 import { Footer } from '../components/Footer'
 import { useTranslation } from '../hooks/useTranslation'
 import { useLanguage } from '../context/LanguageContext'
+import { useSite } from '../context/SiteContext'
 import { stringToColor } from '../utils/colors'
+import { getCanonicalOrigin } from '../lib/canonicalUrl'
+import { buildItemListSchema } from '../lib/itemListSchema'
 import type { Edition, Genre } from '../types/api'
 
 const BOOKS_PER_PAGE = 12
@@ -16,6 +20,7 @@ const BOOKS_PER_PAGE = 12
 export function BooksPage() {
   const { t } = useTranslation()
   const { language } = useLanguage()
+  const { site } = useSite()
   const api = useApi()
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -93,6 +98,10 @@ export function BooksPage() {
 
   const totalPages = Math.ceil(total / BOOKS_PER_PAGE)
   const hasFilters = !!(q || genre || sort)
+  // Only emit ItemList on the canonical indexable version of this page,
+  // otherwise crawlers would ingest structured duplicates for every filter combo.
+  const isIndexable = page === 1 && !hasFilters
+  const canonicalOrigin = getCanonicalOrigin(site?.primaryDomain)
 
   return (
     <>
@@ -109,6 +118,20 @@ export function BooksPage() {
         description={t('books.seoDesc')}
         noindex={page > 1 || hasFilters}
       />
+      {isIndexable && books.length > 0 && (
+        <JsonLd
+          data={buildItemListSchema({
+            origin: canonicalOrigin,
+            name: t('books.title'),
+            description: t('books.seoDesc'),
+            items: books.map((b) => ({
+              url: `/${language}/books/${b.slug}`,
+              name: b.title,
+              image: b.coverPath ? getStorageUrl(b.coverPath) : null,
+            })),
+          })}
+        />
+      )}
       <h1>{t('books.title')}</h1>
 
       {/* Filters */}

--- a/apps/web/src/pages/GenresPage.tsx
+++ b/apps/web/src/pages/GenresPage.tsx
@@ -2,16 +2,22 @@ import { useState, useEffect } from 'react'
 import { useApi } from '../hooks/useApi'
 import { LocalizedLink } from '../components/LocalizedLink'
 import { SeoHead } from '../components/SeoHead'
+import { JsonLd } from '../components/JsonLd'
 import { Footer } from '../components/Footer'
 import { useLanguage } from '../context/LanguageContext'
+import { useSite } from '../context/SiteContext'
+import { getCanonicalOrigin } from '../lib/canonicalUrl'
+import { buildItemListSchema } from '../lib/itemListSchema'
 import type { Genre } from '../types/api'
 
 export function GenresPage() {
   const { language } = useLanguage()
+  const { site } = useSite()
   const api = useApi()
   const [genres, setGenres] = useState<Genre[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const canonicalOrigin = getCanonicalOrigin(site?.primaryDomain)
 
   useEffect(() => {
     api.getGenres()
@@ -55,6 +61,19 @@ export function GenresPage() {
     <>
     <div className="genres-page">
       <SeoHead title={title} description={description} />
+      {genres.length > 0 && (
+        <JsonLd
+          data={buildItemListSchema({
+            origin: canonicalOrigin,
+            name: title,
+            description,
+            items: genres.map((g) => ({
+              url: `/${language}/genres/${g.slug}`,
+              name: g.name,
+            })),
+          })}
+        />
+      )}
       <h1>{title}</h1>
       {genres.length === 0 ? (
         <p>{language === 'uk' ? 'Жанрів поки немає.' : 'No genres available yet.'}</p>

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -118,6 +118,7 @@ export interface AuthorDetail extends Author {
   seoRelevanceText: string | null
   seoThemesJson: string | null
   seoFaqsJson: string | null
+  externalLinksJson: string | null
   editions: Edition[]
 }
 

--- a/backend/src/Api/Endpoints/AdminAuthorsEndpoints.cs
+++ b/backend/src/Api/Endpoints/AdminAuthorsEndpoints.cs
@@ -264,6 +264,7 @@ public static class AdminAuthorsEndpoints
                 a.SeoRelevanceText,
                 a.SeoThemesJson,
                 a.SeoFaqsJson,
+                a.ExternalLinksJson,
                 a.EditionAuthors.Count,
                 a.CreatedAt,
                 a.EditionAuthors
@@ -333,6 +334,8 @@ public static class AdminAuthorsEndpoints
         author.SeoRelevanceText = req.SeoRelevanceText;
         author.SeoThemesJson = req.SeoThemesJson;
         author.SeoFaqsJson = req.SeoFaqsJson;
+        // Normalise empty/whitespace external links to null so JSONB stores nothing
+        author.ExternalLinksJson = string.IsNullOrWhiteSpace(req.ExternalLinksJson) ? null : req.ExternalLinksJson;
 
         await db.SaveChangesAsync(ct);
 

--- a/backend/src/Application/Authors/AuthorsService.cs
+++ b/backend/src/Application/Authors/AuthorsService.cs
@@ -66,6 +66,7 @@ public class AuthorsService(IAppDbContext db)
                 a.SeoRelevanceText,
                 a.SeoThemesJson,
                 a.SeoFaqsJson,
+                a.ExternalLinksJson,
                 a.EditionAuthors
                     .Where(ea => ea.Edition.Status == EditionStatus.Published)
                     .OrderBy(ea => ea.Order)

--- a/backend/src/Contracts/Admin/AuthorDtos.cs
+++ b/backend/src/Contracts/Admin/AuthorDtos.cs
@@ -32,6 +32,7 @@ public record AdminAuthorDetailDto(
     string? SeoRelevanceText,
     string? SeoThemesJson,
     string? SeoFaqsJson,
+    string? ExternalLinksJson,
     int BookCount,
     DateTimeOffset CreatedAt,
     List<AdminAuthorBookDto> Books
@@ -66,7 +67,8 @@ public record UpdateAuthorRequest(
     string? CanonicalOverride,
     string? SeoRelevanceText,
     string? SeoThemesJson,
-    string? SeoFaqsJson
+    string? SeoFaqsJson,
+    string? ExternalLinksJson
 );
 
 public record AdminAuthorStatsDto(

--- a/backend/src/Contracts/Authors/AuthorDtos.cs
+++ b/backend/src/Contracts/Authors/AuthorDtos.cs
@@ -19,6 +19,7 @@ public record AuthorDetailDto(
     string? SeoRelevanceText,
     string? SeoThemesJson,
     string? SeoFaqsJson,
+    string? ExternalLinksJson,
     List<AuthorEditionDto> Editions
 );
 

--- a/backend/src/Domain/Entities/Author.cs
+++ b/backend/src/Domain/Entities/Author.cs
@@ -24,6 +24,13 @@ public class Author
     public string? SeoThemesJson { get; set; }
     public string? SeoFaqsJson { get; set; }
 
+    /// <summary>
+    /// External authority links for schema.org sameAs. Stored as JSON (jsonb).
+    /// Shape: {"wikipedia":"https://…","goodreads":"…","gutenberg":"…","website":"…","twitter":"…"}.
+    /// Keys with null/empty values are filtered out at render time.
+    /// </summary>
+    public string? ExternalLinksJson { get; set; }
+
     /// <summary>Provenance of the SEO fields on this entity. Drives auto-skip logic during bulk backfill.</summary>
     public SeoSource SeoSource { get; set; } = SeoSource.Manual;
 

--- a/backend/src/Infrastructure/Migrations/20260419081550_AddAuthorExternalLinks.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260419081550_AddAuthorExternalLinks.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419081550_AddAuthorExternalLinks")]
+    partial class AddAuthorExternalLinks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Migrations/20260419081550_AddAuthorExternalLinks.cs
+++ b/backend/src/Infrastructure/Migrations/20260419081550_AddAuthorExternalLinks.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAuthorExternalLinks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "external_links_json",
+                table: "authors",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "external_links_json",
+                table: "authors");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.cs
@@ -268,6 +268,7 @@ public class AppDbContext : DbContext, IAppDbContext
             e.HasIndex(x => new { x.SiteId, x.Slug }).IsUnique();
             e.Property(x => x.Slug).HasMaxLength(255);
             e.Property(x => x.Name).HasMaxLength(255);
+            e.Property(x => x.ExternalLinksJson).HasColumnType("jsonb");
             e.HasOne(x => x.Site).WithMany().HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
         });
 


### PR DESCRIPTION
## Summary

- **Author.ExternalLinksJson** (jsonb) + EF migration \`AddAuthorExternalLinks\` (applied by migrator service on deploy)
- **Admin EditAuthorPage**: new \`External Links\` block — Wikipedia / Goodreads / Gutenberg / Website / Twitter
- **Public AuthorDetailPage**: Person JSON-LD \`sameAs[]\` populated from \`externalLinksJson\` — Google uses sameAs to confirm entity identity and can surface Knowledge Panel links
- **BooksPage / AuthorsPage / GenresPage**: ItemList JSON-LD emitted only on indexable variants (page=1, no filters) — gives Google structured signal about collection pages
- **New helper** \`apps/web/src/lib/itemListSchema.ts\` — keeps schema shape consistent across 3 list pages

## Test plan

- [ ] CI green (backend, frontend, docker, e2e)
- [ ] After deploy: migrator applies \`AddAuthorExternalLinks\` cleanly — check \`docker compose logs migrator\`
- [ ] Admin → Edit Author → add Wikipedia + Goodreads URLs → Save → verify persisted
- [ ] View source on \`/en/authors/{slug}\` → Person JSON-LD contains \`sameAs: [...]\`
- [ ] View source on \`/en/books\` → ItemList JSON-LD present; on \`/en/books?page=2\` → ItemList absent
- [ ] Validate schemas at https://validator.schema.org/

🤖 Generated with [Claude Code](https://claude.com/claude-code)