### PR TITLE
presale: CONTRIBUTING + issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Something is broken or behaves unexpectedly
+title: 'bug: '
+labels: bug
+---
+
+## What happened
+
+<!-- Describe the bug in 1-2 sentences. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected vs actual
+
+**Expected**:
+**Actual**:
+
+## Environment
+
+- **Where**: [ ] textstack.app · [ ] self-hosted · [ ] mobile app
+- **Browser / OS / device**:
+- **Logged in?**: [ ] yes · [ ] guest · [ ] N/A
+- **Commit SHA** (if self-hosted): `git rev-parse HEAD`
+
+## Logs / screenshots
+
+<!-- Paste console output, network errors, or screenshots. -->
+
+## Anything else
+
+<!-- Related issues, suspected cause, workarounds you tried, etc. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Try the live app
+    url: https://textstack.app
+    about: Sample chapters open without signup — try before filing anything.
+  - name: Feedback via Twitter
+    url: https://twitter.com/Rexetdeus
+    about: Quick reactions, short feedback. @Rexetdeus.
+  - name: Broader discussion
+    url: https://github.com/mrviduus/textstack/discussions
+    about: Architecture, roadmap, self-hosting questions go here.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+title: 'feat: '
+labels: enhancement
+---
+
+## Problem
+
+<!-- What are you trying to do? Which book, which flow, where did you get
+stuck or felt friction? Concrete examples beat abstract descriptions. -->
+
+## Proposed solution
+
+<!-- How do you think TextStack should handle it? A rough sketch is fine —
+you don't need to design the full implementation. -->
+
+## Why this matters
+
+<!-- Is this about deep reading? SRS quality? Offline? Performance? Tie
+it back to one of the pillars if you can:
+https://github.com/mrviduus/textstack/blob/main/CONTRIBUTING.md#what-i-care-about
+-->
+
+## Alternatives considered
+
+<!-- Other ways to solve the same problem you thought about but rejected. -->
+
+## Additional context
+
+<!-- Links, screenshots, references to similar features elsewhere. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,21 @@
+---
+name: Question
+about: Ask about architecture, self-hosting, or how something works
+title: 'q: '
+labels: question
+---
+
+## What do you want to know?
+
+<!-- Be specific. "How do I do X?" is easier to answer than "How does
+TextStack work?". Check the following places first, they may have your
+answer:
+  - README.md
+  - CLAUDE.md (commands + architecture overview)
+  - docs/ folder
+  - existing Discussions / closed issues
+-->
+
+## What have you already tried or read?
+
+<!-- Makes it much faster for me to point you to what's missing. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+<!-- 1-3 sentences: what changed, and why. Focus on WHY — the diff shows WHAT. -->
+
+## Changes
+
+-
+-
+-
+
+## Testing
+
+- [ ] `dotnet test` passes
+- [ ] `pnpm -C apps/web test` passes
+- [ ] Playwright E2E passes (if touched reader / library / admin flows)
+- [ ] Manual testing done (describe below if UI change)
+
+<!-- If UI change, attach screenshot or GIF. Required, not optional. -->
+
+## Linked issues
+
+<!-- Closes #NNN -->
+
+## Breaking changes / migration notes
+
+<!-- None, or describe impact + how to migrate. -->
+
+## Checklist
+
+- [ ] One logical change per commit (rebase if noisy)
+- [ ] Conventional commit subject (`type(scope): summary`)
+- [ ] Docs / CLAUDE.md updated if behavior changed
+- [ ] No emoji added to code / docs unless the file already uses them

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,138 +1,108 @@
 # Contributing to TextStack
 
-## Getting Started
+Thanks for the interest. This is a solo project right now, but feedback, bug
+reports, and PRs are welcome.
 
-### Prerequisites
-- Docker & Docker Compose
-- Node.js 18+ & pnpm
-- .NET 10 SDK
+## Quick ways to help
 
-### Dev Setup
-```bash
-docker compose up --build
-```
+1. ⭐ **Star the repo** — the strongest signal I have about whether this is
+   useful.
+2. 🐛 **Report a bug** — [open an issue](../../issues/new/choose) with the
+   bug template.
+3. 💡 **Suggest a feature** — especially if you're reading AI/ML books and
+   the reader is missing something.
+4. 📝 **Try it + send feedback** — [textstack.app](https://textstack.app),
+   then ping me on [@Rexetdeus](https://twitter.com/Rexetdeus) or the
+   contact form on the site.
 
-| Service | URL |
-|---------|-----|
-| API | http://localhost:8080 |
-| Web | http://localhost:5173 |
-| Admin | http://localhost:81 |
+## Running locally
 
-## Branch Naming
+See the [README Quick start](README.md#quick-start). Everything runs in
+Docker via `docker compose up --build`.
 
-```
-feat/short-description    # new feature
-fix/issue-description     # bug fix
-docs/what-changed         # documentation
-refactor/what-changed     # code restructure
-test/what-covered         # tests
-```
+For day-to-day dev without Docker, see [CLAUDE.md](CLAUDE.md) — full command
+reference (tests, migrations, mobile, lint).
 
-## Commit Messages
+## Before sending a PR
 
-Format: `type(scope): description`
+1. **Open an issue first** if the change is > ~30 LoC or touches multiple
+   files. Cheaper to align on direction than on code.
+2. **Branch from `main`** with a descriptive name:
+   `feat/<short>`, `fix/<issue>`, `docs/<area>`, `refactor/<area>`, `test/<what>`.
+3. **Tests** — add/update tests for the behavior you changed.
+   ```bash
+   dotnet test                          # backend (unit + integration + extraction + search)
+   pnpm -C apps/web test                # web unit (Vitest)
+   pnpm -C apps/web test:e2e            # Playwright (needs services up)
+   ```
+4. **Lint** — `dotnet format textstack.sln` for backend. Web/admin have no
+   enforced formatter yet; match surrounding style.
+5. **Conventional commit subject** — `type(scope): summary`. Common types:
+   `feat`, `fix`, `refactor`, `docs`, `presale`. One logical change per
+   commit; rebase locally if things got noisy.
 
-```
-feat(reader): add keyboard shortcuts
-fix(search): handle empty query
-docs(api): update endpoint examples
-refactor(auth): extract token validation
-test(ingestion): add epub fixture
-```
+## PR expectations
 
-## Pull Request Process
+- **Title**: short, imperative, < 70 chars.
+- **Body**: follow the template (filled automatically when you open the PR).
+- **Scope**: one concern per PR. Drive-by refactors go in a separate PR.
+- **Breaking changes** — call them out. Include a migration note.
+- **Screenshots / GIFs** for UI changes. Required, not optional.
 
-1. Create branch from `main`
-2. Make changes in small, focused commits
-3. Run tests: `dotnet test`
-4. Run type-check: `pnpm -C apps/web build`
-5. Create PR with description:
-   - What changed
-   - Why
-   - How to test
+## Code style
 
-### PR Template
+- **Backend** — idiomatic C# / .NET 10. Minimal APIs, EF Core. Snake-case
+  in DB (handled by EF naming convention). Nullable-aware. Test naming:
+  `{Method}_{Scenario}_{Expected}`.
+- **Frontend** — React 19 functional components, hooks. CSS variables for
+  theming (no CSS-in-JS). No Redux/Zustand — React Context is enough.
+- **Mobile** — Expo 55, React Native 0.83. Match web patterns where
+  possible.
 
-```markdown
-## Summary
-Brief description of changes.
+## What I care about
 
-## Changes
-- List specific changes
+- **Reader UX** — smooth scroll, fast word-tap response, offline works.
+- **SRS quality** — capped queue, anti-spiral tiers, explanations that
+  actually help the reader.
+- **Performance** — ingestion speed, SSG prerender time, reader cold-start.
+- **Legal hygiene** — only public domain / CC0 / user-owned content.
 
-## Testing
-- [ ] dotnet test passes
-- [ ] Manual testing done
+## What I'll probably push back on
 
-## Screenshots (if UI change)
-```
+- Scope creep that doesn't serve deep reading.
+- Adding new LLM providers just to have them — we have Ollama (local) and
+  plans for Claude; keep that surface small.
+- Reintroducing features I deliberately removed (see
+  [PLAN-presale-8w.md](PLAN-presale-8w.md) for context).
 
-## Code Style
-
-### Backend (C#)
-- Follow existing patterns in codebase
-- Use `record` for DTOs
-- Keep endpoints minimal, logic in services
-- Run `dotnet format` before commit
-
-### Frontend (TypeScript/React)
-- Functional components with hooks
-- Extract reusable logic to custom hooks
-- Keep components under 200 lines when possible
-- Use TypeScript strictly (no `any`)
-
-## Testing
-
-### Backend
-```bash
-dotnet test                                    # all tests
-dotnet test tests/TextStack.UnitTests          # unit only
-dotnet test tests/TextStack.IntegrationTests   # integration
-```
-
-### Frontend
-```bash
-pnpm -C apps/web test       # run tests
-pnpm -C apps/web test:watch # watch mode
-```
-
-## Working with the Codebase
-
-### Key Principle: Small Slices
-- Work in small, independently mergeable chunks
-- Each PR should be reviewable in one sitting
-- If scope grows, split into multiple PRs
-
-### Before Starting
-1. Read relevant docs in `docs/`
-2. Understand existing patterns
-3. Check for similar implementations to follow
-
-### When Stuck
-- Check `CLAUDE.md` for codebase guidance
-- Review existing implementations
-- Ask questions in PR/issues
-
-## Good First Issues
-
-Look for issues labeled `good-first-issue`:
-- Documentation improvements
-- Small bug fixes
-- Test coverage additions
-- UI polish
-
-## Architecture Overview
+## Architecture at a glance
 
 ```
-backend/
-  src/Api/        # Endpoints, middleware
-  src/Domain/     # Entities
-  src/Application/ # Services, business logic
-  src/Infrastructure/ # DB, storage
+backend/src/
+  Api/            # Minimal APIs, middleware
+  Application/    # Business logic, interfaces
+  Domain/         # Entities, enums (pure C#)
+  Infrastructure/ # EF Core, storage, adapters
+  Worker/         # Ingestion + SSG polling + GC
+  Extraction/     # EPUB/PDF/FB2 parsers
+  Search/         # Postgres FTS (Meilisearch provider optional)
 
 apps/
-  web/    # Public reader site
-  admin/  # Admin panel
+  web/            # Public reader (React + Vite)
+  admin/          # Admin panel (React + Vite)
+  mobile/         # Mobile app (Expo)
 ```
 
-See `docs/01-architecture/` for details.
+Deeper detail: [docs/01-architecture/](docs/01-architecture/).
+
+## Code of Conduct
+
+Be kind. Assume good faith. That's it.
+
+## Contact
+
+- Twitter: [@Rexetdeus](https://twitter.com/Rexetdeus)
+- Email via [textstack.app](https://textstack.app) contact form
+- GitHub Discussions (broader questions)
+
+Thanks for being here.


### PR DESCRIPTION
## Summary

Align contributor on-ramp w/ dev.to narrative + solo-maintainer tone. Bundled Week 1-2 item from `PLAN-presale-8w.md`.

## Changes

- CONTRIBUTING.md rewritten — personal/solo tone, references dev.to positioning, lists "what I care about" + "what I'll push back on"
- .github/ISSUE_TEMPLATE/bug.md — bug report template w/ env matrix (app/self-hosted/mobile)
- .github/ISSUE_TEMPLATE/feature.md — feature req template, ties back to CONTRIBUTING pillars
- .github/ISSUE_TEMPLATE/question.md — question template pointing at README/CLAUDE.md/docs first
- .github/ISSUE_TEMPLATE/config.yml — blank issues disabled + contact links (app, Twitter @Rexetdeus, Discussions)
- .github/PULL_REQUEST_TEMPLATE.md — summary/changes/testing/linked-issues/breaking/checklist

## Testing

- [x] Markdown renders locally
- [ ] Verify templates appear on https://github.com/mrviduus/textstack/issues/new/choose after merge

## Linked issues

Part of PLAN-presale-8w.md Week 1-2 tracks.

## Breaking changes / migration notes

None.