### PR TITLE
presale: README rewrite + MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vasyl Vdovychenko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PLAN-presale-8w.md
+++ b/PLAN-presale-8w.md
@@ -1,0 +1,195 @@
+# TextStack — 8-Week Pre-Sale Plan
+
+**Start**: 2026-04-22 · **Target**: 2026-06-17 · **Mode**: polish-for-sale + OSS visibility
+
+## North Star (from dev.to marketing launch)
+
+Article: <https://dev.to/mrviduus/i-quit-designing-data-intensive-applications-ddia-three-times-heres-what-i-build-on-the-fourth-5bom>
+
+**Positioning**: A friction-free reader for developers learning AI engineering.
+Not a dictionary lookup — contextual Claude-powered explanations tied to the
+book's domain. Capped weekly SRS queue (not infinite). Modern replacement for
+Kindle Word Wise / LingQ.
+
+**Target user**: developers stuck on AI engineering books (DDIA, ML papers,
+AI textbooks — 15–20 curated corpus).
+
+**CTAs in article**: star the repo · try sample chapters · send feedback
+(Twitter @Rexetdeus, email).
+
+**6-month goal (public)**: one paying customer.
+
+**Anything we build must serve**: (a) sale diligence, OR (b) GitHub star
+conversion, OR (c) Play Store launch. Nothing else.
+
+---
+
+## Constraints
+
+| Constraint | Value |
+|---|---|
+| Timeline | 8 weeks hard (2026-04-22 → 2026-06-17) |
+| Scope | Full — keep Reader/Vocab/TTS/Mobile/Admin/SEO |
+| Books corpus | **Keep** — 1500+ Standard Ebooks (SEO must not regress) |
+| Mobile | Android **must** publish on Play Store; iOS optional |
+| Buyer | Open market (MicroAcquire / Acquire.com / Flippa) |
+| Parallel | Marketing running — repo public, stars matter |
+
+---
+
+## Weekly tracks
+
+### Week 1–2 · Repo polish + legal foundation  *(current, in progress)*
+
+Goal: repo looks like a top product on first GitHub visit; legal ambiguity
+killed.
+
+- [x] Healthchecks — worker/ssg-worker/admin (#137)
+- [x] Stale Blog/Reading Rooms refs cleanup (#138)
+- [x] Docs: uptime runbook + backup rewrite (#139)
+- [x] Incident runbook — 8 outage scenarios (#140)
+- [x] Bus-factor READMEs — infra/scripts + infra/systemd (#141)
+- [ ] **README full rewrite** — hero, screenshots, demo gif, 5-line
+      quick-start, features table aligned with dev.to narrative (AI
+      engineering books, contextual explanations, capped SRS). Critical for
+      star conversion.
+- [ ] **LICENSE file** — pick MIT or Apache-2.0 (recommend MIT for max star
+      potential + commercial reuse by buyer). Add to root.
+- [ ] **COPYRIGHT.md / NOTICE** — break down: our code (MIT), Standard
+      Ebooks corpus (public domain, CC0), OSS deps (inherited), Edge TTS
+      (Microsoft ToS). Sale-critical clarity.
+- [ ] **CONTRIBUTING.md** — how to dev, PR conventions, test expectations
+- [ ] **`.github/ISSUE_TEMPLATE/`** — bug / feature / question
+- [ ] **`.github/PULL_REQUEST_TEMPLATE.md`**
+- [ ] Repo topics on GitHub (reading, spaced-repetition, ai-engineering,
+      dotnet, react, expo, epub, pdf) — helps discovery
+- [ ] GitHub Discussions enabled
+- [ ] Demo link in repo About + pinned in README hero
+
+Acceptance: new visitor lands on repo, in < 30s knows what it is, sees
+demo, clicks star. License is unambiguous to a buyer's lawyer.
+
+### Week 3–4 · Mobile Android → Play Store
+
+Goal: Android app approved + live on Play Store before buyer diligence.
+(Play review = 2–4 weeks, so kick off asap in week 3.)
+
+- [ ] Audit mobile app for crashes / broken flows (Expo + dev build smoke)
+- [ ] EAS production build (Android) — `npm run build:prod`
+- [ ] App icon + feature graphic + 8 screenshots (phone + tablet)
+- [ ] Play Store listing: title, short/full description, category, content
+      rating, target audience, data-safety form
+- [ ] Privacy policy URL (reuse textstack.app/privacy) + terms URL
+- [ ] Internal testing track → closed testing (10+ testers from network) →
+      production rollout
+- [ ] iOS: EAS build + TestFlight (best-effort; ship if time allows)
+- [ ] Deep-links from web → mobile app (book page → app if installed)
+
+Acceptance: Android app live on Play Store, findable by search
+"TextStack" or "reading vocabulary SRS".
+
+### Week 5–6 · SEO defense + marketing infra
+
+Goal: SSG traffic doesn't regress under polish; repo stars compound via
+marketing; buyer sees "healthy growth" graphs.
+
+- [ ] **Search Console integration** — verify property, submit sitemap,
+      enable Indexing API via service account (advanced, but signals pro)
+- [ ] **Coverage alerting** — small script/GHA that fetches Search Console
+      indexing stats daily, alerts if > 5% regression
+- [ ] Structured data validation in CI — fail PR if book/author/blog JSON-LD
+      breaks
+- [ ] **Demo landing** for non-developers — static HTML with "try it"
+      flow, featured on textstack.app home (if not already)
+- [ ] `public/assets/og-image.png` for link previews (Twitter/LinkedIn
+      share looks polished)
+- [ ] Content pipeline for blog-less world: write 3 technical blog posts
+      on dev.to to drive repo stars (one per SRS/TTS/SSG). (Marketing
+      dep — user owns this, not code.)
+- [ ] "How TextStack Works" architecture 1-pager (SVG or PNG) in README
+- [ ] GitHub Actions badge(s) in README (CI, coverage, license)
+
+Acceptance: Search Console property verified, sitemap submitted, indexing
+stable. Repo has shareable OG card. Architecture diagram visible.
+
+### Week 7–8 · Diligence package
+
+Goal: buyer asks "show me the numbers/health" → you hand over one link.
+
+- [ ] Metrics snapshot page (admin-only or separate Notion/sheet):
+      DAU, WAU, retention D1/D7/D30, books read total, vocab words saved,
+      uptime % last 90d
+- [ ] ERD auto-generated from EF Core → `docs/02-system/erd.svg`
+- [ ] Test coverage report (backend + web) published via GHA artifact
+- [ ] `npm audit --production` clean (or documented known CVEs)
+- [ ] `dotnet list package --vulnerable` clean
+- [ ] **DB restore verification script** — `infra/scripts/verify-backup.sh`
+      + `make verify-backup` target; run quarterly + document last-run date
+- [ ] "Buyer setup" section in README — "clone → env → docker compose up
+      → < 1h running locally" benchmarked on a clean laptop
+- [ ] Financials prep (outside code): hosting costs, Claude API spend,
+      domain/cert costs, per-user unit economics (user owns this)
+- [ ] LOI-ready: repo archived state snapshot tag `v1.0-sale-ready`
+
+Acceptance: diligence checklist ticks all green; buyer can inspect
+code, metrics, legal, ops without asking questions for 48 hours.
+
+---
+
+## PR log
+
+| # | Title | Status |
+|---|-------|--------|
+| #137 | Healthchecks worker/ssg/admin | ✅ merged |
+| #138 | Stale Blog/Reading Rooms refs | ✅ merged |
+| #139 | Uptime runbook + backup fix | ✅ merged |
+| #140 | Incident runbook | ✅ merged |
+| #141 | Infra scripts/systemd READMEs | 🟡 auto-merge armed |
+| next | README rewrite | pending |
+
+---
+
+## Marketing signals inbox  *(user updates this)*
+
+Add raw notes from dev.to / Twitter / HN / Reddit reactions. We adjust the
+plan when signals arrive.
+
+- 2026-04-22 · dev.to article published. Angle: "I quit DDIA 3 times…"
+  CTA: star + try + feedback. Need: README narrative must match this
+  before traffic arrives, or conversion drops.
+
+---
+
+## Decision log
+
+| Date | Decision | Why |
+|---|---|---|
+| 2026-04-22 | Keep Standard Ebooks corpus in sale | SEO SSG pages = indexed inventory; removing = traffic hit |
+| 2026-04-22 | Mobile Android in sale, iOS best-effort | Play review ≤ Apple review; Android gets done, iOS gated on time |
+| 2026-04-22 | MIT license (tentative) | Max star potential, max commercial reuse by buyer |
+| 2026-04-22 | Full scope, not trimmed | 8w is enough time; Full = higher ask |
+
+---
+
+## Known risks
+
+1. **Play Store rejection loop** — Android apps get denied for data-safety
+   form mistakes. Mitigation: start week 3, internal testing first.
+2. **SEO regression** — any change to SSG pipeline can drop indexing. Have
+   Search Console property verified before any risky changes.
+3. **Claude API costs under viral traffic** — if dev.to article hits HN
+   front page, explanation endpoint may burn budget. Consider per-IP
+   rate limit on `/explain` + sample-chapter-only gating.
+4. **License ambiguity blocks sale** — must be resolved week 1. No buyer
+   signs without clear IP position.
+5. **Standard Ebooks derivatives IP claim** — our covers/SSG pages are
+   derivatives. Low risk (CC0 base) but prompt a lawyer if buyer asks.
+
+---
+
+## Running punch list  *(discovered mid-flight — triage into a week)*
+
+- [ ] `.github/workflows/health-check.yml` — confirm it still runs every
+      5min and that the email on failure works
+- [ ] README has screenshots folder `docs/assets/` — reuse / extend for
+      hero, feature shots, mobile screenshots

--- a/README.md
+++ b/README.md
@@ -1,179 +1,209 @@
 # TextStack
 
 <p align="center">
-  <img src="docs/assets/hero.png" alt="TextStack — Language learning through reading" width="800">
+  <img src="docs/assets/hero.png" alt="TextStack — deep reading for developers learning AI engineering" width="800">
 </p>
 
 <p align="center">
-  <strong>Language learning platform powered by long-form reading.</strong><br>
-  Read classic literature, build vocabulary with spaced repetition, track your progress.
+  <strong>Deep-reading tool for developers learning AI engineering.</strong><br>
+  Tap an unknown term → context-aware explanation inline. Capped weekly SRS queue.<br>
+  A modern replacement for Kindle Word Wise and LingQ — built for technical books.
 </p>
 
 <p align="center">
-  <a href="https://textstack.app">textstack.app</a>
+  <a href="https://textstack.app">textstack.app</a> ·
+  <a href="https://dev.to/mrviduus/i-quit-designing-data-intensive-applications-ddia-three-times-heres-what-i-build-on-the-fourth-5bom">Why I built it</a> ·
+  <a href="https://twitter.com/Rexetdeus">@Rexetdeus</a>
 </p>
+
+<p align="center">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
+  <img src="https://img.shields.io/badge/.NET-10-512BD4" alt=".NET 10">
+  <img src="https://img.shields.io/badge/React-19-61DAFB" alt="React 19">
+  <img src="https://img.shields.io/badge/Expo-55-000020" alt="Expo 55">
+  <img src="https://img.shields.io/badge/PostgreSQL-16-336791" alt="PostgreSQL 16">
+</p>
+
+---
+
+## The problem
+
+I quit *Designing Data-Intensive Applications* three times. Not because it's
+hard — I understood most of what was on the page. **The problem was the rest:
+unfamiliar terms that broke the flow.** Eventual consistency. Attention
+mechanism. B-tree. Writing each one down to look up later works until you
+have 40 of them and you've lost the thread anyway.
+
+Summarizing books away defeats the point. The only way to get deep
+understanding is to read them — but the friction has to go.
+
+## What TextStack does
+
+**Tap a term → 2–3 sentence Claude-powered explanation tied to the book's
+domain.** Not a dictionary definition. If you tap "attention" in an ML
+textbook you get the ML meaning, not the everyday one.
+
+Terms you don't recognize enter a **capped weekly SRS queue** — no infinite
+backlog, no guilt. Common words and the top 15K English words are filtered
+out; only technical vocabulary gets surfaced.
+
+| What others do | What TextStack does |
+|---|---|
+| Dictionary definitions | Context-aware explanations |
+| Infinite SRS queue | Capped weekly (no spiral) |
+| One-size-fits-all | Domain-aware per book |
+| Static Kindle Word Wise (2014) | Claude-powered (2026) |
+
+## Try it
+
+1. [textstack.app](https://textstack.app) — sample chapters open without
+   signup.
+2. Tap any word you don't recognize.
+3. That's the whole pitch.
 
 ---
 
 ## Features
 
 **Reader**
-- Kindle-like reading experience — themes (light/sepia/dark), fonts, fullscreen, keyboard shortcuts
-- Text selection — dictionary lookup (Free Dictionary API), translation (LibreTranslate), highlights
-- TTS — Edge TTS via direct WebSocket, 200+ voices, speed control (0.75x–2.0x), two-layer cache (server disk + IndexedDB)
-- Offline reading — PWA with IndexedDB caching, download manager, resume support
+- Kindle-like experience — themes (light/sepia/dark), fonts, fullscreen,
+  keyboard shortcuts
+- Text selection — contextual explanation (Claude), dictionary fallback (Free
+  Dictionary API), translation (LibreTranslate), highlights
+- TTS — Edge TTS via direct WebSocket (200+ voices, 0.75×–2.0× speed, two-
+  layer cache)
+- Offline reading — PWA with IndexedDB caching, download manager
 
-**Vocabulary & SRS**
-- Save words while reading — sentence context, dictionary definition, translation
-- Spaced repetition — 5 stages (New → Recognition → Recall → Context → Mastered), 3 review modes (multiple choice, typed recall, context fill-in-the-blank)
-- LLM-generated distractors & hints (Ollama gemma3:4b)
+**Vocabulary SRS**
+- Auto-added while reading — sentence context, definition, translation
+- 5 stages (New → Recognition → Recall → Context → Mastered)
+- Capped weekly queue + LLM-generated distractors and hints (Ollama
+  `qwen3:8b`)
+- Review modes: multiple choice, classic flashcard
 
 **Library**
-- 1,500+ public domain books (English + Ukrainian)
-- User uploads — EPUB/PDF/FB2, auto-parsed with metadata enrichment (Ollama generates genre, year, description)
-- Reading progress sync, bookmarks, highlights
-- Reading stats — heatmap calendar, weekly charts, daily/yearly goals, streak tracking, 20 achievements
+- 1,500+ curated technical and classic books (starter corpus, self-hostable)
+- Your own uploads — EPUB / PDF / FB2, auto-parsed with metadata enrichment
+- Reading progress sync, bookmarks, highlights, reading stats
 
-**SEO**
-- SSG prerendered pages (Puppeteer worker, polls DB every 5s) — books, authors, genres
-- Sitemap XML auto-generation, IndexNow (Bing/Yandex)
-- Article JSON-LD, FAQ schema markup
+**Mobile**
+- React Native (Expo), Android on Google Play
+- Offline-first, same UX as web
 
-**Admin Panel** ([textstack.dev](https://textstack.dev))
-- Book/author/genre CRUD, bulk import, chapter editor
-- SSG rebuild, ingestion queue, settings
+**Admin** ([textstack.dev](https://textstack.dev))
+- Book/author/genre CRUD, chapter editor, ingestion queue
+- SSG rebuild, auto-publish, SEO backfill
 
 ---
 
-## Tech Stack
+## Tech stack
 
 | Layer | Technology |
 |-------|-----------|
-| API | ASP.NET Core (.NET 10), Minimal APIs |
-| Database | PostgreSQL 16, EF Core (snake_case) |
-| Search | PostgreSQL FTS (Meilisearch provider optional) |
-| Frontend | React 19, Vite, pnpm, CSS Variables |
-| Admin | React (separate app), JWT auth |
-| Mobile | React Native (Expo) |
+| Backend | ASP.NET Core (.NET 10), Minimal APIs |
+| Database | PostgreSQL 16 + EF Core (snake_case) |
+| Search | PostgreSQL FTS |
+| Web | React 19, Vite, pnpm |
+| Mobile | React Native (Expo 55) |
+| LLM | Claude (explanations) + Ollama `qwen3:8b` (distractors) |
 | TTS | Edge TTS (WebSocket, no API key) |
 | Translation | LibreTranslate (self-hosted) |
-| LLM | Ollama (gemma3:4b) — metadata, vocab distractors |
 | SSG | Puppeteer prerender, nginx serves static first |
-| Telemetry | OpenTelemetry → .NET Aspire Dashboard |
+| Telemetry | OpenTelemetry → Aspire Dashboard |
 | Infra | Docker Compose, Cloudflare Tunnel, nginx |
 
-**Prerequisites**: Docker, .NET 10 SDK, Node.js 18+, pnpm
+**Architecture**: `API → Application → Domain ← Infrastructure` (modular
+monolith). Worker runs ingestion + SRS scoring + SSG jobs.
 
 ---
 
-## Quick Start
+## Quick start
 
 ```bash
-cp .env.example .env          # Edit with real values
-docker compose up --build     # Start all services
+git clone https://github.com/mrviduus/textstack
+cd textstack
+cp .env.example .env            # edit with real values
+docker compose up --build       # ~3 min cold start
 ```
 
 | Service | URL |
 |---------|-----|
 | Web | http://localhost:5173 |
-| API | http://localhost:8080 |
-| API Docs | http://localhost:8080/scalar/v1 |
+| API | http://localhost:8080 · [Scalar docs](http://localhost:8080/scalar/v1) |
 | Admin | http://localhost:81 |
-| Aspire | http://localhost:18888 |
+| Aspire (opt-in) | http://localhost:18888 — `docker compose --profile observability up` |
+
+**Prerequisites**: Docker, .NET 10 SDK, Node.js 20+, pnpm.
 
 ---
 
-## Project Structure
-
-```
-backend/src/
-  Api/              Minimal API, endpoints, middleware
-  Worker/           Book ingestion, metadata generation
-  Domain/           Entities, enums
-  Infrastructure/   EF Core, migrations, storage
-  Application/      Business logic, interfaces
-  Contracts/        Shared DTOs (request/response)
-  Search/           FTS providers (Postgres, Meilisearch)
-  Extraction/       EPUB/PDF/FB2 parsers
-  Tts/              Edge TTS client + caching service
-
-apps/
-  web/              Public site (React + Vite)
-  admin/            Admin panel (React + Vite)
-  mobile/           Mobile app (React Native + Expo)
-```
-
-**Architecture**: `API → Application → Domain ← Infrastructure`
-
----
-
-## Commands
+## Development
 
 ```bash
-# Docker
-make up / down / restart / logs / status
-make build                    # docker compose up -d --build
-make rebuild                  # Full rebuild --no-cache
-make deploy                   # Full deploy (pull, build, restart, SSG)
-
-# SSG
-make rebuild-ssg              # Regenerate SEO pages
-make clean-ssg                # Remove dist/ssg*
-
-# Database
-make backup                   # Backup to ~/backups/textstack/
-make backup-list              # List all backups
-make restore FILE=path.gz     # Restore from backup
-
-# Search
-make reindex-search           # Rebuild search indexes
-
-# Tests
-dotnet test                   # All backend tests
-pnpm -C apps/web test         # Frontend unit tests
-pnpm -C apps/web test:e2e     # Playwright E2E
-
-# Lint
-dotnet format textstack.sln   # Backend
-
 # Local dev (no Docker)
 dotnet run --project backend/src/Api
-pnpm -C apps/web dev          # http://localhost:5173
-pnpm -C apps/admin dev        # http://localhost:81
+pnpm -C apps/web dev           # http://localhost:5173
+pnpm -C apps/admin dev         # http://localhost:81
 
-# Migrations
-dotnet ef migrations add <Name> --project backend/src/Infrastructure --startup-project backend/src/Api
+# Mobile
+cd apps/mobile && npx expo start
 
-# Mobile (apps/mobile)
-npx expo start                # Dev server
-npx expo run:ios              # Local iOS build
-npx expo run:android          # Local Android build
+# Tests
+dotnet test                     # backend (unit + integration + extraction + search)
+pnpm -C apps/web test           # Vitest
+pnpm -C apps/web test:e2e       # Playwright
+
+# Lint / format
+dotnet format textstack.sln
 ```
+
+Full command reference: [CLAUDE.md](CLAUDE.md).
 
 ---
 
-## Deployment
+## Ops / self-hosting
 
-```
-Internet → Cloudflare (DNS + SSL) → Cloudflare Tunnel → nginx
-  ├─ textstack.app → SSG static + /api/ proxy to :8080
-  └─ textstack.dev → admin panel (:81)
-```
-
-SSG auto-rebuilds every 24h. Manual rebuild via admin panel or `make rebuild-ssg`.
+- [Deployment](docs/03-ops/deployment.md) — Cloudflare Tunnel + nginx + Docker
+- [Backup & Restore](docs/03-ops/backup.md) — `make backup`, GHA daily dumps
+- [Uptime Monitoring](docs/03-ops/uptime-monitoring.md) — UptimeRobot probes
+- [Incident Runbook](docs/03-ops/incident-runbook.md) — first-response for
+  common outages
+- [infra/scripts](infra/scripts/README.md) — long-running pollers
 
 ---
 
-## Docs
+## Roadmap (6-month)
 
-See [docs/](docs/) for architecture decisions, deployment guides, and API reference.
+- **Now** — Reader + Vocab SRS + offline PWA, 1,500+ books live
+- **Next** — Android on Google Play, cap weekly SRS queue UX polish,
+  curated AI-engineering corpus (DDIA, ML papers, 15–20 titles)
+- **Goal** — one paying customer by October 2026
 
-**Feature docs** (in `docs/05-features/`):
-- [Vocabulary SRS](docs/05-features/vocabulary-srs.md) — spaced repetition, MC/typed/context modes, Ollama distractors
-- [Reader](docs/05-features/reader.md) — Kindle-like reader internals
-- [Offline Reading](docs/05-features/offline-reading.md) — PWA + IndexedDB caching
-- [User Auth](docs/05-features/user-auth.md) — Google/Apple/email auth, guest flow
-- [Search](docs/05-features/feat-0006-search-library.md) — Postgres FTS
-- [Text Extraction](docs/05-features/feat-0003-text-extraction-core.md) — EPUB/PDF/FB2 parsers
-- [SSG Rebuild](docs/05-features/SSG_REBUILD.md) — Puppeteer prerender pipeline
-- [Observability](docs/05-features/feat-0005-observability-opentelemetry.md) — OpenTelemetry + Aspire
+Progress tracked in [PLAN-presale-8w.md](PLAN-presale-8w.md).
+
+---
+
+## Contributing
+
+Feedback, bug reports, and PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md)
+(if it exists yet — otherwise open an issue and we'll sort it out).
+
+**Star the repo** if this resonates. That's the only signal I have right now
+that I'm building the right thing.
+
+---
+
+## License
+
+[MIT](LICENSE) © 2026 Vasyl Vdovychenko.
+
+- Source code: MIT
+- Standard Ebooks corpus (included in seed data): CC0 / public domain
+- Edge TTS: used under Microsoft's Edge Read Aloud terms
+- Third-party deps: their respective licenses
+
+---
+
+## Why the name
+
+A stack of books. A stack of text. Read through it.


### PR DESCRIPTION
## Summary
Repositions the repo to match the dev.to launch narrative published 2026-04-22: [I quit DDIA three times — here's what I build on the fourth](https://dev.to/mrviduus/i-quit-designing-data-intensive-applications-ddia-three-times-heres-what-i-build-on-the-fourth-5bom).

### README changes
- **Hook**: problem (DDIA friction) → solution (contextual Claude explanation + capped weekly SRS)
- **Differentiator table**: dictionary vs explanation · infinite SRS vs capped · generic vs domain-aware
- **Try-it CTA** above features — sample chapters open without signup
- **Badges**: MIT, .NET 10, React 19, Expo 55, Postgres 16
- **Roadmap** section → points at \`PLAN-presale-8w.md\`
- **License section** clarifies: MIT own code, CC0 Standard Ebooks corpus, Microsoft Edge TTS terms, third-party deps — pre-empts buyer diligence questions

### LICENSE
MIT, 2026 Vasyl Vdovychenko. Closes the biggest legal ambiguity. Also unlocks OSS reuse = GitHub stars from forks.

## Why now
Marketing is running in parallel (dev.to article live). Traffic arriving at repo sees generic \"language learning\" README was off-message for the \"AI engineering books\" pitch — that drops star conversion.

Addresses Week 1–2 items in \`PLAN-presale-8w.md\`: README rewrite + LICENSE.

## Test plan
- [ ] Render README on GitHub, confirm hero image loads + badges render
- [ ] All links resolve (dev.to article, textstack.app, Twitter, CLAUDE.md, LICENSE, PLAN)
- [ ] License file is standard MIT, detected by GitHub linguist