### PR TITLE
vocab: Phase 3 foundation — WordLookup + WordFrequency entities

### DIFF
--- a/backend/src/Application/Common/Interfaces/IAppDbContext.cs
+++ b/backend/src/Application/Common/Interfaces/IAppDbContext.cs
@@ -50,6 +50,8 @@ public interface IAppDbContext
     DbSet<VocabularyReview> VocabularyReviews { get; }
     DbSet<UserVocabularySettings> UserVocabularySettings { get; }
     DbSet<PendingVocabularyWord> PendingVocabularyWords { get; }
+    DbSet<WordLookup> WordLookups { get; }
+    DbSet<WordFrequency> WordFrequencies { get; }
     DbSet<ReviewLike> ReviewLikes { get; }
     DbSet<ReviewComment> ReviewComments { get; }
     DbSet<BlogPost> BlogPosts { get; }

--- a/backend/src/Domain/Entities/WordFrequency.cs
+++ b/backend/src/Domain/Entities/WordFrequency.cs
@@ -1,0 +1,24 @@
+namespace Domain.Entities;
+
+// Reference data: Zipf-scale word frequencies from the `wordfreq` library.
+// English-only for now (TextStack is English-learning-only). Loaded once at
+// startup from a committed JSON.gz; no runtime writes. Used by FrequencyFilter
+// to classify taps as SRS-eligible (top-5k), mid-tier (needs 2 taps), or
+// lookup-only (>15k or POS=PROPN).
+public class WordFrequency
+{
+    public Guid Id { get; set; }
+    public required string Language { get; set; }
+    public required string Word { get; set; }
+
+    // 1 = most common. Aligns with wordfreq's rank semantics.
+    public int Rank { get; set; }
+
+    // wordfreq Zipf score: 1.0 (rarest) to ~8.0 (most common). Derived from
+    // Rank in-source; stored to avoid recomputing on every tap.
+    public double Zipf { get; set; }
+
+    // Part-of-speech tag from spaCy (PROPN, NOUN, VERB, ...). Null = untagged
+    // from dataset. PROPN is special-cased — never goes to SRS regardless of rank.
+    public string? Pos { get; set; }
+}

--- a/backend/src/Domain/Entities/WordLookup.cs
+++ b/backend/src/Domain/Entities/WordLookup.cs
@@ -1,0 +1,39 @@
+namespace Domain.Entities;
+
+// Anti-spiral F1: rare/OOV words the user tapped that did NOT enter SRS.
+// Kept so the reader can still show a translation + "Add anyway" CTA without
+// flooding the review queue with words the user will likely never see again.
+// Mid-tier words sit here until TapCount >= LOOKUP_PROMOTION_TAPS, at which
+// point SaveWord auto-promotes into VocabularyWord.
+public class WordLookup
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public Guid SiteId { get; set; }
+
+    public required string Word { get; set; }
+    public required string Language { get; set; }
+
+    // null = OOV / PROPN / not in frequency dataset. Kept so a later dataset
+    // refresh can re-classify without re-tapping.
+    public int? ZipfRank { get; set; }
+
+    public int TapCount { get; set; }
+
+    // Last-seen context — overwritten on each tap, not history.
+    public string? Sentence { get; set; }
+    public string? BookTitle { get; set; }
+    public Guid? EditionId { get; set; }
+    public Guid? ChapterId { get; set; }
+    public Guid? UserBookId { get; set; }
+    public string? LastTranslation { get; set; }
+
+    public DateTimeOffset FirstTappedAt { get; set; }
+    public DateTimeOffset LastTappedAt { get; set; }
+
+    public User User { get; set; } = null!;
+    public Site Site { get; set; } = null!;
+    public Edition? Edition { get; set; }
+    public Chapter? Chapter { get; set; }
+    public UserBook? UserBook { get; set; }
+}

--- a/backend/src/Infrastructure/Migrations/20260421142509_AddWordLookupAndFrequencyTables.Designer.cs
+++ b/backend/src/Infrastructure/Migrations/20260421142509_AddWordLookupAndFrequencyTables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260421142509_AddWordLookupAndFrequencyTables")]
+    partial class AddWordLookupAndFrequencyTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Migrations/20260421142509_AddWordLookupAndFrequencyTables.cs
+++ b/backend/src/Infrastructure/Migrations/20260421142509_AddWordLookupAndFrequencyTables.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWordLookupAndFrequencyTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "word_frequencies",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    language = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: false),
+                    word = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    rank = table.Column<int>(type: "integer", nullable: false),
+                    zipf = table.Column<double>(type: "double precision", nullable: false),
+                    pos = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_word_frequencies", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "word_lookups",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    site_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    word = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    language = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: false),
+                    zipf_rank = table.Column<int>(type: "integer", nullable: true),
+                    tap_count = table.Column<int>(type: "integer", nullable: false),
+                    sentence = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    book_title = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    edition_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    chapter_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    user_book_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    last_translation = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    first_tapped_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    last_tapped_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_word_lookups", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_word_lookups_chapters_chapter_id",
+                        column: x => x.chapter_id,
+                        principalTable: "chapters",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "fk_word_lookups_editions_edition_id",
+                        column: x => x.edition_id,
+                        principalTable: "editions",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "fk_word_lookups_sites_site_id",
+                        column: x => x.site_id,
+                        principalTable: "sites",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_word_lookups_user_books_user_book_id",
+                        column: x => x.user_book_id,
+                        principalTable: "user_books",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "fk_word_lookups_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_word_frequencies_language_rank",
+                table: "word_frequencies",
+                columns: new[] { "language", "rank" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_word_frequencies_language_word",
+                table: "word_frequencies",
+                columns: new[] { "language", "word" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_word_lookups_chapter_id",
+                table: "word_lookups",
+                column: "chapter_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_word_lookups_edition_id",
+                table: "word_lookups",
+                column: "edition_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_word_lookups_site_id",
+                table: "word_lookups",
+                column: "site_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_word_lookups_user_book_id",
+                table: "word_lookups",
+                column: "user_book_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_word_lookups_user_id_site_id_last_tapped_at",
+                table: "word_lookups",
+                columns: new[] { "user_id", "site_id", "last_tapped_at" },
+                descending: new[] { false, false, true });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_word_lookups_user_id_site_id_word_language",
+                table: "word_lookups",
+                columns: new[] { "user_id", "site_id", "word", "language" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "word_frequencies");
+
+            migrationBuilder.DropTable(
+                name: "word_lookups");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/AppDbContext.cs
@@ -57,6 +57,8 @@ public class AppDbContext : DbContext, IAppDbContext
     public DbSet<VocabularyReview> VocabularyReviews => Set<VocabularyReview>();
     public DbSet<UserVocabularySettings> UserVocabularySettings => Set<UserVocabularySettings>();
     public DbSet<PendingVocabularyWord> PendingVocabularyWords => Set<PendingVocabularyWord>();
+    public DbSet<WordLookup> WordLookups => Set<WordLookup>();
+    public DbSet<WordFrequency> WordFrequencies => Set<WordFrequency>();
     public DbSet<ReviewLike> ReviewLikes => Set<ReviewLike>();
     public DbSet<ReviewComment> ReviewComments => Set<ReviewComment>();
     public DbSet<BlogPost> BlogPosts => Set<BlogPost>();
@@ -638,6 +640,37 @@ public class AppDbContext : DbContext, IAppDbContext
             e.HasOne(x => x.Edition).WithMany().HasForeignKey(x => x.EditionId).OnDelete(DeleteBehavior.SetNull);
             e.HasOne(x => x.Chapter).WithMany().HasForeignKey(x => x.ChapterId).OnDelete(DeleteBehavior.SetNull);
             e.HasOne(x => x.UserBook).WithMany().HasForeignKey(x => x.UserBookId).OnDelete(DeleteBehavior.SetNull);
+        });
+
+        // WordLookup (F1: rare-word reference bucket — taps that don't enter SRS)
+        modelBuilder.Entity<WordLookup>(e =>
+        {
+            // Dedup: one row per (user, site, word, language). Tap increments TapCount.
+            e.HasIndex(x => new { x.UserId, x.SiteId, x.Word, x.Language }).IsUnique();
+            // List view (newest tapped first).
+            e.HasIndex(x => new { x.UserId, x.SiteId, x.LastTappedAt }).IsDescending(false, false, true);
+            e.Property(x => x.Word).HasMaxLength(200);
+            e.Property(x => x.Language).HasMaxLength(8);
+            e.Property(x => x.Sentence).HasMaxLength(1000);
+            e.Property(x => x.BookTitle).HasMaxLength(500);
+            e.Property(x => x.LastTranslation).HasMaxLength(500);
+            e.HasOne(x => x.User).WithMany().HasForeignKey(x => x.UserId).OnDelete(DeleteBehavior.Cascade);
+            e.HasOne(x => x.Site).WithMany().HasForeignKey(x => x.SiteId).OnDelete(DeleteBehavior.Restrict);
+            e.HasOne(x => x.Edition).WithMany().HasForeignKey(x => x.EditionId).OnDelete(DeleteBehavior.SetNull);
+            e.HasOne(x => x.Chapter).WithMany().HasForeignKey(x => x.ChapterId).OnDelete(DeleteBehavior.SetNull);
+            e.HasOne(x => x.UserBook).WithMany().HasForeignKey(x => x.UserBookId).OnDelete(DeleteBehavior.SetNull);
+        });
+
+        // WordFrequency (F1: reference data — seeded from wordfreq export at startup)
+        modelBuilder.Entity<WordFrequency>(e =>
+        {
+            // Primary classify lookup: (language, word) unique.
+            e.HasIndex(x => new { x.Language, x.Word }).IsUnique();
+            // Rank-ordered scans (e.g., "top 5000 for language X").
+            e.HasIndex(x => new { x.Language, x.Rank });
+            e.Property(x => x.Language).HasMaxLength(8);
+            e.Property(x => x.Word).HasMaxLength(200);
+            e.Property(x => x.Pos).HasMaxLength(20);
         });
 
         // BlogPost


### PR DESCRIPTION
## Summary
- F1 foundation slice: two empty tables + migration.
- `WordLookup`: per-user rare-word bucket (taps that don't enter SRS).
- `WordFrequency`: Zipf reference data, seeded at startup in a later slice.
- Entities + indexes + FKs only. **No behavior change** — filter logic + dataset import + `SaveWord` integration come in next PR.

## Test plan
- [x] `dotnet build backend/src/Api` — clean
- [x] `dotnet test tests/TextStack.UnitTests` — 230/230 pass
- [ ] Migration applies on deploy (empty tables, no data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)