### PR TITLE
docs: drop stale SEO Crawler refs (README + SSG_REBUILD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 **Admin Panel** ([textstack.dev](https://textstack.dev))
 - Book/author/genre/mood CRUD, bulk import, chapter editor
 - Blog management — create, edit, publish, cover upload
-- SEO crawl, SSG rebuild, ingestion queue, settings
+- SSG rebuild, ingestion queue, settings
 
 ---
 

--- a/docs/05-features/SSG_REBUILD.md
+++ b/docs/05-features/SSG_REBUILD.md
@@ -290,7 +290,6 @@ SSG rebuild from admin panel failed on production with 0% progress. Investigatio
 ## Related Documentation
 
 - [SEO Policy](../02-system/seo-policy.md)
-- [SEO Crawler Usage](./SEO_CRAWLER_USAGE.md)
 - [Deployment Guide](../03-ops/deployment.md)
 
 ---


### PR DESCRIPTION
Audit follow-up to PR #109 — found two remaining doc references after merge:

- `README.md:55` — admin panel bullet still listed "SEO crawl"
- `docs/05-features/SSG_REBUILD.md:293` — linked to non-existent `SEO_CRAWLER_USAGE.md`

Docs-only, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)