### PR TITLE
reader: drop broken ETF from footer, add chapter counter

### DIFF
--- a/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
+++ b/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
@@ -458,8 +458,8 @@ export default function UserBookReaderScreen() {
     }
   }
 
-  const wordsLeft = wordCountRef.current * (1 - progress)
-  const etfMinutes = Math.max(1, Math.round(wordsLeft / 250))
+  const currentChapterIndex = chapters.findIndex(c => c.slug === chapterSlug)
+  const totalChapters = chapters.length
 
   // Memoize HTML + WebView source — without this, every render (bars
   // toggle, progress tick, selection set) rebuilt the full chapter HTML
@@ -583,7 +583,8 @@ export default function UserBookReaderScreen() {
               <View style={[styles.progressFill, { width: `${Math.round(progress * 100)}%`, backgroundColor: colors.primary }]} />
             </View>
             <Text style={[styles.progressText, { color: colors.textSecondary }]}>
-              {Math.round(progress * 100)}% · ~{etfMinutes} min left
+              {Math.round(progress * 100)}%
+              {totalChapters > 1 && currentChapterIndex >= 0 ? `   ${currentChapterIndex + 1} / ${totalChapters}` : ''}
             </Text>
           </View>
         </Animated.View>

--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -781,10 +781,9 @@ export default function ReaderScreen() {
     }
   }
 
-  // ETF calculation
-  const wordsLeft = wordCountRef.current * (1 - progress)
-  const etfMinutes = Math.max(1, Math.round(wordsLeft / 250))
-  const etfDisplay = etfMinutes >= 60 ? `${Math.floor(etfMinutes / 60)}h ${etfMinutes % 60}m` : `${etfMinutes}m`
+  // Chapter counter for footer
+  const currentChapterIndex = chapters.findIndex(c => c.slug === chapterSlug)
+  const totalChapters = chapters.length
 
   // Large HTML string. Rebuilding every render burns CPU and — if the
   // source prop object is recreated — triggers WebView work. Memoize on
@@ -997,7 +996,8 @@ export default function ReaderScreen() {
             <View style={[styles.progressFill, { width: `${Math.round(progress * 100)}%`, backgroundColor: barText + '40' }]} />
           </View>
           <Text style={[styles.footerProgress, { color: barText + '99', textAlign: 'center', paddingVertical: 8, paddingHorizontal: 16 }]}>
-            {Math.round(progress * 100)}% · ~{etfDisplay}
+            {Math.round(progress * 100)}%
+            {totalChapters > 1 && currentChapterIndex >= 0 ? `   ${currentChapterIndex + 1} / ${totalChapters}` : ''}
           </Text>
         </Animated.View>
 

--- a/apps/web/src/components/reader/ReaderFooterNav.tsx
+++ b/apps/web/src/components/reader/ReaderFooterNav.tsx
@@ -1,22 +1,19 @@
-import { useState } from 'react'
-
 interface Props {
   chapterTitle: string
   overallProgress: number
-  bookEtf?: string | null
-  chapterEtf?: string | null
+  currentChapterIndex: number
+  totalChapters: number
 }
 
 export function ReaderFooterNav({
   chapterTitle,
   overallProgress,
-  bookEtf,
-  chapterEtf,
+  currentChapterIndex,
+  totalChapters,
 }: Props) {
   const bookPercent = Math.round(overallProgress * 100)
-  const [showChapterEtf, setShowChapterEtf] = useState(false)
-  const hasEtf = bookEtf || chapterEtf
-  const displayEtf = showChapterEtf && chapterEtf ? chapterEtf : bookEtf
+  const showCounter = totalChapters > 1 && currentChapterIndex >= 0
+  const chapterNumber = currentChapterIndex + 1
 
   return (
     <footer className="reader-footer">
@@ -34,13 +31,15 @@ export function ReaderFooterNav({
 
       <div className="reader-footer__info">
         <span className="reader-footer__chapter">{chapterTitle}</span>
-        <span
-          className="reader-footer__pages"
-          onClick={hasEtf ? () => setShowChapterEtf(!showChapterEtf) : undefined}
-          style={hasEtf ? { cursor: 'pointer' } : undefined}
-        >
-          {bookPercent}%{displayEtf && <span className="reader-footer__etf"> · {displayEtf}</span>}
-        </span>
+        {showCounter && (
+          <span
+            className="reader-footer__counter"
+            aria-label={`Chapter ${chapterNumber} of ${totalChapters}`}
+          >
+            {chapterNumber} / {totalChapters}
+          </span>
+        )}
+        <span className="reader-footer__percent">{bookPercent}%</span>
       </div>
     </footer>
   )

--- a/apps/web/src/lib/etf.ts
+++ b/apps/web/src/lib/etf.ts
@@ -1,4 +1,10 @@
 const DEFAULT_WPM = 250
+// Clamp stored WPM to a sane adult-reader band. Below 100 WPM is almost
+// certainly idle time polluting sessions (100 words in 10 hours ≈ 0.16 WPM →
+// absurd ETF). Above 600 is skimming, not reading. Outside the band: fall
+// back to DEFAULT_WPM instead of trusting the bogus sample.
+const MIN_VALID_WPM = 100
+const MAX_VALID_WPM = 600
 
 export interface EtfResult {
   minutesLeft: number
@@ -13,7 +19,9 @@ export function calculateETF(
 ): EtfResult | null {
   if (totalWords <= 0 || currentProgress >= 1) return null
 
-  const wpm = userWpm && userWpm > 0 ? userWpm : DEFAULT_WPM
+  const wpm = userWpm && userWpm >= MIN_VALID_WPM && userWpm <= MAX_VALID_WPM
+    ? userWpm
+    : DEFAULT_WPM
   const remainingWords = totalWords * (1 - currentProgress)
   const minutesLeft = Math.round(remainingWords / wpm)
 

--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -31,7 +31,7 @@ import { ReaderHighlights } from '../components/reader/ReaderHighlights'
 import { useScrollReader } from '../hooks/useScrollReader'
 import { useReadingSession } from '../hooks/useReadingSession'
 import { useQuickStats } from '../hooks/useQuickStats'
-import { calculateETF, calculateChapterETF } from '../lib/etf'
+import { calculateETF } from '../lib/etf'
 import { trackBookOpened } from '../lib/analytics'
 import { ReaderStatsWidget } from '../components/reader/ReaderStatsWidget'
 import { useGuestLimits } from '../context/GuestLimitsContext'
@@ -412,10 +412,13 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
     [bookTotalWords, overallProgress, userWpm],
   )
 
-  const chapterEtf = useMemo(() => {
-    if (!chapter?.wordCount) return null
-    return calculateChapterETF(chapter.wordCount, chapterScrollProgress, userWpm)
-  }, [chapter?.wordCount, chapterScrollProgress, userWpm])
+  const totalChapters = scrollReaderBook?.chapters.length ?? 0
+  const currentChapterIndex = useMemo(() => {
+    if (!scrollReaderBook) return -1
+    const id = scrollReader.visibleIdentifier || chapterIdentifier
+    if (!id) return -1
+    return scrollReaderBook.chapters.findIndex(c => c.identifier === id)
+  }, [scrollReaderBook, scrollReader.visibleIdentifier, chapterIdentifier])
 
   // Track scroll activity for reading session
   useEffect(() => {
@@ -956,8 +959,8 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
       <ReaderFooterNav
         chapterTitle={activeChapter?.title || chapter.title}
         overallProgress={overallProgress}
-        bookEtf={bookEtf?.formatted}
-        chapterEtf={chapterEtf?.formatted}
+        currentChapterIndex={currentChapterIndex}
+        totalChapters={totalChapters}
       />
 
       <ReaderTocDrawer

--- a/apps/web/src/styles/reader.css
+++ b/apps/web/src/styles/reader.css
@@ -195,9 +195,10 @@ body:has(.reader-page) .site-header {
 }
 
 .reader-footer__info {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  justify-content: space-between;
+  gap: 12px;
   padding: 12px 16px;
 }
 
@@ -207,19 +208,25 @@ body:has(.reader-page) .site-header {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 50%;
+  min-width: 0;
 }
 
-.reader-footer__pages {
+.reader-footer__counter {
+  grid-column: 2;
+  justify-self: center;
   font-size: 14px;
   color: var(--reader-secondary);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 
-.reader-footer__etf {
-  opacity: 0.7;
-  font-size: 13px;
+.reader-footer__percent {
+  grid-column: 3;
+  justify-self: end;
+  font-size: 14px;
+  color: var(--reader-secondary);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 


### PR DESCRIPTION
## Summary
- Footer was showing absurd ETF (user report: `~153h 58m` on Gatsby) caused by polluted `quickStats.wpm` (idle time inflates session seconds → WPM ≈ 5). Dropped ETF from the always-on footer.
- Added centered `N / Total` chapter counter in its place. Progress `%` moves to the right corner; chapter title stays left. Grid-based layout (`1fr auto 1fr`).
- Clamped WPM to [100, 600] in `etf.ts` — so opt-in `ReaderStatsWidget` also stays sane (falls back to 250 WPM default when stored value is out of band).
- Mobile parity: same counter + ETF drop on `apps/mobile/app/reader/...` and `apps/mobile/app/my-books/read/...`.

## Test plan
- [x] `tsc --noEmit` web + mobile — clean
- [x] `vite build` — clean
- [x] Playwright: `reader-progress` (6) + `reader-mobile`/`reader-images` (4) — all pass
- [x] Browser verified: 34-ch book (`7 / 34 | 21%`), 2-ch book (`1 / 2`), forced single-ch (counter hidden, % stays right), 375px narrow viewport (title ellipses, counter center, % right)
- [x] ETF clamp exercised: bogus 5/0.16 WPM → fallback; 200/400 → honored; 1000 → fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)