### PR TITLE
reader: autosave reliability (slice 2)

### DIFF
--- a/apps/web/src/hooks/useReadingProgress.ts
+++ b/apps/web/src/hooks/useReadingProgress.ts
@@ -10,7 +10,6 @@ interface UseReadingProgressOptions {
   chapterSlug?: string
 }
 
-// Store for pending sync (used by lifecycle triggers)
 interface PendingSync {
   editionId: string
   chapterId: string
@@ -26,16 +25,12 @@ export function useReadingProgress(
 ) {
   const { isAuthenticated } = useAuth()
   const serverSyncRef = useRef<number | null>(null)
-  const lastSyncedPercentRef = useRef<number>(0)
-  const lastSyncedLocatorRef = useRef<string>('')
+  // Only advanced after server ACK — transient fails won't lock out retries.
+  const lastAckedKeyRef = useRef<string>('')
   const pendingSyncRef = useRef<PendingSync | null>(null)
   const { editionId, chapterId, chapterSlug: optionsChapterSlug } = options || {}
   const resolvedChapterSlug = optionsChapterSlug || chapterSlug
 
-  // Update progress (called by reader when page changes)
-  // page: page number for paginated mode
-  // scrollLocator: custom locator string for scroll mode (e.g., "scroll:chapter-slug:offset")
-  // overrideChapterId/overrideChapterSlug: for scroll mode where visible chapter differs
   const updateProgress = useCallback((
     percent: number,
     page?: number,
@@ -48,7 +43,6 @@ export function useReadingProgress(
 
     if (!editionId || !effectiveChapterId) return
 
-    // Build locator early to check for changes
     let locator: string
     if (scrollLocator) {
       locator = scrollLocator
@@ -58,18 +52,8 @@ export function useReadingProgress(
       locator = `percent:${percent.toFixed(4)}`
     }
 
-    // Skip if same values synced recently (check both percent AND locator)
-    const percentUnchanged = Math.abs(percent - lastSyncedPercentRef.current) < 0.01
-    const locatorUnchanged = locator === lastSyncedLocatorRef.current
-    if (percentUnchanged && locatorUnchanged) return
-    lastSyncedPercentRef.current = percent
-    lastSyncedLocatorRef.current = locator
-
-    // Timestamp is the source of truth for LWW merge in useRestoreProgress.
-    // Single monotonic stamp shared by localStorage + server payload so both sides merge identically.
     const updatedAt = Date.now()
 
-    // Always save to localStorage (works offline, fallback if API fails)
     try {
       localStorage.setItem(`${STORAGE_KEY}${editionId}`, JSON.stringify({
         chapterId: effectiveChapterId,
@@ -82,7 +66,6 @@ export function useReadingProgress(
       // localStorage might be full or disabled
     }
 
-    // Store pending sync data for lifecycle triggers
     pendingSyncRef.current = {
       editionId,
       chapterId: effectiveChapterId,
@@ -91,63 +74,72 @@ export function useReadingProgress(
       updatedAt,
     }
 
-    // Also sync to server if authenticated (debounced)
-    if (isAuthenticated) {
-      if (serverSyncRef.current) clearTimeout(serverSyncRef.current)
-      serverSyncRef.current = window.setTimeout(() => {
-        upsertProgress(editionId, {
-          chapterId: effectiveChapterId,
-          locator,
-          percent,
-          updatedAt: new Date(updatedAt).toISOString(),
-        }).catch(() => {})
-        pendingSyncRef.current = null
-      }, 2000)
-    }
+    if (!isAuthenticated) return
+
+    const dedupeKey = `${locator}:${percent.toFixed(4)}`
+    // Skip server sync only if the last *successful* sync matches — not if we merely
+    // attempted the same payload. That way a failed sync stays retriable.
+    if (dedupeKey === lastAckedKeyRef.current) return
+
+    if (serverSyncRef.current) clearTimeout(serverSyncRef.current)
+    serverSyncRef.current = window.setTimeout(() => {
+      const payload = pendingSyncRef.current
+      if (!payload) return
+      upsertProgress(payload.editionId, {
+        chapterId: payload.chapterId,
+        locator: payload.locator,
+        percent: payload.percent,
+        updatedAt: new Date(payload.updatedAt).toISOString(),
+      })
+        .then(() => {
+          lastAckedKeyRef.current = `${payload.locator}:${payload.percent.toFixed(4)}`
+          if (pendingSyncRef.current === payload) pendingSyncRef.current = null
+        })
+        .catch(() => {
+          // Leave lastAckedKeyRef as-is so subsequent updateProgress retries.
+        })
+    }, 2000)
   }, [bookSlug, chapterSlug, isAuthenticated, editionId, chapterId, resolvedChapterSlug])
 
-  // Flush pending sync immediately (bypasses debounce)
+  // Flush pending sync immediately via keepalive fetch (bypasses debounce).
   const flushSave = useCallback(() => {
-    if (!pendingSyncRef.current || !isAuthenticated) return
+    const payload = pendingSyncRef.current
+    if (!payload || !isAuthenticated) return
 
-    // Cancel pending debounced sync
     if (serverSyncRef.current) {
       clearTimeout(serverSyncRef.current)
       serverSyncRef.current = null
     }
 
-    const { editionId, chapterId, locator, percent, updatedAt } = pendingSyncRef.current
-    const payload = JSON.stringify({
-      chapterId,
-      locator,
-      percent,
-      updatedAt: new Date(updatedAt).toISOString(),
+    const body = JSON.stringify({
+      chapterId: payload.chapterId,
+      locator: payload.locator,
+      percent: payload.percent,
+      updatedAt: new Date(payload.updatedAt).toISOString(),
     })
-    const url = `/api/me/progress/${editionId}`
 
-    // Use fetch with keepalive (survives page unload like sendBeacon, but supports PUT)
-    fetch(url, {
+    fetch(`/api/me/progress/${payload.editionId}`, {
       method: 'PUT',
-      body: payload,
+      body,
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       keepalive: true,
-    }).catch(() => {})
+    })
+      .then(() => {
+        lastAckedKeyRef.current = `${payload.locator}:${payload.percent.toFixed(4)}`
+      })
+      .catch(() => {})
 
     pendingSyncRef.current = null
   }, [isAuthenticated])
 
-  // Lifecycle event triggers (ADR-007 section 3.3)
+  // Belt-and-suspenders lifecycle flush. The caller (ReaderPage) also flushes explicitly
+  // after its own debounced write — whichever handler fires first wins.
   useEffect(() => {
     const handleVisibilityChange = () => {
-      if (document.visibilityState === 'hidden') {
-        flushSave()
-      }
+      if (document.visibilityState === 'hidden') flushSave()
     }
-
-    const handleBeforeUnload = () => {
-      flushSave()
-    }
+    const handleBeforeUnload = () => flushSave()
 
     document.addEventListener('visibilitychange', handleVisibilityChange)
     window.addEventListener('beforeunload', handleBeforeUnload)

--- a/apps/web/src/hooks/useUserBookProgress.ts
+++ b/apps/web/src/hooks/useUserBookProgress.ts
@@ -24,7 +24,8 @@ export function useUserBookProgress(bookId: string) {
   // Legacy progress requiring migration (has chapterNumber, needs slug)
   const [legacyProgress, setLegacyProgress] = useState<LegacyProgress | null>(null)
   const [isLoading, setIsLoading] = useState(true)
-  const lastSavedRef = useRef<{ slug: string; locator?: string } | null>(null)
+  // Only advanced after server ACK — transient fails stay retriable.
+  const lastAckedKeyRef = useRef<string>('')
   const serverSyncTimerRef = useRef<number | null>(null)
   const pendingSyncRef = useRef<SavedProgress | null>(null)
 
@@ -91,24 +92,31 @@ export function useUserBookProgress(bookId: string) {
     return () => { cancelled = true }
   }, [bookId])
 
-  // Sync to server (debounced)
+  // Sync to server (debounced). Advance lastAckedKeyRef only on success.
   const syncToServer = useCallback((data: SavedProgress) => {
     pendingSyncRef.current = data
+    const dedupeKey = `${data.chapterSlug}:${data.locator ?? ''}`
+    if (dedupeKey === lastAckedKeyRef.current) return
+
     if (serverSyncTimerRef.current) clearTimeout(serverSyncTimerRef.current)
 
     serverSyncTimerRef.current = window.setTimeout(() => {
       const toSync = pendingSyncRef.current
       if (!toSync || !bookId) return
-      pendingSyncRef.current = null
 
       saveUserBookProgress(bookId, {
         chapterSlug: toSync.chapterSlug,
         locator: toSync.locator,
         percent: toSync.percent,
         updatedAt: new Date(toSync.updatedAt).toISOString(),
-      }).catch(() => {
-        // Server unavailable, localStorage is still saved
       })
+        .then(() => {
+          lastAckedKeyRef.current = `${toSync.chapterSlug}:${toSync.locator ?? ''}`
+          if (pendingSyncRef.current === toSync) pendingSyncRef.current = null
+        })
+        .catch(() => {
+          // Leave ref so next save retries.
+        })
     }, DEBOUNCE_MS)
   }, [bookId])
 
@@ -138,7 +146,11 @@ export function useUserBookProgress(bookId: string) {
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       keepalive: true,
-    }).catch(() => {})
+    })
+      .then(() => {
+        lastAckedKeyRef.current = `${toSync.chapterSlug}:${toSync.locator ?? ''}`
+      })
+      .catch(() => {})
 
     pendingSyncRef.current = null
   }, [bookId])
@@ -170,11 +182,6 @@ export function useUserBookProgress(bookId: string) {
   const saveProgress = useCallback((chapterSlug: string, _page: number, percent: number, locator?: string) => {
     if (!bookId) return
 
-    // Skip if same position
-    const last = lastSavedRef.current
-    if (last && last.slug === chapterSlug && last.locator === locator) return
-    lastSavedRef.current = { slug: chapterSlug, locator }
-
     const data: SavedProgress = {
       chapterSlug,
       locator,
@@ -182,7 +189,7 @@ export function useUserBookProgress(bookId: string) {
       updatedAt: Date.now(),
     }
 
-    // Save to localStorage immediately
+    // Save to localStorage immediately (always — offline/fallback safety)
     try {
       localStorage.setItem(`${STORAGE_KEY}${bookId}`, JSON.stringify(data))
       setLegacyProgress(null)
@@ -191,7 +198,7 @@ export function useUserBookProgress(bookId: string) {
       // localStorage full or disabled
     }
 
-    // Sync to server (debounced)
+    // Sync to server (debounced, server-side dedupe)
     syncToServer(data)
   }, [bookId, syncToServer])
 
@@ -211,6 +218,7 @@ export function useUserBookProgress(bookId: string) {
     legacyProgress, // For migration: caller can use chapterNumber to look up slug
     isLoading,
     saveProgress,
+    flushSave,
     clearProgress,
   }
 }

--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -436,12 +436,15 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
     progress: number
   } | null>(null)
 
-  // Flush pending scroll save immediately (bypasses debounce)
+  // Flush pending scroll save immediately: populate the hook's pending ref via
+  // updateProgress/saveProgress, then call the hook's flushSave() synchronously so
+  // the request leaves via keepalive fetch before the tab dies. Without the second
+  // call we'd only schedule the hook's 2s debounce — likely to lose the write on
+  // unload (beforeunload handler order isn't guaranteed).
   const flushScrollSave = useCallback(() => {
     const pending = pendingScrollSaveRef.current
     if (!pending) return
 
-    // Cancel pending debounced save
     if (scrollSaveTimerRef.current) {
       clearTimeout(scrollSaveTimerRef.current)
       scrollSaveTimerRef.current = null
@@ -454,9 +457,11 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
       const bookChapter = publicBook.chapters.find(c => c.slug === identifier)
       if (bookChapter) {
         publicProgress.updateProgress(progress, undefined, scrollLocator, bookChapter.id, identifier)
+        publicProgress.flushSave()
       }
     } else if (mode === 'userbook') {
       userProgress.saveProgress(identifier, 0, progress, scrollLocator)
+      userProgress.flushSave()
     }
 
     pendingScrollSaveRef.current = null
@@ -533,39 +538,6 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
       flushScrollSave()
     }
   }, [flushScrollSave])
-
-  // Time-based auto-save: save every 30s if position changed at all.
-  // Catches small scrolls that bypass the distance threshold.
-  const lastAutoSavePositionRef = useRef<{ identifier: string; offset: number } | null>(null)
-  useEffect(() => {
-    const intervalId = setInterval(() => {
-      if (!scrollRestoredRef.current) return // Don't save until scroll position is restored
-      const visibleId = scrollReader.visibleIdentifier
-      const offset = scrollReader.scrollOffset
-      if (!visibleId) return
-
-      const lastPos = lastAutoSavePositionRef.current
-
-      // Skip if position hasn't changed since last auto-save
-      if (lastPos && lastPos.identifier === visibleId && lastPos.offset === offset) return
-
-      // Position changed - save immediately
-      lastAutoSavePositionRef.current = { identifier: visibleId, offset }
-
-      const scrollLocator = `scroll:${visibleId}:${Math.round(offset)}`
-
-      if (mode === 'public' && publicBook?.chapters) {
-        const bookChapter = publicBook.chapters.find(c => c.slug === visibleId)
-        if (bookChapter) {
-          publicProgress.updateProgress(overallProgress, undefined, scrollLocator, bookChapter.id, visibleId)
-        }
-      } else if (mode === 'userbook') {
-        userProgress.saveProgress(visibleId, 0, overallProgress, scrollLocator)
-      }
-    }, 30000) // 30 seconds
-
-    return () => clearInterval(intervalId)
-  }, [mode, publicBook?.chapters, scrollReader.visibleIdentifier, scrollReader.scrollOffset, overallProgress, publicProgress, userProgress])
 
   // Track current book for guest returning user feature
   useEffect(() => {


### PR DESCRIPTION
## Summary

Slice 2 of the reader desktop audit — autosave reliability.

- **B12 (race on tab close)**: `flushScrollSave` populated the hook's `pendingSyncRef` via `updateProgress`, but the hook's *own* `beforeunload` handler was expected to drain it. Handler order isn't guaranteed — if the hook listener fired first, the ref was still null and nothing was sent. Now `flushScrollSave` calls `publicProgress.flushSave()` / `userProgress.flushSave()` directly after the update, so the keepalive fetch leaves before the tab dies. Exposed `flushSave` from `useUserBookProgress` to support this for user books.

- **B13 (ref advance before ACK)**: `lastSyncedPercentRef` / `lastSyncedLocatorRef` were advanced *before* the debounced `upsertProgress(...)` fired. A silent transient fail then locked retries out — the next `updateProgress` with the same position would be deduped and never re-sent until the user scrolled elsewhere. Replaced with a single `lastAckedKeyRef` that only advances inside `.then()` after a successful response. Same treatment applied to `useUserBookProgress`.

- **B14 (double autosave pipeline)**: removed the 30s `setInterval` auto-save in `ReaderPage`. Scroll-triggered 600ms debounce + visibility/unload flush already cover every save case; the interval was redundant and compounded the B13 dedupe bug (advancing refs from a second code path).

## Test plan

- [x] `pnpm test` — 95/95 web unit tests pass
- [x] `pnpm exec tsc --noEmit` clean
- [x] `playwright test reader-progress.spec.ts` — 6/6 pass
- [x] `playwright test bookmarks.spec.ts` — 6/6 pass (1 unrelated skip)
- [x] Browser smoke: scroll reader → `PUT /me/progress/{editionId}` returns 200 + `localStorage[reading.progress.{editionId}]` persisted
- [ ] After deploy: close tab mid-scroll → reopen → position restored
- [ ] Simulate 500 on first PUT → retry reaches server on next save

🤖 Generated with [Claude Code](https://claude.com/claude-code)