### PR TITLE
presale: admin JWT hardening — 15min access + refresh token GC

### DIFF
--- a/backend/src/Application/AdminSettings/AdminSettingsService.cs
+++ b/backend/src/Application/AdminSettings/AdminSettingsService.cs
@@ -12,7 +12,7 @@ public class AdminSettingsService
 
     private const string AccessTokenExpiryKey = "session.accessTokenExpiryMinutes";
     private const string RefreshTokenExpiryKey = "session.refreshTokenExpiryDays";
-    private const int DefaultAccessTokenExpiryMinutes = 60;
+    private const int DefaultAccessTokenExpiryMinutes = 15;
     private const int DefaultRefreshTokenExpiryDays = 30;
     private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
 

--- a/backend/src/Worker/Program.cs
+++ b/backend/src/Worker/Program.cs
@@ -71,6 +71,9 @@ builder.Services.AddHostedService<IngestionWorker>();
 // Guest cleanup (purge inactive guests every 6h)
 builder.Services.AddHostedService<GuestCleanupWorker>();
 
+// Admin refresh token cleanup (purge expired rows daily)
+builder.Services.AddHostedService<AdminRefreshTokenCleanupWorker>();
+
 // TextStack watcher (optional, enable via config)
 if (builder.Configuration.GetValue("TextStack:EnableWatcher", false))
 {

--- a/backend/src/Worker/Services/AdminRefreshTokenCleanupWorker.cs
+++ b/backend/src/Worker/Services/AdminRefreshTokenCleanupWorker.cs
@@ -1,0 +1,53 @@
+using Application.Common.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Worker.Services;
+
+public class AdminRefreshTokenCleanupWorker(
+    IServiceScopeFactory scopeFactory,
+    ILogger<AdminRefreshTokenCleanupWorker> logger) : BackgroundService
+{
+    // Run daily — expired rows are harmless (rejected by RefreshTokenAsync ExpiresAt filter)
+    // but accumulate forever on an admin-only table. Hourly is overkill.
+    private static readonly TimeSpan Interval = TimeSpan.FromHours(24);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("Admin refresh token cleanup worker started (interval: {Interval})", Interval);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await CleanupAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error during admin refresh token cleanup");
+            }
+
+            await Task.Delay(Interval, stoppingToken);
+        }
+    }
+
+    private async Task CleanupAsync(CancellationToken ct)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<IAppDbContext>();
+
+        var now = DateTimeOffset.UtcNow;
+        var deleted = await db.AdminRefreshTokens
+            .Where(t => t.ExpiresAt < now)
+            .ExecuteDeleteAsync(ct);
+
+        if (deleted > 0)
+            logger.LogInformation("Deleted {Count} expired admin refresh tokens", deleted);
+    }
+}


### PR DESCRIPTION
## Summary

- Default admin access-token expiry: 60min → 15min (tighter blast radius on leak)
- New `AdminRefreshTokenCleanupWorker` — daily `ExecuteDeleteAsync` on expired rows, stops unbounded growth on admin-only table
- Existing admin-settings overrides preserved; only unset default changes

## Test plan

- [x] backend build green
- [x] worker build green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)