### PR TITLE
fix(llm): pad reasoning budget for OpenAI reasoning models

### DIFF
--- a/backend/src/Application/LLM/OpenAiLlmService.cs
+++ b/backend/src/Application/LLM/OpenAiLlmService.cs
@@ -10,6 +10,7 @@ public class OpenAiLlmService : ILlmService
 {
     private readonly ChatClient _client;
     private readonly ILogger<OpenAiLlmService> _logger;
+    private readonly int _reasoningBudget;
 
     public OpenAiLlmService(IConfiguration config, ILogger<OpenAiLlmService> logger)
     {
@@ -22,6 +23,12 @@ public class OpenAiLlmService : ILlmService
         var model = config["OpenAI:Model"]
             ?? Environment.GetEnvironmentVariable("OPENAI_MODEL")
             ?? "gpt-5-mini";
+
+        // Reasoning models (gpt-5, o1, o3…) consume tokens for internal reasoning
+        // before producing visible output. MaxOutputTokenCount caps the combined
+        // total, so we pad the caller's desired output budget with a reserve.
+        // Non-reasoning models just get a harmless higher ceiling.
+        _reasoningBudget = config.GetValue("OpenAI:ReasoningTokenBudget", 512);
 
         _client = new OpenAIClient(apiKey).GetChatClient(model);
     }
@@ -40,11 +47,18 @@ public class OpenAiLlmService : ILlmService
 
         var options = new ChatCompletionOptions
         {
-            MaxOutputTokenCount = maxOutputTokens,
+            MaxOutputTokenCount = maxOutputTokens + _reasoningBudget,
         };
 
         var result = await _client.CompleteChatAsync(messages, options, ct);
         var text = result.Value.Content.FirstOrDefault()?.Text ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            _logger.LogWarning(
+                "OpenAI returned empty content (finish={Finish}, maxOutputTokens={Max})",
+                result.Value.FinishReason,
+                maxOutputTokens + _reasoningBudget);
+        }
         return text.Trim();
     }
 }


### PR DESCRIPTION
## Problem
\`/api/explain\` returned HTTP 502 \`LLM returned empty explanation\` in prod.

Root cause: \`gpt-5-mini\` is a reasoning model — it consumes output tokens for internal reasoning before producing visible content. OpenAI's \`MaxOutputTokenCount\` caps the **combined** total (reasoning + visible). ExplainEndpoints passed \`maxOutputTokens: 200\` → all 200 eaten by reasoning → \`content: ""\`, \`finish_reason: "length"\`.

## Fix
- \`OpenAiLlmService\` pads caller's \`maxOutputTokens\` with \`OpenAI:ReasoningTokenBudget\` (default **512**). Callers stay semantic ("I want 200 tokens of output"), service handles the overhead.
- Log \`finish_reason\` + budget when OpenAI returns empty content → future token-budget issues diagnosable from logs.
- Harmless on non-reasoning models (e.g. gpt-4o) — just a higher ceiling.

## Verified
\`\`\`
POST /api/explain → 200, "Serendipity means a happy, fortunate accident…"
POST /api/translate → 200, "Buenos días"
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)