### PR TITLE
legal: upload form rights warranty checkbox

### DIFF
--- a/apps/mobile/app/my-books/upload.tsx
+++ b/apps/mobile/app/my-books/upload.tsx
@@ -20,6 +20,7 @@ export default function UploadScreen() {
   const [error, setError] = useState<string | null>(null)
   const [fileName, setFileName] = useState<string | null>(null)
   const [quota, setQuota] = useState<{ usedBytes: number; limitBytes: number } | null>(null)
+  const [ownsRights, setOwnsRights] = useState(false)
   const xhrRef = useRef<XMLHttpRequest | null>(null)
   const unmountedRef = useRef(false)
 
@@ -64,6 +65,10 @@ export default function UploadScreen() {
   }
 
   const pickAndUpload = async () => {
+    if (!ownsRights) {
+      setError('Please confirm you own the rights or the book is in the public domain.')
+      return
+    }
     setError(null)
     setUploadProgress(0)
     try {
@@ -160,6 +165,23 @@ export default function UploadScreen() {
             </View>
           )}
 
+          {!uploading && (
+            <TouchableOpacity
+              style={styles.rightsRow}
+              onPress={() => setOwnsRights(v => !v)}
+              accessibilityRole="checkbox"
+              accessibilityState={{ checked: ownsRights }}
+              accessibilityLabel="I own the rights to this book or it is in the public domain"
+            >
+              <View style={[styles.checkbox, ownsRights && styles.checkboxChecked]}>
+                {ownsRights && <Text style={styles.checkmark}>✓</Text>}
+              </View>
+              <Text style={styles.rightsText}>
+                I own the rights to this book or it is in the public domain.
+              </Text>
+            </TouchableOpacity>
+          )}
+
           {uploading ? (
             <View style={styles.uploadingBox}>
               <View style={styles.uploadProgressBar}>
@@ -177,10 +199,12 @@ export default function UploadScreen() {
             </View>
           ) : (
             <TouchableOpacity
-              style={styles.pickBtn}
+              style={[styles.pickBtn, !ownsRights && styles.pickBtnDisabled]}
               onPress={pickAndUpload}
+              disabled={!ownsRights}
               accessibilityLabel="Choose file to upload"
               accessibilityRole="button"
+              accessibilityState={{ disabled: !ownsRights }}
             >
               <Text style={styles.pickBtnText}>Choose File</Text>
             </TouchableOpacity>
@@ -215,7 +239,32 @@ const styles = StyleSheet.create({
     paddingHorizontal: 48,
     borderRadius: 12,
   },
+  pickBtnDisabled: { opacity: 0.4 },
   pickBtnText: { color: '#fff', fontSize: 17, fontWeight: '600' },
+  rightsRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 10,
+    marginBottom: 24,
+    paddingHorizontal: 8,
+    maxWidth: 320,
+  },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: 4,
+    borderWidth: 2,
+    borderColor: colors.textSecondary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 2,
+  },
+  checkboxChecked: {
+    backgroundColor: colors.primary,
+    borderColor: colors.primary,
+  },
+  checkmark: { color: '#fff', fontSize: 14, fontWeight: '700', lineHeight: 16 },
+  rightsText: { flex: 1, fontSize: 13, color: colors.text, lineHeight: 18 },
   uploadingBox: { alignItems: 'center', gap: 12, width: '100%', maxWidth: 280 },
   uploadProgressBar: {
     width: '100%',

--- a/apps/web/src/components/library/UploadSection.tsx
+++ b/apps/web/src/components/library/UploadSection.tsx
@@ -11,6 +11,7 @@ export function UploadSection({ onUploadComplete }: UploadSectionProps) {
   const [error, setError] = useState<string | null>(null)
   const [quota, setQuota] = useState<StorageQuota | null>(null)
   const [isDragging, setIsDragging] = useState(false)
+  const [ownsRights, setOwnsRights] = useState(false)
 
   // Fetch quota on mount
   useEffect(() => {
@@ -20,6 +21,10 @@ export function UploadSection({ onUploadComplete }: UploadSectionProps) {
   }, [])
 
   const handleUpload = useCallback(async (file: File) => {
+    if (!ownsRights) {
+      setError('Please confirm you own the rights or the book is in the public domain.')
+      return
+    }
     setError(null)
     setIsUploading(true)
     setUploadProgress(0)
@@ -37,7 +42,7 @@ export function UploadSection({ onUploadComplete }: UploadSectionProps) {
       setIsUploading(false)
       setUploadProgress(0)
     }
-  }, [onUploadComplete])
+  }, [onUploadComplete, ownsRights])
 
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -76,8 +81,17 @@ export function UploadSection({ onUploadComplete }: UploadSectionProps) {
 
   return (
     <div className="upload-section">
+      <label className="upload-section__rights">
+        <input
+          type="checkbox"
+          checked={ownsRights}
+          onChange={(e) => setOwnsRights(e.target.checked)}
+          disabled={isUploading}
+        />
+        <span>I own the rights to this book or it is in the public domain.</span>
+      </label>
       <div
-        className={`upload-section__dropzone ${isDragging ? 'upload-section__dropzone--dragging' : ''} ${isUploading ? 'upload-section__dropzone--uploading' : ''}`}
+        className={`upload-section__dropzone ${isDragging ? 'upload-section__dropzone--dragging' : ''} ${isUploading ? 'upload-section__dropzone--uploading' : ''} ${!ownsRights ? 'upload-section__dropzone--disabled' : ''}`}
         onDrop={handleDrop}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
@@ -86,8 +100,8 @@ export function UploadSection({ onUploadComplete }: UploadSectionProps) {
           type="file"
           accept=".epub,.pdf,.fb2"
           onChange={handleFileSelect}
-          disabled={isUploading}
-          style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', opacity: 0, cursor: 'pointer', zIndex: 2 }}
+          disabled={isUploading || !ownsRights}
+          style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', opacity: 0, cursor: ownsRights ? 'pointer' : 'not-allowed', zIndex: 2 }}
         />
 
         {isUploading ? (

--- a/apps/web/src/styles/books.css
+++ b/apps/web/src/styles/books.css
@@ -3447,6 +3447,26 @@ html.dark .search-page__sub-result-highlight b {
   opacity: 0.7;
 }
 
+.upload-section__dropzone--disabled {
+  opacity: 0.5;
+}
+
+.upload-section__rights {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 12px;
+  font-size: 13px;
+  color: var(--color-text, #222);
+  cursor: pointer;
+  line-height: 1.4;
+}
+
+.upload-section__rights input[type="checkbox"] {
+  margin-top: 2px;
+  cursor: pointer;
+}
+
 .upload-section__icon {
   color: var(--color-text-secondary, #555);
   margin-bottom: 16px;


### PR DESCRIPTION
## Summary
- Web + mobile upload forms now gate on a rights warranty checkbox ("I own the rights / public domain")
- Dropzone + file picker disabled until user confirms
- First legal de-risk step for pre-sale cleanup

## Test plan
- [x] Web: dropzone greyed + input disabled until checkbox checked (verified in browser)
- [x] Mobile: Choose File button opacity 0.4 + disabled until checked
- [x] Web prod build clean
- [x] Mobile tsc --noEmit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)