### PR TITLE
reader: fix broken images + onerror retry (slice 1)

### DIFF
--- a/apps/web/src/components/reader/ReaderContent.tsx
+++ b/apps/web/src/components/reader/ReaderContent.tsx
@@ -37,6 +37,7 @@ export function ReaderContent({
   onTap,
   onDoubleTap,
 }: Props) {
+  const rootRef = useRef<HTMLDivElement>(null)
   const bottomSentinelRef = useRef<HTMLDivElement>(null)
   const topSentinelRef = useRef<HTMLDivElement>(null)
   const fontFamily = getFontFamily(settings.fontFamily)
@@ -44,6 +45,35 @@ export function ReaderContent({
   const tapTimeoutRef = useRef<number | null>(null)
   const prevScrollHeightRef = useRef<number>(0)
   const prevFirstIndexRef = useRef<number>(-1)
+
+  // Capture-phase error listener for images (error events don't bubble).
+  // Retry once after 1s (survives transient 503s from burst rate-limiting),
+  // mark as broken on second fail so CSS can show a placeholder.
+  useEffect(() => {
+    const root = rootRef.current
+    if (!root) return
+
+    const handleError = (e: Event) => {
+      const target = e.target as HTMLElement
+      if (!target || target.tagName !== 'IMG') return
+      const img = target as HTMLImageElement
+      if (img.dataset.broken === '1') return
+      if (img.dataset.retried === '1') {
+        img.dataset.broken = '1'
+        return
+      }
+      img.dataset.retried = '1'
+      const original = img.getAttribute('src')
+      if (!original) return
+      window.setTimeout(() => {
+        const sep = original.includes('?') ? '&' : '?'
+        img.src = `${original}${sep}r=1`
+      }, 1000)
+    }
+
+    root.addEventListener('error', handleError, true)
+    return () => root.removeEventListener('error', handleError, true)
+  }, [chapters.length])
 
   // Handle tap with double-tap detection for fullscreen
   const handleClick = useCallback((e: React.MouseEvent) => {
@@ -168,7 +198,7 @@ export function ReaderContent({
   }
 
   return (
-    <div className="scroll-reader" onClick={handleClick}>
+    <div ref={rootRef} className="scroll-reader" onClick={handleClick}>
       {/* Top sentinel for loading previous chapters */}
       {onLoadPrev && chapters[0]?.index > 0 && (
         <>

--- a/apps/web/src/styles/reader.css
+++ b/apps/web/src/styles/reader.css
@@ -845,6 +845,20 @@ html[data-theme="dark"] .reader-search-drawer__context mark {
   margin: 1em auto;
 }
 
+/* Broken-image placeholder (src failed after one retry) */
+.scroll-reader__chapter img[data-broken="1"] {
+  min-width: 160px;
+  min-height: 100px;
+  max-width: 320px;
+  background: var(--reader-border, #e5e7eb);
+  border: 1px dashed var(--reader-secondary, #9ca3af);
+  object-fit: contain;
+  padding: 8px;
+  color: var(--reader-secondary, #9ca3af);
+  font-size: 12px;
+  font-style: italic;
+}
+
 /* Chapter separator */
 .chapter-separator {
   display: flex;

--- a/apps/web/src/utils/sanitize.ts
+++ b/apps/web/src/utils/sanitize.ts
@@ -1,13 +1,9 @@
 import DOMPurify from 'dompurify'
 
-// Rewrite book asset img src to use /api/ prefix so they route through
-// the API proxy and bypass stale browser-cached 301 redirects
 DOMPurify.addHook('afterSanitizeAttributes', (node) => {
   if (node.tagName === 'IMG') {
-    const src = node.getAttribute('src')
-    if (src?.startsWith('/books/') && src.includes('/assets/')) {
-      node.setAttribute('src', '/api' + src)
-    }
+    node.setAttribute('loading', 'lazy')
+    node.setAttribute('decoding', 'async')
   }
 })
 


### PR DESCRIPTION
## Summary
- **B1**: removed `sanitize.ts` hook that rewrote `/books/*/assets/*` → `/api/*`. The `/api/` path has `limit_req zone=api_limit burst=20` — with CHAPTERS_BUFFER=2 × ~20 imgs/chapter, bursts hit 503. Dedicated `/books/*/assets/` nginx location (no rate limit) already existed; rewrite was bypassing it.
- **B2**: capture-phase `error` listener on `.scroll-reader` — retry once after 1s with `?r=1` cache-buster, mark `data-broken=1` on second fail. CSS placeholder (160×100) replaces the browser's default collapsed-to-0×0 broken-icon.
- `loading="lazy"` + `decoding="async"` applied to all imgs via DOMPurify hook.

First of 6 planned slices from the reader desktop audit (see `PLAN` in convo).

## Test plan
- [x] `pnpm test` (95/95 web units pass)
- [x] `pnpm build` clean
- [x] Browser check on `/en/books/alices-adventures-in-wonderland/2-down-the-rabbit-hole/` — placeholders render, retry fires, `data-broken=1` set after second fail
- [ ] Deploy → DevTools Network → 0 red 503 on `/books/*/assets/*` during chapter scroll
- [ ] Throttle Network → placeholder shown (not 0×0 collapse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)