### PR TITLE
vocab: auto-retire during review respects AutoRetireEnabled

### DIFF
--- a/backend/src/Api/Endpoints/VocabularyEndpoints.cs
+++ b/backend/src/Api/Endpoints/VocabularyEndpoints.cs
@@ -505,12 +505,20 @@ public static class VocabularyEndpoints
 
         // Anti-spiral F4: retire immediately on threshold cross. Waiting for
         // the 6h sweeper would re-surface the word in the next queue fetch,
-        // negating the "Mastered" graduation UX.
+        // negating the "Mastered" graduation UX. Respect AutoRetireEnabled —
+        // users who disabled it should keep Mastered words reviewable.
         if (!word.IsRetired && srsEngine.ShouldAutoRetire(word.Stage, word.ConsecutiveCorrect, word.IntervalDays))
         {
-            word.IsRetired = true;
-            word.RetiredAt = now;
-            word.RetiredReason = "auto_3_correct_long_interval";
+            var autoRetireEnabled = await db.UserVocabularySettings
+                .Where(s => s.UserId == userId && s.SiteId == siteId)
+                .Select(s => (bool?)s.AutoRetireEnabled)
+                .FirstOrDefaultAsync(ct) ?? true;
+            if (autoRetireEnabled)
+            {
+                word.IsRetired = true;
+                word.RetiredAt = now;
+                word.RetiredReason = "auto_3_correct_long_interval";
+            }
         }
 
         var reviewMode = srsEngine.GetReviewMode(prevStage, word.Sentence != null);


### PR DESCRIPTION
## Summary
- Inline auto-retire in `SubmitReview` flipped `IsRetired=true` unconditionally.
- `RetirementSweeper` already checked `UserVocabularySettings.AutoRetireEnabled` — inline path missed it.
- User who disabled auto-retire would still have Mastered words retired on their next correct answer.

## Fix
Load the setting (defaults to `true` for users with no row) before flipping.

## Test plan
- [x] Unit tests 230/230 pass
- [ ] Integration: disable AutoRetire → submit 3 correct on Stage 4 word → verify `IsRetired=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)