### PR TITLE
presale: remove Meilisearch from default compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,8 @@ GOOGLE_CLIENT_ID=<google-client-id>
 # Environment
 ASPNETCORE_ENVIRONMENT=Production
 
-# Search (postgres or meilisearch)
+# Search (postgres — Meilisearch provider exists in code but not in default compose)
 SEARCH_PROVIDER=postgres
-MEILI_MASTER_KEY=
 
 # IndexNow (Bing/Yandex instant indexing)
 INDEXNOW_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,7 +361,7 @@ Upload EPUB/PDF/FB2 → BookFile (stored) → IngestionJob (queued)
 
 Two providers, swappable via `SEARCH_PROVIDER` env var (default: `postgres`):
 - **PostgreSQL FTS**: Raw SQL (Dapper) in `TextStack.Search/Providers/PostgresFts/PostgresSearchProvider.cs`
-- **Meilisearch**: `TextStack.Search.Meilisearch/` — typo tolerance, better ranking, faceting. Docker service `meilisearch:v1.12`, config: `MEILI_MASTER_KEY`
+- **Meilisearch** (optional): `TextStack.Search.Meilisearch/`. Not in default compose — add service manually if used
 
 Reindex: `make reindex-search`
 
@@ -436,13 +436,13 @@ Internet → Cloudflare (DNS+SSL) → Cloudflare Tunnel → nginx (port 80)
   └─ textstack.dev → admin panel (:81)
 ```
 
-Docker services: `db` (postgres:16), `migrator`, `api`, `worker`, `admin`, `ssg-worker`, `aspire-dashboard`, `libretranslate`, `ollama`, `meilisearch`. All localhost-only, no public ports except 80 via tunnel.
+Docker services: `db` (postgres:16), `migrator`, `api`, `worker`, `admin`, `ssg-worker`, `aspire-dashboard` (profile-gated), `libretranslate`, `ollama`. All localhost-only, no public ports except 80 via tunnel.
 
 **Nginx bot detection**: Regex map identifies crawlers (Google, Bing, Yandex, social bots) → routes to prerendered SSG HTML. Rate limiting zones: API (10r/s), uploads (1r/s), translation (5r/m).
 
 **Systemd services**: `seo-publish-poller` (auto-publish with SEO generation).
 
-**Notable env vars** (beyond `.env.example` basics): `SEARCH_PROVIDER=postgres|meilisearch`, `MEILI_MASTER_KEY`, `INDEXNOW_KEY`, `INDEXNOW_ENABLED`.
+**Notable env vars** (beyond `.env.example` basics): `SEARCH_PROVIDER=postgres` (or `meilisearch` if running a Meilisearch container manually), `INDEXNOW_KEY`, `INDEXNOW_ENABLED`.
 
 ## Extraction Pipeline
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@
 |-------|-----------|
 | API | ASP.NET Core (.NET 10), Minimal APIs |
 | Database | PostgreSQL 16, EF Core (snake_case) |
-| Search | PostgreSQL FTS / Meilisearch (swappable) |
-| Frontend | React 18, Vite, pnpm, CSS Variables |
+| Search | PostgreSQL FTS (Meilisearch provider optional) |
+| Frontend | React 19, Vite, pnpm, CSS Variables |
 | Admin | React (separate app), JWT auth |
 | Mobile | React Native (Expo) |
 | TTS | Edge TTS (WebSocket, no API key) |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,8 +63,6 @@ services:
       Google__ClientId: ${GOOGLE_CLIENT_ID}
       LibreTranslate__BaseUrl: http://libretranslate:5000
       Search__Provider: ${SEARCH_PROVIDER:-postgres}
-      Search__Meilisearch__Url: http://meilisearch:7700
-      Search__Meilisearch__MasterKey: ${MEILI_MASTER_KEY:-changeme}
       Tts__CachePath: /data/tts-cache
       Ollama__BaseUrl: http://ollama:11434
       Ollama__Model: qwen3:8b
@@ -107,8 +105,6 @@ services:
       ConnectionStrings__Default: "Host=db;Port=5432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
       Storage__RootPath: /storage
       Search__Provider: ${SEARCH_PROVIDER:-postgres}
-      Search__Meilisearch__Url: http://meilisearch:7700
-      Search__Meilisearch__MasterKey: ${MEILI_MASTER_KEY:-changeme}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://aspire-dashboard:18889
     volumes:
       - ./data/storage:/storage
@@ -174,32 +170,6 @@ services:
           memory: 2G
         reservations:
           memory: 512M
-
-  # ===========================================
-  # Meilisearch - Full-text search engine
-  # ===========================================
-
-  meilisearch:
-    image: getmeili/meilisearch:v1.12
-    container_name: textstack_meilisearch
-    environment:
-      MEILI_MASTER_KEY: ${MEILI_MASTER_KEY:-changeme}
-      MEILI_ENV: production
-    volumes:
-      - ./data/meilisearch:/meili_data
-    restart: always
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:7700/health || exit 1"]
-      interval: 15s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-    deploy:
-      resources:
-        limits:
-          memory: 1G
-        reservations:
-          memory: 256M
 
   # ===========================================
   # Observability - Aspire Dashboard (all-in-one: traces, logs, metrics)


### PR DESCRIPTION
## Summary

- Prod already runs `SEARCH_PROVIDER=postgres`. Meilisearch container consumed 256MB–1GB idle RAM for no runtime value
- Removes `meilisearch` service + env refs from compose; drops `MEILI_MASTER_KEY` from `.env.example`
- Code path (`TextStack.Search.Meilisearch`) left intact — buyers can re-add the service if they want typo-tolerance later
- Aspire dashboard already profile-gated; no change

## Test plan

- [x] `docker compose config` valid
- [x] `dotnet build textstack.sln` green
- [ ] CI (backend, e2e)
- [ ] Post-deploy: verify `/api/search?q=test` still serves on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)