### PR TITLE
fix(tests): drop rating assertions in BookStats test (post Reviews removal)

### DIFF
--- a/tests/TextStack.IntegrationTests/BookStatsEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/BookStatsEndpointTests.cs
@@ -49,7 +49,6 @@ public class BookStatsEndpointTests : IClassFixture<LiveApiFixture>, IClassFixtu
         Assert.NotNull(stats.LanguageStats);
         Assert.NotNull(stats.BooksOverTime);
         Assert.NotNull(stats.BookLengthDistribution);
-        Assert.NotNull(stats.RatingDistribution);
         Assert.NotNull(stats.PaceStats);
         Assert.NotNull(stats.AvailableYears);
     }
@@ -82,12 +81,10 @@ public class BookStatsEndpointTests : IClassFixture<LiveApiFixture>, IClassFixtu
         Assert.Contains("languageStats", json);
         Assert.Contains("booksOverTime", json);
         Assert.Contains("bookLengthDistribution", json);
-        Assert.Contains("ratingDistribution", json);
         Assert.Contains("paceStats", json);
         Assert.Contains("readingTimeByGenre", json);
         Assert.Contains("readingTimeByAuthor", json);
         Assert.Contains("availableYears", json);
-        Assert.Contains("avgRating", json);
     }
 
     #endregion
@@ -101,11 +98,9 @@ public class BookStatsEndpointTests : IClassFixture<LiveApiFixture>, IClassFixtu
         object[] LanguageStats,
         object[] BooksOverTime,
         object[] BookLengthDistribution,
-        object[] RatingDistribution,
         object[] PaceStats,
         object[] ReadingTimeByGenre,
         object[] ReadingTimeByAuthor,
-        double? AvgRating,
         int[] AvailableYears
     );
 }


### PR DESCRIPTION
Post-merge fix for #124. BookStats response no longer has `ratingDistribution`/`avgRating` fields. Tests asserted them → failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)