### PR TITLE
feat: LLM abstraction — OpenAI + Ollama via ILlmServiceFactory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ SEARCH_PROVIDER=postgres
 INDEXNOW_KEY=
 INDEXNOW_ENABLED=false
 
+# OpenAI (contextual /explain endpoint + translation)
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-5-mini
+
 # Resend (email: password reset + admin ops alerts)
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=noreply@textstack.app

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,9 @@ Upload EPUB/PDF/FB2 → BookFile (stored) → IngestionJob (queued)
 
 **Dictionary**: `GET /dictionary/{lang}/{word}` — proxies Free Dictionary API.
 
-**Translation**: `POST /translate` via LibreTranslate container. Config: `LibreTranslate:BaseUrl`, `LibreTranslate:TimeoutSeconds`, `LibreTranslate:MaxTextLength`.
+**Translation**: `POST /api/translate` via OpenAI (`gpt-5-mini`). Config: `OpenAI:ApiKey`, `OpenAI:Model`, `OpenAI:Translate:MaxTextLength`. LibreTranslate dropped 2026-04-22.
+
+**Explain (contextual)**: `POST /api/explain` — LLM-powered 2-3 sentence explanation of a word in the sentence it appears in. Uses `ILlmService` (OpenAI `gpt-5-mini`). SHA256-keyed file cache at `data/explain-cache`, 30d TTL. Rate limited per-IP (20/min). Impl: `backend/src/Api/Endpoints/ExplainEndpoints.cs`.
 
 **TTS (Text-to-Speech)**: Edge TTS via direct WebSocket to `speech.platform.bing.com`. No API key, no deps.
 - **`TextStack.Tts`** class library: `EdgeTtsClient` (WebSocket protocol), `EdgeTtsService` (disk cache + `IHostedService` startup cleanup)
@@ -436,7 +438,7 @@ Internet → Cloudflare (DNS+SSL) → Cloudflare Tunnel → nginx (port 80)
   └─ textstack.dev → admin panel (:81)
 ```
 
-Docker services: `db` (postgres:16), `migrator`, `api`, `worker`, `admin`, `ssg-worker`, `aspire-dashboard` (profile-gated), `libretranslate`, `ollama`. All localhost-only, no public ports except 80 via tunnel.
+Docker services: `db` (postgres:16), `migrator`, `api`, `worker`, `admin`, `ssg-worker`, `aspire-dashboard` (profile-gated), `ollama`. All localhost-only, no public ports except 80 via tunnel.
 
 **Nginx bot detection**: Regex map identifies crawlers (Google, Bing, Yandex, social bots) → routes to prerendered SSG HTML. Rate limiting zones: API (10r/s), uploads (1r/s), translation (5r/m).
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,8 @@
     <PackageVersion Include="Google.Apis.Auth" Version="1.68.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.3.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
+    <!-- LLM -->
+    <PackageVersion Include="OpenAI" Version="2.2.0" />
     <!-- Search -->
     <PackageVersion Include="Dapper" Version="2.1.35" />
     <PackageVersion Include="Meilisearch" Version="0.16.0" />

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,8 @@ status:
 # Fix volume permissions for containers running as non-root
 fix-permissions:
 	@echo "Fixing volume permissions..."
-	@mkdir -p data/libretranslate data/textstack data/tts-cache
-	@docker run --rm -v $$(pwd)/data/libretranslate:/data alpine chown -R 1032:1032 /data
-	@docker run --rm -v $$(pwd)/data/textstack:/data -v $$(pwd)/data/tts-cache:/tts alpine sh -c 'chown -R 1000:1000 /data /tts'
+	@mkdir -p data/textstack data/tts-cache data/explain-cache
+	@docker run --rm -v $$(pwd)/data/textstack:/data -v $$(pwd)/data/tts-cache:/tts -v $$(pwd)/data/explain-cache:/explain alpine sh -c 'chown -R 1000:1000 /data /tts /explain'
 	@echo "Done."
 
 deploy: fix-permissions

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ understanding is to read them — but the friction has to go.
 
 ## What TextStack does
 
-**Tap a term → 2–3 sentence Claude-powered explanation tied to the book's
+**Tap a term → 2–3 sentence LLM-powered explanation tied to the book's
 domain.** Not a dictionary definition. If you tap "attention" in an ML
-textbook you get the ML meaning, not the everyday one.
+textbook you get the ML meaning, not the everyday one. Powered by OpenAI
+`gpt-5-mini` (swap-in friendly — any `ILlmService` impl works).
 
 Terms you don't recognize enter a **capped weekly SRS queue** — no infinite
 backlog, no guilt. Common words and the top 15K English words are filtered
@@ -52,7 +53,7 @@ out; only technical vocabulary gets surfaced.
 | Dictionary definitions | Context-aware explanations |
 | Infinite SRS queue | Capped weekly (no spiral) |
 | One-size-fits-all | Domain-aware per book |
-| Static Kindle Word Wise (2014) | Claude-powered (2026) |
+| Static Kindle Word Wise (2014) | LLM-powered (2026) |
 
 ## Try it
 
@@ -68,8 +69,8 @@ out; only technical vocabulary gets surfaced.
 **Reader**
 - Kindle-like experience — themes (light/sepia/dark), fonts, fullscreen,
   keyboard shortcuts
-- Text selection — contextual explanation (Claude), dictionary fallback (Free
-  Dictionary API), translation (LibreTranslate), highlights
+- Text selection — contextual explanation (OpenAI `gpt-5-mini`), dictionary
+  fallback (Free Dictionary API), translation (OpenAI), highlights
 - TTS — Edge TTS via direct WebSocket (200+ voices, 0.75×–2.0× speed, two-
   layer cache)
 - Offline reading — PWA with IndexedDB caching, download manager
@@ -105,9 +106,8 @@ out; only technical vocabulary gets surfaced.
 | Search | PostgreSQL FTS |
 | Web | React 19, Vite, pnpm |
 | Mobile | React Native (Expo 55) |
-| LLM | Claude (explanations) + Ollama `qwen3:8b` (distractors) |
+| LLM | OpenAI `gpt-5-mini` (explanations + translation) + Ollama `qwen3:8b` (distractors, local) |
 | TTS | Edge TTS (WebSocket, no API key) |
-| Translation | LibreTranslate (self-hosted) |
 | SSG | Puppeteer prerender, nginx serves static first |
 | Telemetry | OpenTelemetry → Aspire Dashboard |
 | Infra | Docker Compose, Cloudflare Tunnel, nginx |

--- a/backend/src/Api/Endpoints/ExplainEndpoints.cs
+++ b/backend/src/Api/Endpoints/ExplainEndpoints.cs
@@ -1,7 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
-using Application.LLM;
+using Domain.LLM;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Endpoints;
@@ -17,7 +17,7 @@ public static class ExplainEndpoints
     private static async Task<IResult> Explain(
         [FromBody] ExplainRequest request,
         IConfiguration config,
-        ILlmService llm,
+        ILlmServiceFactory llmFactory,
         ILogger<Program> logger,
         CancellationToken ct)
     {
@@ -65,6 +65,7 @@ public static class ExplainEndpoints
 
         try
         {
+            var llm = llmFactory.Get("Explain");
             var text = await llm.CompleteAsync(
                 systemPrompt,
                 userPrompt,

--- a/backend/src/Api/Endpoints/ExplainEndpoints.cs
+++ b/backend/src/Api/Endpoints/ExplainEndpoints.cs
@@ -1,0 +1,142 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Application.LLM;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Endpoints;
+
+public static class ExplainEndpoints
+{
+    public static void MapExplainEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/explain").WithTags("Explain");
+        group.MapPost("", Explain).WithName("Explain").RequireRateLimiting("explain");
+    }
+
+    private static async Task<IResult> Explain(
+        [FromBody] ExplainRequest request,
+        IConfiguration config,
+        ILlmService llm,
+        ILogger<Program> logger,
+        CancellationToken ct)
+    {
+        var maxWordLength = config.GetValue("Explain:MaxWordLength", 100);
+        var maxSentenceLength = config.GetValue("Explain:MaxSentenceLength", 800);
+        var cachePath = config.GetValue<string>("Explain:CachePath") ?? "/tmp/explain-cache";
+        var cacheTtlDays = config.GetValue("Explain:CacheTtlDays", 30);
+
+        if (string.IsNullOrWhiteSpace(request.Word))
+            return Results.BadRequest("Word is required");
+        if (request.Word.Length > maxWordLength)
+            return Results.BadRequest($"Word exceeds {maxWordLength} chars");
+        if (string.IsNullOrWhiteSpace(request.Sentence))
+            return Results.BadRequest("Sentence is required");
+        if (request.Sentence.Length > maxSentenceLength)
+            return Results.BadRequest($"Sentence exceeds {maxSentenceLength} chars");
+
+        var targetLang = string.IsNullOrWhiteSpace(request.TargetLang) ? "en" : request.TargetLang.Split('-')[0];
+
+        var cacheKey = ComputeCacheKey(request.Word, request.Sentence, request.Genre, targetLang);
+        var cacheFile = Path.Combine(cachePath, cacheKey + ".json");
+
+        try
+        {
+            Directory.CreateDirectory(cachePath);
+            if (File.Exists(cacheFile))
+            {
+                var info = new FileInfo(cacheFile);
+                if (info.LastWriteTimeUtc > DateTime.UtcNow.AddDays(-cacheTtlDays))
+                {
+                    var cached = await File.ReadAllTextAsync(cacheFile, ct);
+                    var cachedResp = JsonSerializer.Deserialize<ExplainResponse>(cached);
+                    if (cachedResp != null && !string.IsNullOrWhiteSpace(cachedResp.Explanation))
+                        return Results.Ok(cachedResp with { Cached = true });
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Explain cache read failed, falling through to LLM");
+        }
+
+        var systemPrompt = BuildSystemPrompt(request.Genre, targetLang);
+        var userPrompt = BuildUserPrompt(request.Word, request.Sentence);
+
+        try
+        {
+            var text = await llm.CompleteAsync(
+                systemPrompt,
+                userPrompt,
+                maxOutputTokens: 200,
+                ct);
+
+            if (string.IsNullOrWhiteSpace(text))
+                return Results.Problem("LLM returned empty explanation", statusCode: 502);
+
+            var resp = new ExplainResponse(text, request.Word, false);
+
+            try
+            {
+                await File.WriteAllTextAsync(
+                    cacheFile,
+                    JsonSerializer.Serialize(resp),
+                    ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Explain cache write failed");
+            }
+
+            return Results.Ok(resp);
+        }
+        catch (TaskCanceledException)
+        {
+            return Results.Problem("Explain request timed out", statusCode: 504);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Explain LLM call failed");
+            return Results.Problem(
+                detail: "Explain service unavailable",
+                statusCode: 503);
+        }
+    }
+
+    private static string BuildSystemPrompt(string? genre, string targetLang)
+    {
+        var domain = string.IsNullOrWhiteSpace(genre) ? "general" : genre.Trim();
+        return
+            $"You explain unfamiliar words or phrases to a reader in context. " +
+            $"Domain hint: {domain}. " +
+            $"Respond in {targetLang}. " +
+            "Write 2-3 sentences. Focus on how the word is used IN THIS SENTENCE, " +
+            "not a dictionary definition. If it is a technical term, give the meaning and " +
+            "one concrete analogy. No preface, no quotes around the answer, no markdown.";
+    }
+
+    private static string BuildUserPrompt(string word, string sentence) =>
+        $"Word: {word}\nSentence: {sentence}";
+
+    private static string ComputeCacheKey(string word, string sentence, string? genre, string targetLang)
+    {
+        var payload = $"{word.ToLowerInvariant()}|{sentence}|{genre ?? ""}|{targetLang}";
+        var bytes = Encoding.UTF8.GetBytes(payload);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+}
+
+public record ExplainRequest(
+    string Word,
+    string Sentence,
+    string? Genre,
+    string? BookId,
+    string? TargetLang
+);
+
+public record ExplainResponse(
+    string Explanation,
+    string Word,
+    bool Cached
+);

--- a/backend/src/Api/Endpoints/TranslationEndpoints.cs
+++ b/backend/src/Api/Endpoints/TranslationEndpoints.cs
@@ -1,4 +1,4 @@
-using Application.LLM;
+using Domain.LLM;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Endpoints;
@@ -19,7 +19,7 @@ public static class TranslationEndpoints
     private static async Task<IResult> Translate(
         [FromBody] TranslateRequest request,
         IConfiguration config,
-        ILlmService llm,
+        ILlmServiceFactory llmFactory,
         CancellationToken ct)
     {
         var maxLength = config.GetValue("OpenAI:Translate:MaxTextLength", 500);
@@ -44,6 +44,7 @@ public static class TranslationEndpoints
 
         try
         {
+            var llm = llmFactory.Get("Translate");
             var translated = await llm.CompleteAsync(
                 systemPrompt,
                 request.Text,

--- a/backend/src/Api/Endpoints/TranslationEndpoints.cs
+++ b/backend/src/Api/Endpoints/TranslationEndpoints.cs
@@ -1,5 +1,4 @@
-using System.Net.Http.Json;
-using System.Text.Json;
+using Application.LLM;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Endpoints;
@@ -20,14 +19,11 @@ public static class TranslationEndpoints
     private static async Task<IResult> Translate(
         [FromBody] TranslateRequest request,
         IConfiguration config,
-        IHttpClientFactory httpClientFactory,
+        ILlmService llm,
         CancellationToken ct)
     {
-        var maxLength = config.GetValue("LibreTranslate:MaxTextLength", 500);
-        var baseUrl = config.GetValue<string>("LibreTranslate:BaseUrl") ?? "http://localhost:5000";
-        var timeout = config.GetValue("LibreTranslate:TimeoutSeconds", 30);
+        var maxLength = config.GetValue("OpenAI:Translate:MaxTextLength", 500);
 
-        // Validate input
         if (string.IsNullOrWhiteSpace(request.Text))
             return Results.BadRequest("Text is required");
 
@@ -40,42 +36,25 @@ public static class TranslationEndpoints
         if (string.IsNullOrWhiteSpace(request.TargetLang))
             return Results.BadRequest("Target language is required");
 
-        // Normalize BCP47 region codes to base language (pt-BR → pt).
-        // LibreTranslate accepts only base codes (en, pt, ko, ...).
         var srcLang = request.SourceLang.Split('-')[0];
         var tgtLang = request.TargetLang.Split('-')[0];
 
+        var systemPrompt = $"You are a translation engine. Translate from {srcLang} to {tgtLang}. " +
+                           "Output ONLY the translated text. No preface, no quotes, no explanation.";
+
         try
         {
-            var client = httpClientFactory.CreateClient();
-            client.Timeout = TimeSpan.FromSeconds(timeout);
+            var translated = await llm.CompleteAsync(
+                systemPrompt,
+                request.Text,
+                maxOutputTokens: Math.Min(maxLength * 2, 1000),
+                ct);
 
-            var libreRequest = new
-            {
-                q = request.Text,
-                source = srcLang,
-                target = tgtLang,
-                format = "text"
-            };
-
-            var response = await client.PostAsJsonAsync($"{baseUrl}/translate", libreRequest, ct);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                var errorBody = await response.Content.ReadAsStringAsync(ct);
-                return Results.Problem(
-                    detail: $"Translation service error: {response.StatusCode}",
-                    statusCode: 502
-                );
-            }
-
-            var result = await response.Content.ReadFromJsonAsync<LibreTranslateResponse>(ct);
-
-            if (result == null || string.IsNullOrEmpty(result.TranslatedText))
-                return Results.Problem("Translation service returned empty result", statusCode: 502);
+            if (string.IsNullOrWhiteSpace(translated))
+                return Results.Problem("Translation returned empty result", statusCode: 502);
 
             return Results.Ok(new TranslateResponse(
-                result.TranslatedText,
+                translated,
                 request.SourceLang,
                 request.TargetLang
             ));
@@ -84,7 +63,7 @@ public static class TranslationEndpoints
         {
             return Results.Problem("Translation request timed out", statusCode: 504);
         }
-        catch (HttpRequestException ex)
+        catch (Exception ex)
         {
             return Results.Problem(
                 detail: $"Translation service unavailable: {ex.Message}",
@@ -93,36 +72,33 @@ public static class TranslationEndpoints
         }
     }
 
-    private static async Task<IResult> GetLanguages(
-        IConfiguration config,
-        IHttpClientFactory httpClientFactory,
-        CancellationToken ct)
+    private static IResult GetLanguages()
     {
-        var baseUrl = config.GetValue<string>("LibreTranslate:BaseUrl") ?? "http://localhost:5000";
-        var timeout = config.GetValue("LibreTranslate:TimeoutSeconds", 30);
-
-        try
+        // Static list — OpenAI handles any BCP47 pair, but clients want a UI list.
+        // Matches prior LibreTranslate set + a few extras.
+        var languages = new[]
         {
-            var client = httpClientFactory.CreateClient();
-            client.Timeout = TimeSpan.FromSeconds(timeout);
-
-            var response = await client.GetAsync($"{baseUrl}/languages", ct);
-
-            if (!response.IsSuccessStatusCode)
-                return Results.Problem("Failed to fetch languages", statusCode: 502);
-
-            var languages = await response.Content.ReadFromJsonAsync<List<LibreTranslateLanguage>>(ct);
-
-            return Results.Ok(languages?.Select(l => new LanguageInfo(l.Code, l.Name)) ?? []);
-        }
-        catch (HttpRequestException)
-        {
-            return Results.Problem("Translation service unavailable", statusCode: 503);
-        }
+            new LanguageInfo("en", "English"),
+            new LanguageInfo("es", "Spanish"),
+            new LanguageInfo("fr", "French"),
+            new LanguageInfo("de", "German"),
+            new LanguageInfo("it", "Italian"),
+            new LanguageInfo("pt", "Portuguese"),
+            new LanguageInfo("ru", "Russian"),
+            new LanguageInfo("uk", "Ukrainian"),
+            new LanguageInfo("pl", "Polish"),
+            new LanguageInfo("nl", "Dutch"),
+            new LanguageInfo("ja", "Japanese"),
+            new LanguageInfo("ko", "Korean"),
+            new LanguageInfo("zh", "Chinese"),
+            new LanguageInfo("ar", "Arabic"),
+            new LanguageInfo("tr", "Turkish"),
+            new LanguageInfo("hi", "Hindi"),
+        };
+        return Results.Ok(languages);
     }
 }
 
-// Request/Response DTOs
 public record TranslateRequest(
     string Text,
     string SourceLang,
@@ -136,15 +112,3 @@ public record TranslateResponse(
 );
 
 public record LanguageInfo(string Code, string Name);
-
-// LibreTranslate API response types
-file class LibreTranslateResponse
-{
-    public string TranslatedText { get; set; } = "";
-}
-
-file class LibreTranslateLanguage
-{
-    public string Code { get; set; } = "";
-    public string Name { get; set; } = "";
-}

--- a/backend/src/Api/Program.cs
+++ b/backend/src/Api/Program.cs
@@ -213,7 +213,7 @@ builder.Services.AddRateLimiter(options =>
             QueueLimit = 0,
         });
     });
-    // Translation — per-IP. LibreTranslate is the upstream cost; users
+    // Translation — per-IP. OpenAI is the upstream cost; users
     // typically call 1-3 times per reading session via SelectionToolbar.
     // 30/min is generous for normal UX, blocks scripted scraping of the
     // translation service.
@@ -237,6 +237,19 @@ builder.Services.AddRateLimiter(options =>
         {
             Window = TimeSpan.FromMinutes(1),
             PermitLimit = 60,
+            QueueLimit = 0,
+        });
+    });
+    // /explain — Claude/OpenAI-backed contextual explanation. Paid API
+    // call per miss (cache fronts it). 20/min per IP is plenty for
+    // active reading; anything higher smells like scripting.
+    options.AddPolicy("explain", httpContext =>
+    {
+        var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
+        {
+            Window = TimeSpan.FromMinutes(1),
+            PermitLimit = 20,
             QueueLimit = 0,
         });
     });
@@ -361,6 +374,7 @@ app.MapProfileEndpoints();
 app.MapUserDataEndpoints();
 app.MapHighlightsEndpoints();
 app.MapTranslationEndpoints();
+app.MapExplainEndpoints();
 app.MapDictionaryEndpoints();
 app.MapUserBooksEndpoints();
 app.MapReadingTrackingEndpoints();

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -43,6 +43,15 @@
     "Model": "qwen3:8b",
     "TimeoutSeconds": 10
   },
+  "LLM": {
+    "DefaultProvider": "openai",
+    "Providers": {
+      "Explain": "openai",
+      "Translate": "openai",
+      "Distractor": "ollama",
+      "BookMetadata": "ollama"
+    }
+  },
   "FileUpload": {
     "MaxBookSizeMb": 100,
     "MaxCoverSizeMb": 5,

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -20,10 +20,18 @@
   "Google": {
     "ClientId": ""
   },
-  "LibreTranslate": {
-    "BaseUrl": "http://localhost:5000",
-    "MaxTextLength": 500,
-    "TimeoutSeconds": 30
+  "OpenAI": {
+    "ApiKey": "",
+    "Model": "gpt-5-mini",
+    "Translate": {
+      "MaxTextLength": 500
+    }
+  },
+  "Explain": {
+    "MaxWordLength": 100,
+    "MaxSentenceLength": 800,
+    "CachePath": "data/explain-cache",
+    "CacheTtlDays": 30
   },
   "Tts": {
     "CachePath": "data/tts-cache",

--- a/backend/src/Application/Application.csproj
+++ b/backend/src/Application/Application.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="OpenAI" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 

--- a/backend/src/Application/DependencyInjection.cs
+++ b/backend/src/Application/DependencyInjection.cs
@@ -6,6 +6,7 @@ using Application.Authors;
 using Application.Books;
 using Application.Reprocessing;
 using Application.Seo;
+using Application.LLM;
 using Application.Vocabulary;
 using Application.Export;
 using Application.SsgRebuild;
@@ -41,6 +42,9 @@ public static class DependencyInjection
         services.AddScoped<RetirementSweeper>();
         services.AddScoped<ClusterCandidateService>();
         services.AddSingleton<IFrequencyFilter, FrequencyFilter>();
+
+        // LLM (OpenAI)
+        services.AddSingleton<ILlmService, OpenAiLlmService>();
 
         // SSG Rebuild - interfaces for SOLID compliance
         services.AddScoped<ISsgRouteProvider, SsgRouteProvider>();

--- a/backend/src/Application/DependencyInjection.cs
+++ b/backend/src/Application/DependencyInjection.cs
@@ -43,8 +43,10 @@ public static class DependencyInjection
         services.AddScoped<ClusterCandidateService>();
         services.AddSingleton<IFrequencyFilter, FrequencyFilter>();
 
-        // LLM (OpenAI)
-        services.AddSingleton<ILlmService, OpenAiLlmService>();
+        // LLM — keyed providers; consumers pick per job via ILlmServiceFactory.
+        services.AddKeyedSingleton<Domain.LLM.ILlmService, OpenAiLlmService>("openai");
+        services.AddKeyedSingleton<Domain.LLM.ILlmService, OllamaLlmService>("ollama");
+        services.AddSingleton<Domain.LLM.ILlmServiceFactory, LlmServiceFactory>();
 
         // SSG Rebuild - interfaces for SOLID compliance
         services.AddScoped<ISsgRouteProvider, SsgRouteProvider>();

--- a/backend/src/Application/LLM/ILlmService.cs
+++ b/backend/src/Application/LLM/ILlmService.cs
@@ -1,0 +1,10 @@
+namespace Application.LLM;
+
+public interface ILlmService
+{
+    Task<string> CompleteAsync(
+        string systemPrompt,
+        string userPrompt,
+        int maxOutputTokens,
+        CancellationToken ct);
+}

--- a/backend/src/Application/LLM/LlmServiceFactory.cs
+++ b/backend/src/Application/LLM/LlmServiceFactory.cs
@@ -1,0 +1,32 @@
+using Domain.LLM;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Application.LLM;
+
+/// <summary>
+/// Resolves an <see cref="ILlmService"/> per job. Provider selection is
+/// config-driven — <c>LLM:Providers:{JobName}</c> picks the key under
+/// which the service was registered. Falls back to
+/// <c>LLM:DefaultProvider</c>, then to <c>"openai"</c>.
+/// </summary>
+public class LlmServiceFactory : ILlmServiceFactory
+{
+    private readonly IServiceProvider _sp;
+    private readonly IConfiguration _config;
+
+    public LlmServiceFactory(IServiceProvider sp, IConfiguration config)
+    {
+        _sp = sp;
+        _config = config;
+    }
+
+    public ILlmService Get(string jobName)
+    {
+        var key = _config[$"LLM:Providers:{jobName}"]
+            ?? _config["LLM:DefaultProvider"]
+            ?? "openai";
+
+        return _sp.GetRequiredKeyedService<ILlmService>(key);
+    }
+}

--- a/backend/src/Application/LLM/OllamaLlmService.cs
+++ b/backend/src/Application/LLM/OllamaLlmService.cs
@@ -1,0 +1,84 @@
+using System.Net.Http.Json;
+using Domain.LLM;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Application.LLM;
+
+public class OllamaLlmService : ILlmService
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<OllamaLlmService> _logger;
+    private readonly string _baseUrl;
+    private readonly string _model;
+    private readonly int _timeoutSeconds;
+
+    public OllamaLlmService(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration config,
+        ILogger<OllamaLlmService> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+        _baseUrl = config["Ollama:BaseUrl"]
+            ?? Environment.GetEnvironmentVariable("OLLAMA_BASE_URL")
+            ?? "http://localhost:11434";
+        _model = config["Ollama:Model"]
+            ?? Environment.GetEnvironmentVariable("OLLAMA_MODEL")
+            ?? "qwen3:8b";
+        _timeoutSeconds = config.GetValue("Ollama:TimeoutSeconds", 30);
+    }
+
+    public async Task<string> CompleteAsync(
+        string systemPrompt,
+        string userPrompt,
+        int maxOutputTokens,
+        CancellationToken ct)
+    {
+        // Ollama /api/generate takes a single prompt. Concatenate system + user
+        // with a clear separator so the model treats them as role-split.
+        var prompt = string.IsNullOrWhiteSpace(systemPrompt)
+            ? userPrompt
+            : $"{systemPrompt}\n\n{userPrompt}";
+
+        var client = _httpClientFactory.CreateClient();
+        client.Timeout = TimeSpan.FromSeconds(_timeoutSeconds);
+
+        var request = new
+        {
+            model = _model,
+            prompt,
+            stream = false,
+            options = new { num_predict = maxOutputTokens },
+        };
+
+        try
+        {
+            var response = await client.PostAsJsonAsync($"{_baseUrl}/api/generate", request, ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Ollama returned {StatusCode}", response.StatusCode);
+                return string.Empty;
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<OllamaResponse>(ct);
+            return result?.Response?.Trim() ?? string.Empty;
+        }
+        catch (TaskCanceledException)
+        {
+            _logger.LogWarning("Ollama request timed out after {Seconds}s", _timeoutSeconds);
+            return string.Empty;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Ollama request failed");
+            return string.Empty;
+        }
+    }
+
+    private class OllamaResponse
+    {
+        public string? Response { get; set; }
+    }
+}

--- a/backend/src/Application/LLM/OpenAiLlmService.cs
+++ b/backend/src/Application/LLM/OpenAiLlmService.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using OpenAI;
+using OpenAI.Chat;
+
+namespace Application.LLM;
+
+public class OpenAiLlmService : ILlmService
+{
+    private readonly ChatClient _client;
+    private readonly ILogger<OpenAiLlmService> _logger;
+
+    public OpenAiLlmService(IConfiguration config, ILogger<OpenAiLlmService> logger)
+    {
+        _logger = logger;
+
+        var apiKey = config["OpenAI:ApiKey"]
+            ?? Environment.GetEnvironmentVariable("OPENAI_API_KEY")
+            ?? throw new InvalidOperationException("OPENAI_API_KEY not configured");
+
+        var model = config["OpenAI:Model"]
+            ?? Environment.GetEnvironmentVariable("OPENAI_MODEL")
+            ?? "gpt-5-mini";
+
+        _client = new OpenAIClient(apiKey).GetChatClient(model);
+    }
+
+    public async Task<string> CompleteAsync(
+        string systemPrompt,
+        string userPrompt,
+        int maxOutputTokens,
+        CancellationToken ct)
+    {
+        var messages = new List<ChatMessage>
+        {
+            new SystemChatMessage(systemPrompt),
+            new UserChatMessage(userPrompt),
+        };
+
+        var options = new ChatCompletionOptions
+        {
+            MaxOutputTokenCount = maxOutputTokens,
+        };
+
+        var result = await _client.CompleteChatAsync(messages, options, ct);
+        var text = result.Value.Content.FirstOrDefault()?.Text ?? string.Empty;
+        return text.Trim();
+    }
+}

--- a/backend/src/Application/LLM/OpenAiLlmService.cs
+++ b/backend/src/Application/LLM/OpenAiLlmService.cs
@@ -1,3 +1,4 @@
+using Domain.LLM;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using OpenAI;

--- a/backend/src/Domain/LLM/ILlmService.cs
+++ b/backend/src/Domain/LLM/ILlmService.cs
@@ -1,4 +1,4 @@
-namespace Application.LLM;
+namespace Domain.LLM;
 
 public interface ILlmService
 {
@@ -7,4 +7,9 @@ public interface ILlmService
         string userPrompt,
         int maxOutputTokens,
         CancellationToken ct);
+}
+
+public interface ILlmServiceFactory
+{
+    ILlmService Get(string jobName);
 }

--- a/backend/src/Vocabulary/TextStack.Vocabulary/DistractorGenerator.cs
+++ b/backend/src/Vocabulary/TextStack.Vocabulary/DistractorGenerator.cs
@@ -1,48 +1,39 @@
-using System.Net.Http.Json;
-using System.Text.Json;
-using Microsoft.Extensions.Options;
+using Domain.LLM;
 
 namespace TextStack.Vocabulary;
 
 public sealed class DistractorGenerator : IDistractorGenerator
 {
-    private readonly IHttpClientFactory _httpClientFactory;
-    private readonly VocabularyOptions _options;
+    private readonly ILlmServiceFactory _llmFactory;
 
-    public DistractorGenerator(IHttpClientFactory httpClientFactory, IOptions<VocabularyOptions> options)
+    public DistractorGenerator(ILlmServiceFactory llmFactory)
     {
-        _httpClientFactory = httpClientFactory;
-        _options = options.Value;
+        _llmFactory = llmFactory;
     }
 
     public async Task<(List<string>? Distractors, string? Hint, string? Explanation)> GenerateAsync(
         string word, string language, string? definition, string? sentence,
         string nativeLanguage, CancellationToken ct)
     {
-        var prompt = BuildPrompt(word, language, definition, sentence, nativeLanguage);
+        var (systemPrompt, userPrompt) = BuildPrompt(word, language, definition, sentence, nativeLanguage);
 
-        var client = _httpClientFactory.CreateClient();
-        client.Timeout = TimeSpan.FromSeconds(_options.OllamaTimeoutSeconds);
+        var llm = _llmFactory.Get("Distractor");
+        var text = await llm.CompleteAsync(systemPrompt, userPrompt, maxOutputTokens: 600, ct);
 
-        var request = new { model = _options.OllamaModel, prompt, stream = false };
-        var response = await client.PostAsJsonAsync($"{_options.OllamaBaseUrl}/api/generate", request, ct);
-
-        if (!response.IsSuccessStatusCode)
+        if (string.IsNullOrWhiteSpace(text))
             return (null, null, null);
 
-        var result = await response.Content.ReadFromJsonAsync<OllamaResponse>(ct);
-        if (string.IsNullOrWhiteSpace(result?.Response))
-            return (null, null, null);
-
-        return ParseStructuredResponse(result.Response, word);
+        return ParseStructuredResponse(text, word);
     }
 
-    private static string BuildPrompt(string word, string language, string? definition, string? sentence, string nativeLanguage)
+    private static (string System, string User) BuildPrompt(
+        string word, string language, string? definition, string? sentence, string nativeLanguage)
     {
+        var system = "You generate vocabulary quiz data for language learners. " +
+                     "Always reply in the EXACT format requested. No preface, no markdown.";
+
         var parts = new List<string>
         {
-            "You generate vocabulary quiz data for language learners.",
-            "",
             $"Word: \"{word}\"",
         };
 
@@ -61,19 +52,17 @@ public sealed class DistractorGenerator : IDistractorGenerator
         parts.Add("");
         parts.Add("Task 2 - Hint: Write ONE short sentence (under 15 words) describing what this word means.");
         parts.Add($"Do NOT use the word \"{word}\" or direct synonyms in the hint.");
-
         parts.Add("");
         parts.Add($"Task 3 - Explanation: Write 2-3 sentences in {nativeLanguage} explaining the meaning of \"{word}\".");
         if (!string.IsNullOrWhiteSpace(sentence))
             parts.Add($"Include how it is used in this context: \"{sentence}\"");
-
         parts.Add("");
         parts.Add("Reply in this EXACT format (no other text):");
         parts.Add("DISTRACTORS: word1, word2, word3, word4, word5");
         parts.Add("HINT: your hint sentence here");
         parts.Add("EXPLANATION: your explanation here");
 
-        return string.Join("\n", parts);
+        return (system, string.Join("\n", parts));
     }
 
     private static (List<string>? Distractors, string? Hint, string? Explanation) ParseStructuredResponse(string raw, string originalWord)
@@ -93,12 +82,10 @@ public sealed class DistractorGenerator : IDistractorGenerator
                 explanationLine = line["EXPLANATION:".Length..].Trim();
         }
 
-        // Parse distractors from structured line, or fall back to old comma parsing
         var distractors = distractorLine != null
             ? ParseWordList(distractorLine, originalWord)
             : ParseWordList(raw.Replace("\n", ","), originalWord);
 
-        // Validate hint
         string? hint = null;
         if (!string.IsNullOrWhiteSpace(hintLine)
             && hintLine.Length < 500
@@ -107,7 +94,6 @@ public sealed class DistractorGenerator : IDistractorGenerator
             hint = hintLine;
         }
 
-        // Validate explanation
         string? explanation = null;
         if (!string.IsNullOrWhiteSpace(explanationLine) && explanationLine.Length < 1000)
             explanation = explanationLine;
@@ -122,9 +108,9 @@ public sealed class DistractorGenerator : IDistractorGenerator
             .Select(w => w.TrimStart('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', '-', ' ').Trim())
             .Where(w => w.Length > 1
                 && w.Length < 50
-                && w.Any(char.IsLetter) // must contain at least one letter
+                && w.Any(char.IsLetter)
                 && !w.Equals(originalWord, StringComparison.OrdinalIgnoreCase)
-                && !w.Contains(' ')) // single words only
+                && !w.Contains(' '))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .Take(5)
             .Select(w => w.ToLowerInvariant())
@@ -132,9 +118,4 @@ public sealed class DistractorGenerator : IDistractorGenerator
 
         return words.Count >= 3 ? words : null;
     }
-}
-
-file class OllamaResponse
-{
-    public string Response { get; set; } = "";
 }

--- a/backend/src/Vocabulary/TextStack.Vocabulary/TextStack.Vocabulary.csproj
+++ b/backend/src/Vocabulary/TextStack.Vocabulary/TextStack.Vocabulary.csproj
@@ -4,4 +4,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Domain\Domain.csproj" />
+  </ItemGroup>
 </Project>

--- a/backend/src/Worker/Program.cs
+++ b/backend/src/Worker/Program.cs
@@ -58,10 +58,11 @@ builder.Services.AddSingleton<IImageOptimizer, ImageOptimizer>();
 // Application services (for ISsgRouteProvider, etc.)
 builder.Services.AddApplication();
 
-// HTTP client factory (required by UserIngestionService for metadata enrichment)
+// HTTP client factory (for OllamaLlmService + etc.)
 builder.Services.AddHttpClient();
 
 // Services
+builder.Services.AddSingleton<IBookMetadataGenerator, BookMetadataGenerator>();
 builder.Services.AddSingleton<IngestionWorkerService>();
 builder.Services.AddSingleton<UserIngestionService>();
 builder.Services.AddHostedService<IngestionWorker>();

--- a/backend/src/Worker/Services/BookMetadataGenerator.cs
+++ b/backend/src/Worker/Services/BookMetadataGenerator.cs
@@ -1,45 +1,36 @@
-using System.Net.Http.Json;
-using Microsoft.Extensions.Configuration;
+using Domain.LLM;
 
 namespace Worker.Services;
 
-public static class BookMetadataGenerator
+public class BookMetadataGenerator : IBookMetadataGenerator
 {
-    public static async Task<BookMetadataResult?> GenerateAsync(
-        string title, string? author, bool needsDescription,
-        IHttpClientFactory httpClientFactory, IConfiguration config,
-        CancellationToken ct)
+    private readonly ILlmServiceFactory _llmFactory;
+
+    public BookMetadataGenerator(ILlmServiceFactory llmFactory)
     {
-        var baseUrl = config.GetValue<string>("Ollama:BaseUrl") ?? "http://localhost:11434";
-        var model = config.GetValue<string>("Ollama:Model") ?? "qwen3:8b";
-        var timeout = config.GetValue("Ollama:TimeoutSeconds", 30);
-
-        var prompt = BuildPrompt(title, author, needsDescription);
-
-        var client = httpClientFactory.CreateClient();
-        client.Timeout = TimeSpan.FromSeconds(timeout);
-
-        var request = new { model, prompt, stream = false };
-        var response = await client.PostAsJsonAsync($"{baseUrl}/api/generate", request, ct);
-
-        if (!response.IsSuccessStatusCode)
-            return null;
-
-        var result = await response.Content.ReadFromJsonAsync<OllamaResponse>(ct);
-        if (string.IsNullOrWhiteSpace(result?.Response))
-            return null;
-
-        return ParseResponse(result.Response, needsDescription);
+        _llmFactory = llmFactory;
     }
 
-    private static string BuildPrompt(string title, string? author, bool needsDescription)
+    public async Task<BookMetadataResult?> GenerateAsync(
+        string title, string? author, bool needsDescription, CancellationToken ct)
     {
-        var parts = new List<string>
-        {
-            "You are a librarian. Given a book's title and author, provide metadata.",
-            "",
-            $"Book title: \"{title}\""
-        };
+        var (systemPrompt, userPrompt) = BuildPrompt(title, author, needsDescription);
+
+        var llm = _llmFactory.Get("BookMetadata");
+        var text = await llm.CompleteAsync(systemPrompt, userPrompt, maxOutputTokens: 400, ct);
+
+        if (string.IsNullOrWhiteSpace(text))
+            return null;
+
+        return ParseResponse(text, needsDescription);
+    }
+
+    private static (string System, string User) BuildPrompt(string title, string? author, bool needsDescription)
+    {
+        var system = "You are a librarian. Given a book's title and author, provide metadata " +
+                     "in the EXACT format requested. No preface, no markdown.";
+
+        var parts = new List<string> { $"Book title: \"{title}\"" };
 
         if (!string.IsNullOrWhiteSpace(author))
             parts.Add($"Author: \"{author}\"");
@@ -52,7 +43,7 @@ public static class BookMetadataGenerator
         if (needsDescription)
             parts.Add("DESCRIPTION: <2-3 sentence book description, no spoilers>");
 
-        return string.Join("\n", parts);
+        return (system, string.Join("\n", parts));
     }
 
     private static readonly HashSet<string> ValidGenres = new(StringComparer.OrdinalIgnoreCase)
@@ -98,9 +89,10 @@ public static class BookMetadataGenerator
     }
 }
 
-public record BookMetadataResult(string? Genre, int? PublishedYear, string? Description);
-
-file class OllamaResponse
+public interface IBookMetadataGenerator
 {
-    public string Response { get; set; } = "";
+    Task<BookMetadataResult?> GenerateAsync(
+        string title, string? author, bool needsDescription, CancellationToken ct);
 }
+
+public record BookMetadataResult(string? Genre, int? PublishedYear, string? Description);

--- a/backend/src/Worker/Services/UserIngestionService.cs
+++ b/backend/src/Worker/Services/UserIngestionService.cs
@@ -18,8 +18,7 @@ public class UserIngestionService
     private readonly IFileStorageService _storage;
     private readonly IExtractorRegistry _extractorRegistry;
     private readonly IImageOptimizer _imageOptimizer;
-    private readonly IHttpClientFactory _httpClientFactory;
-    private readonly IConfiguration _config;
+    private readonly IBookMetadataGenerator _metadataGenerator;
     private readonly ILogger<UserIngestionService> _logger;
 
     public UserIngestionService(
@@ -27,16 +26,14 @@ public class UserIngestionService
         IFileStorageService storage,
         IExtractorRegistry extractorRegistry,
         IImageOptimizer imageOptimizer,
-        IHttpClientFactory httpClientFactory,
-        IConfiguration config,
+        IBookMetadataGenerator metadataGenerator,
         ILogger<UserIngestionService> logger)
     {
         _dbFactory = dbFactory;
         _storage = storage;
         _extractorRegistry = extractorRegistry;
         _imageOptimizer = imageOptimizer;
-        _httpClientFactory = httpClientFactory;
-        _config = config;
+        _metadataGenerator = metadataGenerator;
         _logger = logger;
     }
 
@@ -255,9 +252,8 @@ public class UserIngestionService
             {
                 try
                 {
-                    var meta = await BookMetadataGenerator.GenerateAsync(
-                        bookTitle, bookAuthor, needsDesc,
-                        _httpClientFactory, _config, CancellationToken.None);
+                    var meta = await _metadataGenerator.GenerateAsync(
+                        bookTitle, bookAuthor, needsDesc, CancellationToken.None);
 
                     if (meta is null) return;
 

--- a/backend/src/Worker/appsettings.json
+++ b/backend/src/Worker/appsettings.json
@@ -4,5 +4,21 @@
       "Default": "Information",
       "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
     }
+  },
+  "OpenAI": {
+    "ApiKey": "",
+    "Model": "gpt-5-mini"
+  },
+  "Ollama": {
+    "BaseUrl": "http://localhost:11434",
+    "Model": "qwen3:8b",
+    "TimeoutSeconds": 30
+  },
+  "LLM": {
+    "DefaultProvider": "ollama",
+    "Providers": {
+      "Distractor": "ollama",
+      "BookMetadata": "ollama"
+    }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,11 +61,13 @@ services:
       Jwt__Issuer: ${JWT_ISSUER}
       Jwt__Audience: ${JWT_AUDIENCE}
       Google__ClientId: ${GOOGLE_CLIENT_ID}
-      LibreTranslate__BaseUrl: http://libretranslate:5000
       Search__Provider: ${SEARCH_PROVIDER:-postgres}
       Tts__CachePath: /data/tts-cache
+      Explain__CachePath: /data/explain-cache
       Ollama__BaseUrl: http://ollama:11434
       Ollama__Model: qwen3:8b
+      OpenAI__ApiKey: ${OPENAI_API_KEY:-}
+      OpenAI__Model: ${OPENAI_MODEL:-gpt-5-mini}
       Resend__ApiKey: ${RESEND_API_KEY:-}
       Resend__FromEmail: ${RESEND_FROM_EMAIL:-noreply@textstack.app}
       Resend__AdminAlertEmail: ${ADMIN_ALERT_EMAIL:-}
@@ -74,6 +76,7 @@ services:
       - ./data/storage:/storage
       - ./data/textstack:/data/textstack
       - ./data/tts-cache:/data/tts-cache
+      - ./data/explain-cache:/data/explain-cache
     ports:
       - "127.0.0.1:8080:8080"  # Only localhost, nginx will proxy
     restart: always
@@ -241,29 +244,3 @@ services:
         reservations:
           memory: 2G
 
-  # ===========================================
-  # LibreTranslate - Self-hosted translation API
-  # ===========================================
-
-  libretranslate:
-    image: libretranslate/libretranslate:v1.6.4
-    container_name: textstack_libretranslate
-    environment:
-      - LT_LOAD_ONLY=en,uk,ru,de,fr,es,pl,pt,fa
-      - LT_DISABLE_WEB_UI=true
-      - LT_UPDATE_MODELS=true
-    volumes:
-      - ./data/libretranslate:/home/libretranslate/.local
-    restart: always
-    healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:5000/languages')\""]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 120s
-    deploy:
-      resources:
-        limits:
-          memory: 4G
-        reservations:
-          memory: 1G

--- a/tests/TextStack.IntegrationTests/TranslationEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/TranslationEndpointTests.cs
@@ -5,7 +5,8 @@ namespace TextStack.IntegrationTests;
 
 /// <summary>
 /// Integration tests for translation endpoints.
-/// Requires: docker compose up (API + LibreTranslate must be running)
+/// Requires: docker compose up (API must be running). Translation now runs
+/// through OpenAI — without OPENAI_API_KEY these return 502/503 (tests skip).
 /// </summary>
 public class TranslationEndpointTests : IClassFixture<LiveApiFixture>
 {
@@ -31,11 +32,11 @@ public class TranslationEndpointTests : IClassFixture<LiveApiFixture>
 
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        // LibreTranslate might not be running, so accept 502/503
+        // OpenAI may not be configured, so accept 502/503
         if (response.StatusCode == HttpStatusCode.BadGateway ||
             response.StatusCode == HttpStatusCode.ServiceUnavailable)
         {
-            return; // Skip - LibreTranslate not available
+            return; // Skip - OpenAI not available
         }
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -122,11 +123,11 @@ public class TranslationEndpointTests : IClassFixture<LiveApiFixture>
         var request = _fixture.CreateRequest(HttpMethod.Get, "/api/translate/languages");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        // LibreTranslate might not be running, so accept 502/503
+        // OpenAI may not be configured, so accept 502/503
         if (response.StatusCode == HttpStatusCode.BadGateway ||
             response.StatusCode == HttpStatusCode.ServiceUnavailable)
         {
-            return; // Skip - LibreTranslate not available
+            return; // Skip - OpenAI not available
         }
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -142,7 +143,7 @@ public class TranslationEndpointTests : IClassFixture<LiveApiFixture>
         var request = _fixture.CreateRequest(HttpMethod.Get, "/api/translate/languages");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
-        // LibreTranslate might not be running
+        // OpenAI may not be configured
         if (response.StatusCode != HttpStatusCode.OK)
         {
             return;

--- a/tests/TextStack.UnitTests/BookMetadataGeneratorTests.cs
+++ b/tests/TextStack.UnitTests/BookMetadataGeneratorTests.cs
@@ -1,6 +1,4 @@
-using System.Net;
-using System.Text.Json;
-using Microsoft.Extensions.Configuration;
+using Domain.LLM;
 using Moq;
 using Worker.Services;
 
@@ -8,36 +6,27 @@ namespace TextStack.UnitTests;
 
 public class BookMetadataGeneratorTests
 {
-    private static IConfiguration CreateConfig() =>
-        new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Ollama:BaseUrl"] = "http://localhost:11434",
-                ["Ollama:Model"] = "qwen3:8b",
-                ["Ollama:TimeoutSeconds"] = "5"
-            })
-            .Build();
-
-    private static IHttpClientFactory CreateHttpFactory(HttpStatusCode status, string ollamaResponse)
+    private static BookMetadataGenerator CreateGenerator(string llmResponse)
     {
-        var handler = new FakeHandler(status, ollamaResponse);
-        var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:11434") };
-        var factory = new Mock<IHttpClientFactory>();
-        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
-        return factory.Object;
+        var llm = new Mock<ILlmService>();
+        llm.Setup(l => l.CompleteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+           .ReturnsAsync(llmResponse);
+
+        var factory = new Mock<ILlmServiceFactory>();
+        factory.Setup(f => f.Get("BookMetadata")).Returns(llm.Object);
+
+        return new BookMetadataGenerator(factory.Object);
     }
 
     [Fact]
     public async Task GenerateAsync_ValidResponse_ParsesGenreAndYear()
     {
-        var response = "GENRE: Fiction\nYEAR: 1897";
-        var factory = CreateHttpFactory(HttpStatusCode.OK, response);
+        var gen = CreateGenerator("GENRE: Fiction\nYEAR: 1897");
 
-        var result = await BookMetadataGenerator.GenerateAsync(
-            "Dracula", "Bram Stoker", false, factory, CreateConfig(), CancellationToken.None);
+        var result = await gen.GenerateAsync("Dracula", "Bram Stoker", false, CancellationToken.None);
 
         Assert.NotNull(result);
-        Assert.Equal("Fiction", result.Genre);
+        Assert.Equal("Fiction", result!.Genre);
         Assert.Equal(1897, result.PublishedYear);
         Assert.Null(result.Description);
     }
@@ -45,14 +34,13 @@ public class BookMetadataGeneratorTests
     [Fact]
     public async Task GenerateAsync_WithDescription_ParsesAll()
     {
-        var response = "GENRE: Science Fiction\nYEAR: 1984\nDESCRIPTION: A dystopian novel about totalitarian surveillance and control in a future society.";
-        var factory = CreateHttpFactory(HttpStatusCode.OK, response);
+        var gen = CreateGenerator(
+            "GENRE: Science Fiction\nYEAR: 1984\nDESCRIPTION: A dystopian novel about totalitarian surveillance and control in a future society.");
 
-        var result = await BookMetadataGenerator.GenerateAsync(
-            "1984", "George Orwell", true, factory, CreateConfig(), CancellationToken.None);
+        var result = await gen.GenerateAsync("1984", "George Orwell", true, CancellationToken.None);
 
         Assert.NotNull(result);
-        Assert.Equal("Science Fiction", result.Genre);
+        Assert.Equal("Science Fiction", result!.Genre);
         Assert.Equal(1984, result.PublishedYear);
         Assert.NotNull(result.Description);
         Assert.Contains("dystopian", result.Description);
@@ -61,14 +49,13 @@ public class BookMetadataGeneratorTests
     [Fact]
     public async Task GenerateAsync_DescriptionIgnored_WhenNeedsDescriptionFalse()
     {
-        var response = "GENRE: Fiction\nYEAR: 1925\nDESCRIPTION: Some description here for the book.";
-        var factory = CreateHttpFactory(HttpStatusCode.OK, response);
+        var gen = CreateGenerator(
+            "GENRE: Fiction\nYEAR: 1925\nDESCRIPTION: Some description here for the book.");
 
-        var result = await BookMetadataGenerator.GenerateAsync(
-            "The Great Gatsby", "F. Scott Fitzgerald", false, factory, CreateConfig(), CancellationToken.None);
+        var result = await gen.GenerateAsync("The Great Gatsby", "F. Scott Fitzgerald", false, CancellationToken.None);
 
         Assert.NotNull(result);
-        Assert.Equal("Fiction", result.Genre);
+        Assert.Equal("Fiction", result!.Genre);
         Assert.Equal(1925, result.PublishedYear);
         Assert.Null(result.Description);
     }
@@ -76,11 +63,9 @@ public class BookMetadataGeneratorTests
     [Fact]
     public async Task GenerateAsync_InvalidGenre_ReturnsNull()
     {
-        var response = "GENRE: Cooking\nYEAR: UNKNOWN";
-        var factory = CreateHttpFactory(HttpStatusCode.OK, response);
+        var gen = CreateGenerator("GENRE: Cooking\nYEAR: UNKNOWN");
 
-        var result = await BookMetadataGenerator.GenerateAsync(
-            "Test", null, false, factory, CreateConfig(), CancellationToken.None);
+        var result = await gen.GenerateAsync("Test", null, false, CancellationToken.None);
 
         Assert.Null(result);
     }
@@ -88,49 +73,33 @@ public class BookMetadataGeneratorTests
     [Fact]
     public async Task GenerateAsync_UnknownYear_OnlyGenre()
     {
-        var response = "GENRE: Fantasy\nYEAR: UNKNOWN";
-        var factory = CreateHttpFactory(HttpStatusCode.OK, response);
+        var gen = CreateGenerator("GENRE: Fantasy\nYEAR: UNKNOWN");
 
-        var result = await BookMetadataGenerator.GenerateAsync(
-            "Some Book", null, false, factory, CreateConfig(), CancellationToken.None);
+        var result = await gen.GenerateAsync("Some Book", null, false, CancellationToken.None);
 
         Assert.NotNull(result);
-        Assert.Equal("Fantasy", result.Genre);
+        Assert.Equal("Fantasy", result!.Genre);
         Assert.Null(result.PublishedYear);
     }
 
     [Fact]
     public async Task GenerateAsync_FutureYear_Rejected()
     {
-        var response = $"GENRE: Fiction\nYEAR: {DateTime.UtcNow.Year + 5}";
-        var factory = CreateHttpFactory(HttpStatusCode.OK, response);
+        var gen = CreateGenerator($"GENRE: Fiction\nYEAR: {DateTime.UtcNow.Year + 5}");
 
-        var result = await BookMetadataGenerator.GenerateAsync(
-            "Test", null, false, factory, CreateConfig(), CancellationToken.None);
+        var result = await gen.GenerateAsync("Test", null, false, CancellationToken.None);
 
         Assert.NotNull(result);
-        Assert.Equal("Fiction", result.Genre);
+        Assert.Equal("Fiction", result!.Genre);
         Assert.Null(result.PublishedYear);
-    }
-
-    [Fact]
-    public async Task GenerateAsync_HttpError_ReturnsNull()
-    {
-        var factory = CreateHttpFactory(HttpStatusCode.ServiceUnavailable, "");
-
-        var result = await BookMetadataGenerator.GenerateAsync(
-            "Test", null, false, factory, CreateConfig(), CancellationToken.None);
-
-        Assert.Null(result);
     }
 
     [Fact]
     public async Task GenerateAsync_EmptyResponse_ReturnsNull()
     {
-        var factory = CreateHttpFactory(HttpStatusCode.OK, "");
+        var gen = CreateGenerator("");
 
-        var result = await BookMetadataGenerator.GenerateAsync(
-            "Test", null, false, factory, CreateConfig(), CancellationToken.None);
+        var result = await gen.GenerateAsync("Test", null, false, CancellationToken.None);
 
         Assert.Null(result);
     }
@@ -138,10 +107,9 @@ public class BookMetadataGeneratorTests
     [Fact]
     public async Task GenerateAsync_GarbageResponse_ReturnsNull()
     {
-        var factory = CreateHttpFactory(HttpStatusCode.OK, "I don't know that book sorry.");
+        var gen = CreateGenerator("I don't know that book sorry.");
 
-        var result = await BookMetadataGenerator.GenerateAsync(
-            "Test", null, false, factory, CreateConfig(), CancellationToken.None);
+        var result = await gen.GenerateAsync("Test", null, false, CancellationToken.None);
 
         Assert.Null(result);
     }
@@ -149,14 +117,12 @@ public class BookMetadataGeneratorTests
     [Fact]
     public async Task GenerateAsync_ShortDescription_Rejected()
     {
-        var response = "GENRE: Fiction\nYEAR: 2000\nDESCRIPTION: Short.";
-        var factory = CreateHttpFactory(HttpStatusCode.OK, response);
+        var gen = CreateGenerator("GENRE: Fiction\nYEAR: 2000\nDESCRIPTION: Short.");
 
-        var result = await BookMetadataGenerator.GenerateAsync(
-            "Test", null, true, factory, CreateConfig(), CancellationToken.None);
+        var result = await gen.GenerateAsync("Test", null, true, CancellationToken.None);
 
         Assert.NotNull(result);
-        Assert.Equal("Fiction", result.Genre);
+        Assert.Equal("Fiction", result!.Genre);
         Assert.Null(result.Description);
     }
 
@@ -180,52 +146,34 @@ public class BookMetadataGeneratorTests
     [InlineData("Other")]
     public async Task GenerateAsync_AllValidGenres_Accepted(string genre)
     {
-        var response = $"GENRE: {genre}\nYEAR: 2000";
-        var factory = CreateHttpFactory(HttpStatusCode.OK, response);
+        var gen = CreateGenerator($"GENRE: {genre}\nYEAR: 2000");
 
-        var result = await BookMetadataGenerator.GenerateAsync(
-            "Test Book", null, false, factory, CreateConfig(), CancellationToken.None);
+        var result = await gen.GenerateAsync("Test Book", null, false, CancellationToken.None);
 
         Assert.NotNull(result);
-        Assert.Equal(genre, result.Genre);
+        Assert.Equal(genre, result!.Genre);
     }
 
     [Fact]
     public async Task GenerateAsync_CaseInsensitiveGenre_Accepted()
     {
-        var response = "GENRE: fiction\nYEAR: 2000";
-        var factory = CreateHttpFactory(HttpStatusCode.OK, response);
+        var gen = CreateGenerator("GENRE: fiction\nYEAR: 2000");
 
-        var result = await BookMetadataGenerator.GenerateAsync(
-            "Test", null, false, factory, CreateConfig(), CancellationToken.None);
+        var result = await gen.GenerateAsync("Test", null, false, CancellationToken.None);
 
         Assert.NotNull(result);
-        Assert.Equal("fiction", result.Genre);
+        Assert.Equal("fiction", result!.Genre);
     }
 
     [Fact]
     public async Task GenerateAsync_ExtraWhitespace_Handled()
     {
-        var response = "  GENRE:   Fantasy  \n  YEAR:   1937  ";
-        var factory = CreateHttpFactory(HttpStatusCode.OK, response);
+        var gen = CreateGenerator("  GENRE:   Fantasy  \n  YEAR:   1937  ");
 
-        var result = await BookMetadataGenerator.GenerateAsync(
-            "The Hobbit", "J.R.R. Tolkien", false, factory, CreateConfig(), CancellationToken.None);
+        var result = await gen.GenerateAsync("The Hobbit", "J.R.R. Tolkien", false, CancellationToken.None);
 
         Assert.NotNull(result);
-        Assert.Equal("Fantasy", result.Genre);
+        Assert.Equal("Fantasy", result!.Genre);
         Assert.Equal(1937, result.PublishedYear);
-    }
-
-    private class FakeHandler(HttpStatusCode status, string ollamaResponse) : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
-        {
-            var json = JsonSerializer.Serialize(new { response = ollamaResponse });
-            return Task.FromResult(new HttpResponseMessage(status)
-            {
-                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
-            });
-        }
     }
 }

--- a/tests/TextStack.UnitTests/DistractorGeneratorTests.cs
+++ b/tests/TextStack.UnitTests/DistractorGeneratorTests.cs
@@ -1,6 +1,4 @@
-using System.Net;
-using System.Text.Json;
-using Microsoft.Extensions.Options;
+using Domain.LLM;
 using Moq;
 using TextStack.Vocabulary;
 
@@ -8,37 +6,36 @@ namespace TextStack.UnitTests;
 
 public class DistractorGeneratorTests
 {
-    private static IHttpClientFactory CreateHttpFactory(HttpStatusCode status, string responseText)
+    private static DistractorGenerator CreateGenerator(string llmResponse, bool throwOnCall = false)
     {
-        var json = JsonSerializer.Serialize(new { response = responseText });
-        var handler = new FakeHandler(status, json);
-        var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:11434") };
-        var factory = new Mock<IHttpClientFactory>();
-        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
-        return factory.Object;
-    }
-
-    private static IOptions<VocabularyOptions> CreateOptions() =>
-        Options.Create(new VocabularyOptions
+        var llm = new Mock<ILlmService>();
+        if (throwOnCall)
         {
-            OllamaBaseUrl = "http://localhost:11434",
-            OllamaModel = "qwen3:8b",
-            OllamaTimeoutSeconds = 5,
-        });
+            llm.Setup(l => l.CompleteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+               .ThrowsAsync(new HttpRequestException("mock"));
+        }
+        else
+        {
+            llm.Setup(l => l.CompleteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(llmResponse);
+        }
 
-    private static DistractorGenerator CreateGenerator(HttpStatusCode status, string responseText) =>
-        new(CreateHttpFactory(status, responseText), CreateOptions());
+        var factory = new Mock<ILlmServiceFactory>();
+        factory.Setup(f => f.Get("Distractor")).Returns(llm.Object);
+
+        return new DistractorGenerator(factory.Object);
+    }
 
     // === Structured response parsing ===
 
     [Fact]
     public async Task Generate_StructuredResponse_ParsesDistractorsAndHint()
     {
-        var gen = CreateGenerator(HttpStatusCode.OK,
+        var gen = CreateGenerator(
             "DISTRACTORS: fuzzy, bright, sharp, narrow, gentle\nHINT: Moving quickly without delay.");
 
         var (distractors, hint, _) = await gen.GenerateAsync(
-            "fast", "en", "Quick", null, null, CancellationToken.None);
+            "fast", "en", "Quick", null, "en", CancellationToken.None);
 
         Assert.NotNull(distractors);
         Assert.Equal(5, distractors!.Count);
@@ -50,11 +47,11 @@ public class DistractorGeneratorTests
     [Fact]
     public async Task Generate_HintContainsWord_HintExcluded()
     {
-        var gen = CreateGenerator(HttpStatusCode.OK,
+        var gen = CreateGenerator(
             "DISTRACTORS: a, b, c, d, e\nHINT: The word fast means quick.");
 
         var (_, hint, _) = await gen.GenerateAsync(
-            "fast", "en", null, null, null, CancellationToken.None);
+            "fast", "en", null, null, "en", CancellationToken.None);
 
         Assert.Null(hint);
     }
@@ -62,11 +59,11 @@ public class DistractorGeneratorTests
     [Fact]
     public async Task Generate_DistractorContainsOriginalWord_Excluded()
     {
-        var gen = CreateGenerator(HttpStatusCode.OK,
+        var gen = CreateGenerator(
             "DISTRACTORS: fast, bright, sharp, narrow, gentle");
 
         var (distractors, _, _) = await gen.GenerateAsync(
-            "fast", "en", null, null, null, CancellationToken.None);
+            "fast", "en", null, null, "en", CancellationToken.None);
 
         Assert.NotNull(distractors);
         Assert.DoesNotContain("fast", distractors!);
@@ -75,11 +72,11 @@ public class DistractorGeneratorTests
     [Fact]
     public async Task Generate_DuplicateDistractors_Deduplicated()
     {
-        var gen = CreateGenerator(HttpStatusCode.OK,
+        var gen = CreateGenerator(
             "DISTRACTORS: bright, bright, sharp, narrow, gentle");
 
         var (distractors, _, _) = await gen.GenerateAsync(
-            "fast", "en", null, null, null, CancellationToken.None);
+            "fast", "en", null, null, "en", CancellationToken.None);
 
         Assert.NotNull(distractors);
         Assert.Equal(distractors!.Count, distractors.Distinct().Count());
@@ -88,11 +85,10 @@ public class DistractorGeneratorTests
     [Fact]
     public async Task Generate_LessThan3Distractors_ReturnsNull()
     {
-        var gen = CreateGenerator(HttpStatusCode.OK,
-            "DISTRACTORS: one, two");
+        var gen = CreateGenerator("DISTRACTORS: one, two");
 
         var (distractors, _, _) = await gen.GenerateAsync(
-            "fast", "en", null, null, null, CancellationToken.None);
+            "fast", "en", null, null, "en", CancellationToken.None);
 
         Assert.Null(distractors);
     }
@@ -100,11 +96,11 @@ public class DistractorGeneratorTests
     [Fact]
     public async Task Generate_MultiWordDistractors_Filtered()
     {
-        var gen = CreateGenerator(HttpStatusCode.OK,
+        var gen = CreateGenerator(
             "DISTRACTORS: very bright, sharp, narrow, gentle, bold");
 
         var (distractors, _, _) = await gen.GenerateAsync(
-            "fast", "en", null, null, null, CancellationToken.None);
+            "fast", "en", null, null, "en", CancellationToken.None);
 
         Assert.NotNull(distractors);
         Assert.DoesNotContain("very bright", distractors!);
@@ -115,11 +111,10 @@ public class DistractorGeneratorTests
     [Fact]
     public async Task Generate_NoPrefix_FallsBackToCommaParsing()
     {
-        var gen = CreateGenerator(HttpStatusCode.OK,
-            "bright, sharp, narrow, gentle, bold");
+        var gen = CreateGenerator("bright, sharp, narrow, gentle, bold");
 
         var (distractors, _, _) = await gen.GenerateAsync(
-            "fast", "en", null, null, null, CancellationToken.None);
+            "fast", "en", null, null, "en", CancellationToken.None);
 
         Assert.NotNull(distractors);
         Assert.True(distractors!.Count >= 3);
@@ -128,11 +123,11 @@ public class DistractorGeneratorTests
     [Fact]
     public async Task Generate_NumberedList_StripsNumbers()
     {
-        var gen = CreateGenerator(HttpStatusCode.OK,
+        var gen = CreateGenerator(
             "DISTRACTORS: 1. bright, 2. sharp, 3. narrow, 4. gentle, 5. bold");
 
         var (distractors, _, _) = await gen.GenerateAsync(
-            "fast", "en", null, null, null, CancellationToken.None);
+            "fast", "en", null, null, "en", CancellationToken.None);
 
         Assert.NotNull(distractors);
         Assert.Contains("bright", distractors!);
@@ -142,7 +137,7 @@ public class DistractorGeneratorTests
     [Fact]
     public async Task Generate_StructuredResponse_ParsesExplanation()
     {
-        var gen = CreateGenerator(HttpStatusCode.OK,
+        var gen = CreateGenerator(
             "DISTRACTORS: fuzzy, bright, sharp, narrow, gentle\nHINT: Moving quickly.\nEXPLANATION: Слово означает быстрый, скорый.");
 
         var (_, _, explanation) = await gen.GenerateAsync(
@@ -151,40 +146,29 @@ public class DistractorGeneratorTests
         Assert.Equal("Слово означает быстрый, скорый.", explanation);
     }
 
-    // === API failure ===
+    // === LLM failure ===
 
     [Fact]
-    public async Task Generate_ApiError_ReturnsNulls()
+    public async Task Generate_LlmReturnsEmpty_ReturnsNulls()
     {
-        var gen = CreateGenerator(HttpStatusCode.InternalServerError, "");
+        var gen = CreateGenerator("");
 
-        var (distractors, hint, _) = await gen.GenerateAsync(
-            "fast", "en", null, null, null, CancellationToken.None);
+        var (distractors, hint, explanation) = await gen.GenerateAsync(
+            "fast", "en", null, null, "en", CancellationToken.None);
 
         Assert.Null(distractors);
         Assert.Null(hint);
-    }
-
-    [Fact]
-    public async Task Generate_EmptyResponse_ReturnsNulls()
-    {
-        var gen = CreateGenerator(HttpStatusCode.OK, "");
-
-        var (distractors, hint, _) = await gen.GenerateAsync(
-            "fast", "en", null, null, null, CancellationToken.None);
-
-        Assert.Null(distractors);
-        Assert.Null(hint);
+        Assert.Null(explanation);
     }
 
     [Fact]
     public async Task Generate_DistractorsLowercased()
     {
-        var gen = CreateGenerator(HttpStatusCode.OK,
+        var gen = CreateGenerator(
             "DISTRACTORS: Bright, SHARP, Narrow, Gentle, Bold");
 
         var (distractors, _, _) = await gen.GenerateAsync(
-            "fast", "en", null, null, null, CancellationToken.None);
+            "fast", "en", null, null, "en", CancellationToken.None);
 
         Assert.NotNull(distractors);
         Assert.All(distractors!, d => Assert.Equal(d, d.ToLowerInvariant()));
@@ -193,11 +177,11 @@ public class DistractorGeneratorTests
     [Fact]
     public async Task Generate_Max5Distractors()
     {
-        var gen = CreateGenerator(HttpStatusCode.OK,
+        var gen = CreateGenerator(
             "DISTRACTORS: alpha, bravo, charlie, delta, echo, foxtrot, golf, hotel");
 
         var (distractors, _, _) = await gen.GenerateAsync(
-            "fast", "en", null, null, null, CancellationToken.None);
+            "fast", "en", null, null, "en", CancellationToken.None);
 
         Assert.NotNull(distractors);
         Assert.True(distractors!.Count <= 5);
@@ -207,22 +191,13 @@ public class DistractorGeneratorTests
     public async Task Generate_LongDistractors_Filtered()
     {
         var longWord = new string('a', 60);
-        var gen = CreateGenerator(HttpStatusCode.OK,
+        var gen = CreateGenerator(
             $"DISTRACTORS: {longWord}, bright, sharp, narrow, gentle");
 
         var (distractors, _, _) = await gen.GenerateAsync(
-            "fast", "en", null, null, null, CancellationToken.None);
+            "fast", "en", null, null, "en", CancellationToken.None);
 
         Assert.NotNull(distractors);
         Assert.DoesNotContain(longWord, distractors!);
-    }
-
-    private class FakeHandler(HttpStatusCode status, string body) : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
-            Task.FromResult(new HttpResponseMessage(status)
-            {
-                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json")
-            });
     }
 }


### PR DESCRIPTION
## Summary

- New `ILlmService` abstraction in Domain + `ILlmServiceFactory` (keyed DI: `openai` / `ollama`)
- OpenAI (gpt-5-mini) for `/explain` + `/translate` — replaces LibreTranslate
- Ollama kept for `Distractor` + `BookMetadata` (saves $ at scale)
- Per-job routing via `LLM:Providers` config — buyer flips provider per job without code change
- Fixes eager-DI 500 in prior OpenAI PR (#145) — factory pattern defers construction

Supersedes #145.

## Config

\`\`\`json
"LLM": {
  "DefaultProvider": "openai",
  "Providers": {
    "Explain": "openai",
    "Translate": "openai",
    "Distractor": "ollama",
    "BookMetadata": "ollama"
  }
}
\`\`\`

## Test plan

- [x] Unit tests (204 pass, including rewritten DistractorGeneratorTests + BookMetadataGeneratorTests w/ Moq)
- [x] Full solution build clean
- [ ] Docker integration tests (CI — translation tests will pass now since validation returns 400 before factory.Get call)
- [ ] E2E smoke on staging w/ real OPENAI_API_KEY

🤖 Generated with [Claude Code](https://claude.com/claude-code)