### PR TITLE
reader: clamp overall progress monotonic per session

### DIFF
--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -354,7 +354,17 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
   }, [scrollReaderBook, scrollReader.visibleIdentifier, chapterScrollProgress])
 
   // Force 100% when book is completed
-  const overallProgress = bookCompleted ? 1 : calculatedProgress
+  const rawProgress = bookCompleted ? 1 : calculatedProgress
+
+  // Clamp progress monotonically within a session: scrolling down must never
+  // reduce the bar. Fixes jitter from chapter-boundary scroll handoff and
+  // Math.round flipping between 99/100.
+  const maxProgressRef = useRef(0)
+  useEffect(() => {
+    maxProgressRef.current = 0
+  }, [book?.id])
+  if (rawProgress > maxProgressRef.current) maxProgressRef.current = rawProgress
+  const overallProgress = maxProgressRef.current
 
   // Reading session tracking (time, words)
   const readingSession = useReadingSession({


### PR DESCRIPTION
## Summary

- Progress bar could briefly drop (e.g., 100 → 99) while scrolling down, from chapter-boundary handoff or `Math.round` flip
- Clamp `overallProgress` to monotonic maximum per session via ref; reset on `book.id` change

## Test plan

- [ ] Scroll to end of any book — bar reaches 100% and stays
- [ ] Navigate between chapters — bar doesn't regress
- [ ] `reader-progress.spec.ts` e2e passes without retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)