### PR TITLE
legal: GDPR cookie banner + Google Consent Mode v2

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -46,13 +46,21 @@
       }
     }
     </script>
-    <!-- Ahrefs Web Analytics -->
-    <script src="https://analytics.ahrefs.com/analytics.js" data-key="2oq1kt/zWCddxFtUBZPE9w" async></script>
-    <!-- Google tag (gtag.js) -->
+    <!-- Google tag (gtag.js) with Consent Mode v2 — analytics denied until user consents.
+         CookieBanner flips consent on Accept and lazy-loads Ahrefs. -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-C6QM16WQGE"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
+      gtag('consent', 'default', {
+        ad_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
+        analytics_storage: 'denied',
+        functionality_storage: 'granted',
+        security_storage: 'granted',
+        wait_for_update: 500
+      });
       gtag('js', new Date());
       gtag('config', 'G-C6QM16WQGE');
       gtag('config', 'G-3ZNR40KDFP');

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -36,6 +36,7 @@ import { NotFoundPage } from './pages/NotFoundPage'
 import { Header } from './components/Header'
 import { DownloadProgressBar } from './components/DownloadProgressBar'
 import { AuthModal } from './components/auth/AuthModal'
+import { CookieBanner } from './components/CookieBanner'
 import { Toast } from './components/Toast'
 import { useTranslation } from './hooks/useTranslation'
 import './styles/theme.css'
@@ -165,6 +166,7 @@ function App() {
           </NativeLanguageProvider>
           </GuestLimitsProvider>
           <AuthModal />
+          <CookieBanner />
         </AuthProvider>
       </SiteProvider>
     </BrowserRouter>

--- a/apps/web/src/components/CookieBanner.tsx
+++ b/apps/web/src/components/CookieBanner.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react'
+import { LocalizedLink } from './LocalizedLink'
+import { useTranslation } from '../hooks/useTranslation'
+import '../styles/cookie-banner.css'
+
+const STORAGE_KEY = 'cookieConsent'
+const AHREFS_KEY = '2oq1kt/zWCddxFtUBZPE9w'
+
+type Choice = 'accepted' | 'rejected'
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void
+  }
+}
+
+function grantAnalytics() {
+  window.gtag?.('consent', 'update', {
+    analytics_storage: 'granted',
+    ad_storage: 'granted',
+    ad_user_data: 'granted',
+    ad_personalization: 'granted',
+  })
+  if (!document.querySelector('script[data-ahrefs]')) {
+    const s = document.createElement('script')
+    s.src = 'https://analytics.ahrefs.com/analytics.js'
+    s.async = true
+    s.dataset.key = AHREFS_KEY
+    s.dataset.ahrefs = '1'
+    document.head.appendChild(s)
+  }
+}
+
+export function CookieBanner() {
+  const { t } = useTranslation()
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const choice = localStorage.getItem(STORAGE_KEY) as Choice | null
+    if (choice === 'accepted') {
+      grantAnalytics()
+      return
+    }
+    if (choice === 'rejected') return
+    setVisible(true)
+  }, [])
+
+  const accept = () => {
+    localStorage.setItem(STORAGE_KEY, 'accepted')
+    grantAnalytics()
+    setVisible(false)
+  }
+
+  const reject = () => {
+    localStorage.setItem(STORAGE_KEY, 'rejected')
+    setVisible(false)
+  }
+
+  if (!visible) return null
+
+  return (
+    <div className="cookie-banner" role="dialog" aria-labelledby="cookie-banner-title">
+      <div className="cookie-banner__inner">
+        <div className="cookie-banner__text">
+          <strong id="cookie-banner-title">{t('cookieBanner.title')}</strong>
+          <p>
+            {t('cookieBanner.body')}{' '}
+            <LocalizedLink to="/privacy">{t('cookieBanner.privacyLink')}</LocalizedLink>.
+          </p>
+        </div>
+        <div className="cookie-banner__actions">
+          <button type="button" className="cookie-banner__btn cookie-banner__btn--secondary" onClick={reject}>
+            {t('cookieBanner.reject')}
+          </button>
+          <button type="button" className="cookie-banner__btn cookie-banner__btn--primary" onClick={accept}>
+            {t('cookieBanner.accept')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -174,6 +174,13 @@
       }
     }
   },
+  "cookieBanner": {
+    "title": "We use cookies",
+    "body": "Essential cookies keep you signed in and save your reading progress. Analytics cookies help us understand how the site is used. You can reject analytics — we still work without them. Learn more in our",
+    "privacyLink": "Privacy Policy",
+    "accept": "Accept all",
+    "reject": "Reject analytics"
+  },
   "reader": {
     "wordPopup": {
       "known": "Known",

--- a/apps/web/src/styles/cookie-banner.css
+++ b/apps/web/src/styles/cookie-banner.css
@@ -1,0 +1,83 @@
+.cookie-banner {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  background: var(--color-bg, #fff);
+  border-top: 1px solid var(--color-border, #e5e5e5);
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.08);
+  padding: 16px;
+}
+
+.cookie-banner__inner {
+  max-width: 1080px;
+  margin: 0 auto;
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.cookie-banner__text {
+  flex: 1;
+  min-width: 260px;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--color-text, #222);
+}
+
+.cookie-banner__text strong {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 14px;
+}
+
+.cookie-banner__text p {
+  margin: 0;
+}
+
+.cookie-banner__text a {
+  color: var(--color-brand, #C4704B);
+  text-decoration: underline;
+}
+
+.cookie-banner__actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.cookie-banner__btn {
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: opacity 0.15s ease;
+}
+
+.cookie-banner__btn:hover {
+  opacity: 0.85;
+}
+
+.cookie-banner__btn--primary {
+  background: var(--color-text, #222);
+  color: var(--color-bg, #fff);
+}
+
+.cookie-banner__btn--secondary {
+  background: transparent;
+  color: var(--color-text, #222);
+  border-color: var(--color-border, #d0d0d0);
+}
+
+@media (max-width: 600px) {
+  .cookie-banner__actions {
+    width: 100%;
+  }
+  .cookie-banner__btn {
+    flex: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- Google Consent Mode v2: ads + analytics default=denied until user consents
- Ahrefs script moved from HTML to lazy inject — only fires after Accept
- New \`CookieBanner\` bottom bar with Accept / Reject, choice in localStorage
- Link to Privacy Policy

## Test plan
- [x] Fresh visit: banner visible on \`/en\`
- [x] Accept: banner dismisses, gtag consent update pushed, Ahrefs injected, \`cookieConsent=accepted\` in LS
- [x] Reject: banner dismisses, no Ahrefs, consent stays denied
- [x] Reload after choice: banner does not reappear
- [x] Web prod build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)