### PR TITLE
fix(worker): register IHttpClientFactory (unblocks book uploads)

### DIFF
--- a/backend/src/Worker/Program.cs
+++ b/backend/src/Worker/Program.cs
@@ -58,6 +58,9 @@ builder.Services.AddSingleton<IImageOptimizer, ImageOptimizer>();
 // Application services (for ISsgRouteProvider, etc.)
 builder.Services.AddApplication();
 
+// HTTP client factory (required by UserIngestionService for metadata enrichment)
+builder.Services.AddHttpClient();
+
 // Services
 builder.Services.AddSingleton<IngestionWorkerService>();
 builder.Services.AddSingleton<UserIngestionService>();


### PR DESCRIPTION
## Summary
- Worker crashes on startup since PR #109 — `IHttpClientFactory` no longer registered after SeoCrawl removal
- `UserIngestionService` requires it for metadata enrichment → user book uploads frozen in queue (status=0)
- Re-add default `AddHttpClient()` call

## Impact
Without this, any uploaded user book sits in queue forever. Evidence: "Designing Data-Intensive Applications" stuck 2h+, worker container in CrashLoop.

## Test plan
- [x] `dotnet build` clean
- [ ] Deploy → worker starts → stuck jobs pick up

🤖 Generated with [Claude Code](https://claude.com/claude-code)