### PR TITLE
presale: bus-factor READMEs for infra/scripts + systemd

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,8 @@ Free book library with Kindle-like reader. EPUB/PDF/FB2 upload, parsing, SEO pag
 | [Backup & Restore](03-ops/backup.md) | `make backup`, GHA daily dump, restore drill |
 | [Uptime Monitoring](03-ops/uptime-monitoring.md) | External probes + alert runbook |
 | [Incident Runbook](03-ops/incident-runbook.md) | First-response for DB/worker/SSG/site outages |
+| [infra/scripts/README](../infra/scripts/README.md) | Pollers (SEO publish, SEO backfill, quality) — what, install, logs |
+| [infra/systemd/README](../infra/systemd/README.md) | User-level systemd units |
 | [E2E Testing Guide](04-dev/e2e-guide.md) | Playwright setup, UI mode, troubleshooting |
 | [LLM Provider Swap](04-dev/llm-provider-swap.md) | Swap Ollama → OpenAI/Anthropic API (2 files) |
 

--- a/infra/scripts/README.md
+++ b/infra/scripts/README.md
@@ -1,0 +1,93 @@
+# infra/scripts
+
+Long-running shell pollers that run on the prod server. Each one watches
+Postgres (or an API endpoint) for queued jobs, dispatches work through the
+Claude CLI, and reports back.
+
+All scripts run as the unprivileged deploy user under **systemd --user**.
+Units live next door in [`../systemd/`](../systemd/README.md).
+
+## Scripts
+
+| Script | Purpose | Run as |
+|--------|---------|--------|
+| `seo-publish-poll.sh` | Polls `auto_publish_jobs`. Generates SEO fields (description, relevance, themes, FAQs) via Claude CLI, then publishes drafts. | systemd unit `seo-publish-poller` |
+| `seo-backfill-poll.sh` | Polls `seo_backfill_jobs` via API (not DB directly — API owns state machine). Dispatches `seo-backfill-generate.sh` per job. | systemd unit `seo-backfill-poller` |
+| `seo-backfill-generate.sh` | One-shot per-job runner: fetches rendered prompts from API, invokes Claude CLI per field with retries, POSTs output back. | Invoked by `seo-backfill-poll.sh` |
+| `seo-generate.sh` | Manual SEO generation for a single edition or author. Admin-invoked, not polled. | `./infra/scripts/seo-generate.sh edition <uuid>` |
+| `quality-poll.sh` | Polls `book_quality_jobs`. Validates book text (spelling, formatting) then applies fixes via internal API. | systemd unit `quality-poller` |
+
+## Dependencies
+
+All scripts require:
+- **`claude` CLI** on PATH — paid Max subscription. The deploy user must have
+  `claude` logged in (`~/.claude` config must exist and be readable).
+- **`curl`**, **`jq`** — standard tooling.
+- **`docker`** with `textstack_db_prod` running (for scripts that shell into
+  `psql` directly — mostly `seo-publish-poll.sh`, `seo-generate.sh`,
+  `quality-poll.sh`).
+- **`textstack_api_prod`** reachable at `http://localhost:8080` (for scripts
+  that go through API: `seo-backfill-*`).
+
+Internal API endpoints (`/internal/**`) are only reachable from within the
+Docker network — scripts run on the host, so they hit `localhost:8080`.
+
+## Logs
+
+```bash
+journalctl --user -u seo-publish-poller -f
+journalctl --user -u seo-backfill-poller -f
+journalctl --user -u quality-poller -f
+```
+
+Or via Makefile where available:
+```bash
+make seo-backfill-logs
+```
+
+## Install / restart / stop
+
+Each poller has a bundle of Makefile targets. Pattern:
+
+| Action | Command |
+|--------|---------|
+| Install + start | `make <name>-setup` |
+| Status | `make <name>-status` |
+| Follow logs | `make <name>-logs` |
+| Restart | `make <name>-restart` |
+| Stop | `make <name>-stop` |
+
+Installed units (all currently):
+- `seo-publish-poller` — `make seo-publish-setup` / `-status`
+- `seo-backfill-poller` — `make seo-backfill-setup` / `-status` / `-logs` /
+  `-restart` / `-stop`
+- `quality-poller` — no Makefile shortcut yet; `systemctl --user enable
+  quality-poller && systemctl --user start quality-poller`
+
+First-time host setup requires `loginctl enable-linger $(whoami)` so that
+user-level systemd survives logout (the `-setup` targets call this).
+
+## What to monitor
+
+| Signal | What it means |
+|--------|--------------|
+| `systemctl --user is-active <unit>` != `active` | Poller crashed, restart pending or exhausted (`Restart=on-failure`, 5 attempts over 300s). |
+| `journalctl` shows repeated `claude: command not found` | `claude` CLI missing for deploy user, or subscription lapsed. |
+| Jobs stuck in `Running` in DB > 30 min | CLI hung. Restart the relevant poller. |
+| `seo_backfill_jobs` all `Failed` | Check Resend admin alert emails (`ADMIN_ALERT_EMAIL`). Usually prompt validation error — see API logs. |
+
+## When to **not** install a poller
+
+The pollers burn Claude API tokens on a schedule. Only install what you use:
+- `seo-publish-poller` — needed if you rely on **admin → Auto Publish**.
+- `seo-backfill-poller` — needed if you rely on **admin → SEO Backfill**.
+- `quality-poller` — optional book-text QA; can stay off in a fresh deploy.
+
+The API itself works without any poller running — jobs just queue up without
+being processed.
+
+## See also
+
+- [`../systemd/README.md`](../systemd/README.md) — unit files
+- [`docs/03-ops/incident-runbook.md`](../../docs/03-ops/incident-runbook.md) — first-response steps
+- [CLAUDE.md](../../CLAUDE.md#auto-publish) — Auto Publish feature overview

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -1,0 +1,72 @@
+# infra/systemd
+
+User-level systemd unit files for the long-running pollers in
+[`../scripts/`](../scripts/README.md).
+
+Why **user-level** (`systemctl --user`) and not system-wide?
+- No root required — deploy user owns everything.
+- Survives deploys: `git pull` doesn't touch `~/.config/systemd/user/`.
+- Requires `loginctl enable-linger <user>` so units keep running after logout
+  (the `make <name>-setup` targets handle this automatically).
+
+## Units
+
+| File | Service | ExecStart |
+|------|---------|-----------|
+| `seo-publish-poller.service` | SEO Auto-Publish | `infra/scripts/seo-publish-poll.sh` |
+| `seo-backfill-poller.service` | SEO Backfill | `infra/scripts/seo-backfill-poll.sh` |
+| `quality-poller.service` | Book Quality validation | `infra/scripts/quality-poll.sh` |
+
+All three share the same shape:
+- `Type=simple`
+- `Restart=on-failure`, `RestartSec=10`
+- `StartLimitBurst=5` over `StartLimitIntervalSec=300` — after 5 crashes in
+  5 min systemd stops retrying (check logs to unblock).
+- Hardcoded `WorkingDirectory=/home/vasyl/projects/onlinelib/textstack` —
+  **edit if the deploy path changes**.
+
+## Install
+
+Done via Makefile targets — they copy the unit into
+`~/.config/systemd/user/`, reload the daemon, enable + start.
+
+```bash
+make seo-publish-setup
+make seo-backfill-setup
+# quality-poller: no make target yet
+systemctl --user enable quality-poller
+systemctl --user start quality-poller
+```
+
+First time on a fresh host:
+```bash
+loginctl enable-linger $(whoami)  # units survive logout
+```
+
+## Manual install (if Makefile target is missing)
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp infra/systemd/<name>.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now <name>
+```
+
+## Uninstall
+
+```bash
+systemctl --user stop <name>
+systemctl --user disable <name>
+rm ~/.config/systemd/user/<name>.service
+systemctl --user daemon-reload
+```
+
+## Status quick-check
+
+```bash
+systemctl --user list-units --type=service | grep poller
+```
+
+All three should show `active running`. If one is `failed` — see
+[`../scripts/README.md`](../scripts/README.md#what-to-monitor) and
+[`docs/03-ops/incident-runbook.md`](../../docs/03-ops/incident-runbook.md).


### PR DESCRIPTION
## Summary
- \`infra/scripts/README.md\` — documents 5 pollers (seo-publish-poll, seo-backfill-poll, seo-backfill-generate, seo-generate, quality-poll): purpose, deps (Claude CLI + docker + curl), run mode, logs, what to monitor, when *not* to install
- \`infra/systemd/README.md\` — 3 user-level units: install via \`make <name>-setup\` targets, status check, uninstall, manual install fallback
- Linked from docs/README.md quick-links

Bus-factor reduction: buyer's ops team can install / diagnose / uninstall pollers without tribal knowledge. Addresses the pre-sale playbook \"Bus-factor docs: \`infra/scripts/*.sh\` + systemd units → README\" item.

## Test plan
- [ ] Render infra/scripts/README.md — commands copy-paste runnable
- [ ] Cross-check Makefile targets referenced exist (seo-publish-setup, seo-backfill-setup/-status/-logs/-restart/-stop) — confirmed present