### PR TITLE
api: rate limit /translate + /api/dictionary (per-IP)

### DIFF
--- a/backend/src/Api/Endpoints/DictionaryEndpoints.cs
+++ b/backend/src/Api/Endpoints/DictionaryEndpoints.cs
@@ -9,7 +9,7 @@ public static class DictionaryEndpoints
     {
         var group = app.MapGroup("/api/dictionary").WithTags("Dictionary");
 
-        group.MapGet("/{lang}/{word}", LookupWord).WithName("LookupWord");
+        group.MapGet("/{lang}/{word}", LookupWord).WithName("LookupWord").RequireRateLimiting("dictionary");
     }
 
     private static async Task<IResult> LookupWord(

--- a/backend/src/Api/Endpoints/TranslationEndpoints.cs
+++ b/backend/src/Api/Endpoints/TranslationEndpoints.cs
@@ -10,11 +10,11 @@ public static class TranslationEndpoints
     {
         var group = app.MapGroup("/api/translate").WithTags("Translation");
 
-        group.MapPost("", Translate).WithName("Translate");
+        group.MapPost("", Translate).WithName("Translate").RequireRateLimiting("translate");
         group.MapGet("/languages", GetLanguages).WithName("GetTranslationLanguages");
 
         // Also map without /api/ prefix for nginx compatibility
-        app.MapPost("/translate", Translate).WithTags("Translation").WithName("TranslateCompat");
+        app.MapPost("/translate", Translate).WithTags("Translation").WithName("TranslateCompat").RequireRateLimiting("translate");
     }
 
     private static async Task<IResult> Translate(

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -213,6 +213,33 @@ builder.Services.AddRateLimiter(options =>
             QueueLimit = 0,
         });
     });
+    // Translation — per-IP. LibreTranslate is the upstream cost; users
+    // typically call 1-3 times per reading session via SelectionToolbar.
+    // 30/min is generous for normal UX, blocks scripted scraping of the
+    // translation service.
+    options.AddPolicy("translate", httpContext =>
+    {
+        var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
+        {
+            Window = TimeSpan.FromMinutes(1),
+            PermitLimit = 30,
+            QueueLimit = 0,
+        });
+    });
+    // Dictionary lookup — per-IP. Proxies Free Dictionary API (cheap,
+    // public). Users tap words rapidly while reading; 60/min fits the
+    // natural pace and still caps scripted abuse.
+    options.AddPolicy("dictionary", httpContext =>
+    {
+        var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
+        {
+            Window = TimeSpan.FromMinutes(1),
+            PermitLimit = 60,
+            QueueLimit = 0,
+        });
+    });
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
     // Emit Retry-After so clients can back off intelligently instead of
     // hammering in a tight retry loop. RateLimiter exposes the metadata


### PR DESCRIPTION
## Summary

- Per-IP fixed-window limits on two previously un-ratelimited endpoints
- \`translate\`: 30/min (LibreTranslate upstream cost, bursts blocked)
- \`dictionary\`: 60/min (free upstream, cheap but blocks scrapers)
- TTS already had rate limits (tts, tts-voices)

## Test plan

- [ ] 31st translate call within 1 min returns 429 with Retry-After
- [ ] 61st dictionary call within 1 min returns 429 with Retry-After
- [ ] Existing limits (auth, guest-session, tts) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)