### PR TITLE
presale: healthchecks for worker, ssg-worker, admin

### DIFF
--- a/apps/web/scripts/ssg-worker.mjs
+++ b/apps/web/scripts/ssg-worker.mjs
@@ -310,6 +310,17 @@ async function main() {
     process.exit(1);
   }
 
+  // Heartbeat file — docker healthcheck reads mtime
+  const HEARTBEAT = '/tmp/ssg-worker-alive';
+  setInterval(() => {
+    try {
+      writeFileSync(HEARTBEAT, new Date().toISOString());
+    } catch (err) {
+      console.warn('Failed to write heartbeat:', err.message);
+    }
+  }, 30_000);
+  writeFileSync(HEARTBEAT, new Date().toISOString());
+
   // Main polling loop
   while (true) {
     try {

--- a/backend/src/Worker/Program.cs
+++ b/backend/src/Worker/Program.cs
@@ -74,6 +74,9 @@ builder.Services.AddHostedService<GuestCleanupWorker>();
 // Admin refresh token cleanup (purge expired rows daily)
 builder.Services.AddHostedService<AdminRefreshTokenCleanupWorker>();
 
+// Heartbeat file for docker healthcheck
+builder.Services.AddHostedService<HeartbeatWorker>();
+
 // TextStack watcher (optional, enable via config)
 if (builder.Configuration.GetValue("TextStack:EnableWatcher", false))
 {

--- a/backend/src/Worker/Services/HeartbeatWorker.cs
+++ b/backend/src/Worker/Services/HeartbeatWorker.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Worker.Services;
+
+// Docker healthcheck reads file mtime. Interval + grace must exceed worker's
+// longest normal pause (ingestion polling is ~5s, so 30s heartbeat + 2min grace
+// is comfortably safe — only hangs/OOM will miss the window).
+public class HeartbeatWorker(ILogger<HeartbeatWorker> logger) : BackgroundService
+{
+    private const string HeartbeatPath = "/tmp/worker-alive";
+    private static readonly TimeSpan Interval = TimeSpan.FromSeconds(30);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("Heartbeat worker started (file: {Path}, interval: {Interval})",
+            HeartbeatPath, Interval);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await File.WriteAllTextAsync(HeartbeatPath,
+                    DateTimeOffset.UtcNow.ToString("O"), stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to write heartbeat");
+            }
+
+            await Task.Delay(Interval, stoppingToken);
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,14 @@ services:
     volumes:
       - ./data/storage:/storage
     restart: always
+    healthcheck:
+      # HeartbeatWorker writes /tmp/worker-alive every 30s. 2min grace covers
+      # GC pauses and brief ingestion stalls without false-negatives.
+      test: ["CMD-SHELL", "find /tmp/worker-alive -mmin -2 | grep -q ."]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     depends_on:
       db:
         condition: service_healthy
@@ -131,6 +139,12 @@ services:
     ports:
       - "127.0.0.1:81:81"  # Only localhost - not exposed to internet
     restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:81/ > /dev/null || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     depends_on:
       - api
     deploy:
@@ -159,6 +173,13 @@ services:
     volumes:
       - ./apps/web/dist:/app/dist
     restart: always
+    healthcheck:
+      # ssg-worker.mjs writes /tmp/ssg-worker-alive every 30s.
+      test: ["CMD-SHELL", "find /tmp/ssg-worker-alive -mmin -2 | grep -q ."]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     depends_on:
       api:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- **worker**: new `HeartbeatWorker` BackgroundService writes `/tmp/worker-alive` every 30s → compose healthcheck checks mtime < 2min
- **ssg-worker**: `setInterval` writes `/tmp/ssg-worker-alive` every 30s; same mtime check
- **admin**: wget probe on port 81

Heartbeat-file pattern chosen over embedding an HTTP listener in the .NET worker / Node SSG worker — zero extra ports, matches the background-only nature.

## Test plan

- [x] `dotnet build Worker.csproj` green
- [x] `docker compose config` valid
- [ ] CI
- [ ] Post-deploy: `docker compose ps` shows all four services healthy within ~90s

🤖 Generated with [Claude Code](https://claude.com/claude-code)