### PR TITLE
reader: reliability audit — cache, model swap, session hygiene

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,10 @@ INDEXNOW_KEY=
 INDEXNOW_ENABLED=false
 
 # OpenAI (contextual /explain endpoint + translation)
+# gpt-4o-mini: fast, non-reasoning. For /explain + /translate hot paths.
+# gpt-5-mini: reasoning model (slower, higher quality but wastes tokens on internal reasoning).
 OPENAI_API_KEY=
-OPENAI_MODEL=gpt-5-mini
+OPENAI_MODEL=gpt-4o-mini
 
 # Resend (email: password reset + admin ops alerts)
 RESEND_API_KEY=

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -7,9 +7,24 @@ in each project's own LICENSE.
 ## TextStack source code
 
 Everything under this repository authored by TextStack contributors is
-**MIT-licensed**. See `LICENSE` at repo root.
+licensed under the **Business Source License 1.1** (BUSL-1.1). See
+`LICENSE` at repo root.
 
 Copyright © 2026 Vasyl Vdovychenko and contributors.
+
+**Summary (not legal advice, see LICENSE for authoritative text):**
+
+- You may: read, fork, modify, redistribute, self-host for personal or
+  internal use, run in development/CI.
+- You may **not**: offer TextStack as a **Hosted Service** — i.e. a
+  commercial product that lets third parties access TextStack
+  functionality as a service — without a commercial license from the
+  Licensor.
+- **Change Date: 2030-04-22.** On that date the code auto-converts to
+  Apache License 2.0 and all restrictions drop.
+
+For a commercial / hosted-service license, contact the Licensor via the
+contact form at https://textstack.app.
 
 ## Book content
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,102 @@
-MIT License
+Business Source License 1.1
 
-Copyright (c) 2026 Vasyl Vdovychenko
+Parameters
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Licensor:             Vasyl Vdovychenko
+Licensed Work:        TextStack
+                      The Licensed Work is (c) 2026 Vasyl Vdovychenko.
+Additional Use Grant: You may make use of the Licensed Work, provided that
+                      you do not use the Licensed Work for a Hosted Service.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+                      A "Hosted Service" is a commercial offering that
+                      allows third parties (other than your employees and
+                      contractors) to access the functionality of the
+                      Licensed Work by performing an action directly or
+                      indirectly that causes the creation of an instance,
+                      or interaction with an instance, of the Licensed
+                      Work.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Change Date:          2030-04-22
+
+Change License:       Apache License, Version 2.0
+
+For information about alternative licensing arrangements for the Licensed
+Work, please contact the Licensor.
+
+Notice
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first
+publicly available distribution of a specific version of the Licensed Work
+under this License, whichever comes first, the Licensor hereby grants you
+rights under the terms of the Change License, and the rights granted in the
+paragraph above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may
+vary for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified
+copy of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in
+this License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License's text to license
+your works, and to refer to it using the trademark "Business Source
+License", as long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to
+all other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later
+   version, or a license that is compatible with GPL Version 2.0 or a later
+   version, where "compatible" means that software provided under the
+   Change License can be included in a program with software provided
+   under GPL Version 2.0 or a later version. Licensor may specify
+   additional Change Licenses without limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does
+   not impose any additional restriction on the right granted in this
+   License, as the Additional Use Grant; or (b) insert the text
+   "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.

--- a/PLAN-presale-8w.md
+++ b/PLAN-presale-8w.md
@@ -53,8 +53,9 @@ killed.
       quick-start, features table aligned with dev.to narrative (AI
       engineering books, contextual explanations, capped SRS). Critical for
       star conversion.
-- [ ] **LICENSE file** — pick MIT or Apache-2.0 (recommend MIT for max star
-      potential + commercial reuse by buyer). Add to root.
+- [ ] **LICENSE file** — BUSL-1.1 w/ Apache-2.0 change license @ 4y
+      (non-compete: no competing managed service). MIT rejected 2026-04-22
+      — owner pays OpenAI, plans to monetize if traffic grows. Add to root.
 - [ ] **COPYRIGHT.md / NOTICE** — break down: our code (MIT), Standard
       Ebooks corpus (public domain, CC0), OSS deps (inherited), Edge TTS
       (Microsoft ToS). Sale-critical clarity.
@@ -166,7 +167,7 @@ plan when signals arrive.
 |---|---|---|
 | 2026-04-22 | Keep Standard Ebooks corpus in sale | SEO SSG pages = indexed inventory; removing = traffic hit |
 | 2026-04-22 | Mobile Android in sale, iOS best-effort | Play review ≤ Apple review; Android gets done, iOS gated on time |
-| 2026-04-22 | MIT license (tentative) | Max star potential, max commercial reuse by buyer |
+| 2026-04-22 | ~~MIT license (tentative)~~ → BUSL-1.1 + Apache-2.0 @ 4y | Owner pays OpenAI, wants to monetize if traffic grows; MIT would let anyone host competing SaaS free |
 | 2026-04-22 | Full scope, not trimmed | 8w is enough time; Full = higher ask |
 
 ---

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-BUSL--1.1-blue.svg" alt="Business Source License 1.1"></a>
   <img src="https://img.shields.io/badge/.NET-10-512BD4" alt=".NET 10">
   <img src="https://img.shields.io/badge/React-19-61DAFB" alt="React 19">
   <img src="https://img.shields.io/badge/Expo-55-000020" alt="Expo 55">
@@ -195,9 +195,15 @@ that I'm building the right thing.
 
 ## License
 
-[MIT](LICENSE) © 2026 Vasyl Vdovychenko.
+[Business Source License 1.1](LICENSE) © 2026 Vasyl Vdovychenko.
 
-- Source code: MIT
+Source-available, **not** open source. You may fork, modify, and self-host
+for personal or internal use. You may **not** offer TextStack as a hosted
+commercial service without a commercial license. On **2030-04-22** the code
+auto-converts to Apache 2.0 and all restrictions drop. See
+[COPYRIGHT.md](COPYRIGHT.md) for plain-English summary.
+
+- Source code: BUSL-1.1 → Apache-2.0 (2030-04-22)
 - Standard Ebooks corpus (included in seed data): CC0 / public domain
 - Edge TTS: used under Microsoft's Edge Read Aloud terms
 - Third-party deps: their respective licenses

--- a/apps/web/src/components/home/ComparisonSection.tsx
+++ b/apps/web/src/components/home/ComparisonSection.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from '../../hooks/useTranslation'
 
 const FEATURES = [
+  'contextualExplain',
   'tapTranslate',
   'srsCards',
   'uploadBooks',
@@ -15,6 +16,7 @@ const COMPETITORS = ['textstack', 'lingq', 'kindle', 'speechify'] as const
 type Status = 'yes' | 'no' | 'partial'
 
 const DATA: Record<string, Record<string, Status>> = {
+  contextualExplain: { textstack: 'yes', lingq: 'no', kindle: 'partial', speechify: 'no' },
   tapTranslate:  { textstack: 'yes', lingq: 'yes', kindle: 'partial', speechify: 'no' },
   srsCards:      { textstack: 'yes', lingq: 'yes', kindle: 'no', speechify: 'no' },
   uploadBooks:   { textstack: 'yes', lingq: 'yes', kindle: 'no', speechify: 'yes' },

--- a/apps/web/src/components/home/FaqSection.tsx
+++ b/apps/web/src/components/home/FaqSection.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from '../../hooks/useTranslation'
 const FAQ_KEYS = [
   'whatIs',
   'isFree',
+  'techBooks',
   'languages',
   'tapTranslate',
   'uploadBooks',

--- a/apps/web/src/components/home/FeaturesSection.tsx
+++ b/apps/web/src/components/home/FeaturesSection.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from '../../hooks/useTranslation'
 
 const FEATURES = [
-  { key: 'translate', icon: '🔍' },
+  { key: 'explain', icon: '💡' },
   { key: 'srs', icon: '🧠' },
   { key: 'upload', icon: '📖' },
   { key: 'stats', icon: '📊' },

--- a/apps/web/src/hooks/useExplain.ts
+++ b/apps/web/src/hooks/useExplain.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from 'react'
 import { explain as explainApi, type ExplainRequest } from '../api/explain'
+import { getCachedExplain, cacheExplain } from '../lib/offlineDb'
 
 interface ExplainState {
   explanation: string | null
@@ -26,6 +27,23 @@ export function useExplain() {
 
     setState({ explanation: null, isLoading: true, error: null, cached: false })
 
+    const targetLang = (req.targetLang || 'en').split('-')[0]
+
+    try {
+      const hit = await getCachedExplain(req.word, req.sentence, req.genre, targetLang)
+      if (hit) {
+        setState({
+          explanation: hit.explanation,
+          isLoading: false,
+          error: null,
+          cached: true,
+        })
+        return hit.explanation
+      }
+    } catch {
+      // cache read failed — fall through
+    }
+
     if (!navigator.onLine) {
       setState({ explanation: null, isLoading: false, error: 'Offline', cached: false })
       return null
@@ -39,6 +57,7 @@ export function useExplain() {
         error: null,
         cached: result.cached,
       })
+      cacheExplain(req.word, req.sentence, req.genre, targetLang, result.explanation).catch(() => {})
       return result.explanation
     } catch (err) {
       if ((err as { name?: string })?.name === 'AbortError') return null

--- a/apps/web/src/hooks/useReadingSession.ts
+++ b/apps/web/src/hooks/useReadingSession.ts
@@ -192,14 +192,25 @@ function savePendingSession(session: PendingSession) {
   }
 }
 
+// Server rejects sessions older than 7 days — drop at 6 to give a safety margin.
+const MAX_SESSION_AGE_MS = 6 * 24 * 60 * 60 * 1000
+
 async function flushPendingSessions() {
   try {
     const raw = localStorage.getItem(PENDING_SESSIONS_KEY)
     if (!raw) return
-    const sessions = JSON.parse(raw) as PendingSession[]
-    if (sessions.length === 0) return
+    const all = JSON.parse(raw) as PendingSession[]
+    if (all.length === 0) return
+
+    const now = Date.now()
+    const sessions = all.filter(s => {
+      const startedAt = Date.parse(s.startedAt)
+      return Number.isFinite(startedAt) && now - startedAt < MAX_SESSION_AGE_MS
+    })
 
     localStorage.removeItem(PENDING_SESSIONS_KEY)
+
+    if (sessions.length === 0) return
 
     const failed: PendingSession[] = []
     for (const session of sessions) {

--- a/apps/web/src/lib/offlineDb.ts
+++ b/apps/web/src/lib/offlineDb.ts
@@ -80,6 +80,14 @@ export interface CachedTtsAudio {
   cachedAt: number
 }
 
+export interface CachedExplain {
+  key: string // hash of word+sentence+genre+targetLang
+  explanation: string
+  word: string
+  targetLang: string
+  cachedAt: number
+}
+
 export interface PendingVocabWord {
   id: string           // crypto.randomUUID(), stable local ID
   word: string
@@ -96,7 +104,7 @@ export interface PendingVocabWord {
 }
 
 const DB_NAME = 'textstack-reader'
-const DB_VERSION = 8
+const DB_VERSION = 9
 const CHAPTERS_STORE = 'chapters'
 const BOOKS_META_STORE = 'cachedBooks'
 const HIGHLIGHTS_STORE = 'highlights'
@@ -104,6 +112,7 @@ const TRANSLATIONS_STORE = 'translations'
 const DICTIONARY_STORE = 'dictionary'
 const TTS_STORE = 'tts-audio'
 const PENDING_VOCAB_STORE = 'pendingVocabWords'
+const EXPLAIN_STORE = 'explains'
 
 let dbPromise: Promise<IDBDatabase> | null = null
 
@@ -176,6 +185,12 @@ export function openOfflineDb(): Promise<IDBDatabase> {
       if (!db.objectStoreNames.contains(PENDING_VOCAB_STORE)) {
         const store = db.createObjectStore(PENDING_VOCAB_STORE, { keyPath: 'id' })
         store.createIndex('createdAt', 'createdAt', { unique: false })
+      }
+
+      // Explain cache store (v9) — mirrors server-side file cache for zero-latency repeat lookups.
+      if (!db.objectStoreNames.contains(EXPLAIN_STORE)) {
+        const store = db.createObjectStore(EXPLAIN_STORE, { keyPath: 'key' })
+        store.createIndex('cachedAt', 'cachedAt', { unique: false })
       }
     }
   })
@@ -800,6 +815,89 @@ export async function clearPendingVocabWords(): Promise<void> {
     const store = tx.objectStore(PENDING_VOCAB_STORE)
     const request = store.clear()
     request.onsuccess = () => resolve()
+    request.onerror = () => reject(request.error)
+  })
+}
+
+// ============ EXPLAIN CACHE ============
+
+const EXPLAIN_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+function makeExplainKey(word: string, sentence: string, genre: string | null | undefined, targetLang: string): string {
+  return `${word.toLowerCase()}|${sentence}|${genre || ''}|${targetLang}`
+}
+
+export async function getCachedExplain(
+  word: string,
+  sentence: string,
+  genre: string | null | undefined,
+  targetLang: string
+): Promise<CachedExplain | null> {
+  const db = await openOfflineDb()
+  const key = makeExplainKey(word, sentence, genre, targetLang)
+
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(EXPLAIN_STORE, 'readonly')
+    const store = tx.objectStore(EXPLAIN_STORE)
+    const request = store.get(key)
+
+    request.onsuccess = () => {
+      const result = request.result as CachedExplain | undefined
+      if (result && Date.now() - result.cachedAt < EXPLAIN_TTL_MS) {
+        resolve(result)
+      } else {
+        resolve(null)
+      }
+    }
+    request.onerror = () => reject(request.error)
+  })
+}
+
+export async function cacheExplain(
+  word: string,
+  sentence: string,
+  genre: string | null | undefined,
+  targetLang: string,
+  explanation: string
+): Promise<void> {
+  const db = await openOfflineDb()
+  const cached: CachedExplain = {
+    key: makeExplainKey(word, sentence, genre, targetLang),
+    explanation,
+    word,
+    targetLang,
+    cachedAt: Date.now(),
+  }
+
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(EXPLAIN_STORE, 'readwrite')
+    const store = tx.objectStore(EXPLAIN_STORE)
+    const request = store.put(cached)
+    request.onsuccess = () => resolve()
+    request.onerror = () => reject(request.error)
+  })
+}
+
+export async function clearOldExplains(maxAgeMs = EXPLAIN_TTL_MS): Promise<void> {
+  const db = await openOfflineDb()
+  const cutoff = Date.now() - maxAgeMs
+
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(EXPLAIN_STORE, 'readwrite')
+    const store = tx.objectStore(EXPLAIN_STORE)
+    const index = store.index('cachedAt')
+    const range = IDBKeyRange.upperBound(cutoff)
+    const request = index.openCursor(range)
+
+    request.onsuccess = () => {
+      const cursor = request.result
+      if (cursor) {
+        cursor.delete()
+        cursor.continue()
+      } else {
+        resolve()
+      }
+    }
     request.onerror = () => reject(request.error)
   })
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -4,13 +4,13 @@
   },
   "home": {
     "hero": {
-      "title": "Read books in English without stopping",
-      "subtitleBefore": "Tap any word to translate to",
-      "subtitleAfter": "— and stay in flow",
-      "brandLine": "TextStack Reader — learn English by reading real books",
-      "seoTitle": "TextStack Reader — Read books in English with instant translation",
-      "seoDescription": "Read books in English without stopping. Tap any word to translate instantly and stay in flow. Learn English by reading real books with TextStack.",
-      "description": "TextStack Reader is a reading platform for language learners. Thousands of classic books with built-in vocabulary tools, spaced repetition, and reading statistics.",
+      "title": "Finish the book you keep quitting.",
+      "subtitleBefore": "Tap any word for a contextual explanation in",
+      "subtitleAfter": "— stay in flow, finish the book.",
+      "brandLine": "TextStack — a reader for developers, students, and curious minds.",
+      "seoTitle": "TextStack — A reader that helps you finish dense books",
+      "seoDescription": "Finish the tech book, paper, or classic you keep quitting. Contextual word explanations tied to the book's domain. Capped weekly SRS, offline reading. EPUB, PDF, FB2.",
+      "description": "TextStack is a reader for dense tech books, papers, and literary classics. Contextual word explanations tied to the book's domain, a capped weekly SRS queue, and detailed reading stats — all in one place.",
       "cta": "Browse catalog",
       "ctaPrimary": "Start reading",
       "ctaSecondary": "Upload your book",
@@ -33,26 +33,26 @@
       "read": "Read"
     },
     "recommended": {
-      "title": "Recommended for You",
-      "subtitle": "Highest-rated books in our catalog",
+      "title": "Classic literature",
+      "subtitle": "Free, public-domain books — thousands ready to read.",
       "viewAll": "View all books"
     },
     "seo": {
-      "content": "TextStack Reader is a language learning platform built around reading. The catalog features thousands of classic and public-domain books. As you read, you can look up words, save them to your vocabulary, and review with spaced repetition. Track reading stats, set goals, and grow your fluency — all in a calm, distraction-free environment."
+      "content": "TextStack is a reader built for people who want to finish the book they keep quitting — from dense tech books and papers to classic literature. Every word you tap gets a contextual explanation tied to the book's domain, not a generic dictionary. Save words to a capped weekly SRS queue, track reading stats, and sync across web and mobile."
     },
     "continueReading": {
       "label": "Continue Reading"
     },
     "features": {
-      "heading": "Everything you need to read — and learn",
-      "subheading": "One clean app. Real books. Real progress.",
-      "translate": {
-        "title": "Tap to translate",
-        "description": "Tap any word for instant translation, definition, and pronunciation. 18+ languages."
+      "heading": "Tools that keep you reading",
+      "subheading": "Contextual explanations. Capped SRS. Offline. Across devices.",
+      "explain": {
+        "title": "Explain in context",
+        "description": "Tap any word for a 2-sentence explanation tied to the book's domain — plus translation and pronunciation."
       },
       "srs": {
-        "title": "Smart flashcards",
-        "description": "Saved words become SRS flashcards. 5 stages from Recognition to Mastered."
+        "title": "Capped weekly SRS",
+        "description": "Saved words become flashcards with a capped weekly queue — not infinite. 5 stages from Recognition to Mastered."
       },
       "upload": {
         "title": "Your own books",
@@ -118,11 +118,15 @@
       "subheading": "Everything you need to know about TextStack.",
       "whatIs": {
         "q": "What is TextStack?",
-        "a": "TextStack is a free reading platform for language learners. Read classic English books with built-in translation, vocabulary flashcards, text-to-speech, and reading statistics — all in one app."
+        "a": "TextStack is a reader for people who want to finish the book they keep quitting — dense tech books and papers, or classic literature. Every word you tap gets a contextual explanation tied to the book's domain. Save words to a capped weekly SRS queue. Works on web and mobile, online or offline."
       },
       "isFree": {
         "q": "Is TextStack really free?",
-        "a": "Yes. The full catalog, reader, translation, SRS flashcards, and reading statistics are completely free. No credit card required, no hidden limits."
+        "a": "Yes. The full catalog, reader, contextual explanations, translation, SRS flashcards, text-to-speech, and reading statistics are completely free. No credit card required, no hidden limits."
+      },
+      "techBooks": {
+        "q": "Do you have programming or tech books?",
+        "a": "The catalog ships with thousands of public-domain classics. MIT/Apache/CC-BY licensed programming books are being added — priority given to Rust, Go, and systems titles. You can also upload your own EPUB or PDF at any time and read it with the full toolkit."
       },
       "languages": {
         "q": "Which languages are supported?",
@@ -164,6 +168,7 @@
         "speechify": "Speechify"
       },
       "features": {
+        "contextualExplain": "Contextual explanations",
         "tapTranslate": "Tap-to-translate",
         "srsCards": "SRS flashcards",
         "uploadBooks": "Upload your books",

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -1,6 +1,7 @@
 import { SeoHead } from '../components/SeoHead'
 import { HeroSection } from '../components/home/HeroSection'
 import { StatsBar } from '../components/home/StatsBar'
+import { FeaturesSection } from '../components/home/FeaturesSection'
 import { RecommendedSection } from '../components/home/RecommendedSection'
 import { TestimonialsSection } from '../components/home/TestimonialsSection'
 import { ComparisonSection } from '../components/home/ComparisonSection'
@@ -21,6 +22,7 @@ export function HomePage() {
         />
         <HeroSection />
         <StatsBar />
+        <FeaturesSection />
         <RecommendedSection />
         <TestimonialsSection />
         <ComparisonSection />

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -3,7 +3,6 @@ import { HeroSection } from '../components/home/HeroSection'
 import { StatsBar } from '../components/home/StatsBar'
 import { FeaturesSection } from '../components/home/FeaturesSection'
 import { RecommendedSection } from '../components/home/RecommendedSection'
-import { TestimonialsSection } from '../components/home/TestimonialsSection'
 import { ComparisonSection } from '../components/home/ComparisonSection'
 import { FaqSection } from '../components/home/FaqSection'
 import { Footer } from '../components/Footer'
@@ -24,7 +23,6 @@ export function HomePage() {
         <StatsBar />
         <FeaturesSection />
         <RecommendedSection />
-        <TestimonialsSection />
         <ComparisonSection />
         <FaqSection />
       </div>

--- a/backend/src/Api/Endpoints/ExplainEndpoints.cs
+++ b/backend/src/Api/Endpoints/ExplainEndpoints.cs
@@ -96,8 +96,16 @@ public static class ExplainEndpoints
             var text = await llm.CompleteAsync(
                 systemPrompt,
                 userPrompt,
-                maxOutputTokens: 200,
+                maxOutputTokens: 500,
                 ct);
+
+            // Reasoning models can exhaust the visible budget on internal reasoning
+            // and return empty. Retry once with doubled budget before giving up.
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                logger.LogWarning("Explain got empty result at 500 tokens, retrying with 1000");
+                text = await llm.CompleteAsync(systemPrompt, userPrompt, maxOutputTokens: 1000, ct);
+            }
 
             if (string.IsNullOrWhiteSpace(text))
                 return Results.Problem("LLM returned empty explanation", statusCode: 502);

--- a/backend/src/Api/Endpoints/ReadingTrackingEndpoints.cs
+++ b/backend/src/Api/Endpoints/ReadingTrackingEndpoints.cs
@@ -33,6 +33,7 @@ public static class ReadingTrackingEndpoints
         HttpContext httpContext,
         AuthService authService,
         IAppDbContext db,
+        ILogger<Program> logger,
         CancellationToken ct)
     {
         var userId = httpContext.GetUserId(authService);
@@ -80,12 +81,20 @@ public static class ReadingTrackingEndpoints
             return Results.Ok(new SubmitSessionResponse(session.Id, []));
         }
 
-        // Calculate streak for achievement checker
-        var streakMinMinutes = await GetStreakMinMinutes(db, userId.Value, siteId, ct);
-        var currentStreak = await CalculateStreak(db, userId.Value, siteId, streakMinMinutes, request.EndedAt, ct);
+        // Achievement check is best-effort — never fail the session submit because of it.
+        List<string> newAchievements = [];
+        try
+        {
+            var streakMinMinutes = await GetStreakMinMinutes(db, userId.Value, siteId, ct);
+            var currentStreak = await CalculateStreak(db, userId.Value, siteId, streakMinMinutes, request.EndedAt, ct);
 
-        var checker = new AchievementChecker(db);
-        var newAchievements = await checker.CheckAfterSession(userId.Value, siteId, session, currentStreak, ct);
+            var checker = new AchievementChecker(db);
+            newAchievements = await checker.CheckAfterSession(userId.Value, siteId, session, currentStreak, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "AchievementChecker failed for session {SessionId}, session still saved", session.Id);
+        }
 
         return Results.Ok(new SubmitSessionResponse(session.Id, newAchievements));
     }

--- a/backend/src/Api/Endpoints/TranslationEndpoints.cs
+++ b/backend/src/Api/Endpoints/TranslationEndpoints.cs
@@ -1,3 +1,6 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using Domain.LLM;
 using Microsoft.AspNetCore.Mvc;
 
@@ -20,9 +23,12 @@ public static class TranslationEndpoints
         [FromBody] TranslateRequest request,
         IConfiguration config,
         ILlmServiceFactory llmFactory,
+        ILogger<Program> logger,
         CancellationToken ct)
     {
         var maxLength = config.GetValue("OpenAI:Translate:MaxTextLength", 500);
+        var cachePath = config.GetValue<string>("Translate:CachePath") ?? "/tmp/translate-cache";
+        var cacheTtlDays = config.GetValue("Translate:CacheTtlDays", 30);
 
         if (string.IsNullOrWhiteSpace(request.Text))
             return Results.BadRequest("Text is required");
@@ -39,6 +45,29 @@ public static class TranslationEndpoints
         var srcLang = request.SourceLang.Split('-')[0];
         var tgtLang = request.TargetLang.Split('-')[0];
 
+        var cacheKey = ComputeCacheKey(request.Text, srcLang, tgtLang);
+        var cacheFile = Path.Combine(cachePath, cacheKey + ".json");
+
+        try
+        {
+            Directory.CreateDirectory(cachePath);
+            if (File.Exists(cacheFile))
+            {
+                var info = new FileInfo(cacheFile);
+                if (info.LastWriteTimeUtc > DateTime.UtcNow.AddDays(-cacheTtlDays))
+                {
+                    var cached = await File.ReadAllTextAsync(cacheFile, ct);
+                    var cachedResp = JsonSerializer.Deserialize<TranslateResponse>(cached);
+                    if (cachedResp != null && !string.IsNullOrWhiteSpace(cachedResp.TranslatedText))
+                        return Results.Ok(cachedResp);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Translate cache read failed, falling through to LLM");
+        }
+
         var systemPrompt = $"You are a translation engine. Translate from {srcLang} to {tgtLang}. " +
                            "Output ONLY the translated text. No preface, no quotes, no explanation.";
 
@@ -54,11 +83,18 @@ public static class TranslationEndpoints
             if (string.IsNullOrWhiteSpace(translated))
                 return Results.Problem("Translation returned empty result", statusCode: 502);
 
-            return Results.Ok(new TranslateResponse(
-                translated,
-                request.SourceLang,
-                request.TargetLang
-            ));
+            var resp = new TranslateResponse(translated, request.SourceLang, request.TargetLang);
+
+            try
+            {
+                await File.WriteAllTextAsync(cacheFile, JsonSerializer.Serialize(resp), ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Translate cache write failed");
+            }
+
+            return Results.Ok(resp);
         }
         catch (TaskCanceledException)
         {
@@ -71,6 +107,14 @@ public static class TranslationEndpoints
                 statusCode: 503
             );
         }
+    }
+
+    private static string ComputeCacheKey(string text, string srcLang, string tgtLang)
+    {
+        var payload = $"{srcLang}|{tgtLang}|{text}";
+        var bytes = Encoding.UTF8.GetBytes(payload);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash).ToLowerInvariant();
     }
 
     private static IResult GetLanguages()

--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -22,10 +22,14 @@
   },
   "OpenAI": {
     "ApiKey": "",
-    "Model": "gpt-5-mini",
+    "Model": "gpt-4o-mini",
     "Translate": {
       "MaxTextLength": 500
     }
+  },
+  "Translate": {
+    "CachePath": "data/translate-cache",
+    "CacheTtlDays": 30
   },
   "Explain": {
     "MaxWordLength": 100,

--- a/backend/src/Application/LLM/OpenAiLlmService.cs
+++ b/backend/src/Application/LLM/OpenAiLlmService.cs
@@ -10,6 +10,7 @@ public class OpenAiLlmService : ILlmService
 {
     private readonly ChatClient _client;
     private readonly ILogger<OpenAiLlmService> _logger;
+    private readonly int _reasoningBudget;
 
     public OpenAiLlmService(IConfiguration config, ILogger<OpenAiLlmService> logger)
     {
@@ -22,6 +23,12 @@ public class OpenAiLlmService : ILlmService
         var model = config["OpenAI:Model"]
             ?? Environment.GetEnvironmentVariable("OPENAI_MODEL")
             ?? "gpt-5-mini";
+
+        // Reasoning models (gpt-5, o1, o3…) consume tokens for internal reasoning
+        // before producing visible output. MaxOutputTokenCount caps the combined
+        // total, so we pad the caller's desired output budget with a reserve.
+        // Non-reasoning models just get a harmless higher ceiling.
+        _reasoningBudget = config.GetValue("OpenAI:ReasoningTokenBudget", 512);
 
         _client = new OpenAIClient(apiKey).GetChatClient(model);
     }
@@ -40,11 +47,18 @@ public class OpenAiLlmService : ILlmService
 
         var options = new ChatCompletionOptions
         {
-            MaxOutputTokenCount = maxOutputTokens,
+            MaxOutputTokenCount = maxOutputTokens + _reasoningBudget,
         };
 
         var result = await _client.CompleteChatAsync(messages, options, ct);
         var text = result.Value.Content.FirstOrDefault()?.Text ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            _logger.LogWarning(
+                "OpenAI returned empty content (finish={Finish}, maxOutputTokens={Max})",
+                result.Value.FinishReason,
+                maxOutputTokens + _reasoningBudget);
+        }
         return text.Trim();
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,10 +64,11 @@ services:
       Search__Provider: ${SEARCH_PROVIDER:-postgres}
       Tts__CachePath: /data/tts-cache
       Explain__CachePath: /data/explain-cache
+      Translate__CachePath: /data/translate-cache
       Ollama__BaseUrl: http://ollama:11434
       Ollama__Model: qwen3:8b
       OpenAI__ApiKey: ${OPENAI_API_KEY:-}
-      OpenAI__Model: ${OPENAI_MODEL:-gpt-5-mini}
+      OpenAI__Model: ${OPENAI_MODEL:-gpt-4o-mini}
       Resend__ApiKey: ${RESEND_API_KEY:-}
       Resend__FromEmail: ${RESEND_FROM_EMAIL:-noreply@textstack.app}
       Resend__AdminAlertEmail: ${ADMIN_ALERT_EMAIL:-}
@@ -77,6 +78,7 @@ services:
       - ./data/textstack:/data/textstack
       - ./data/tts-cache:/data/tts-cache
       - ./data/explain-cache:/data/explain-cache
+      - ./data/translate-cache:/data/translate-cache
     ports:
       - "127.0.0.1:8080:8080"  # Only localhost, nginx will proxy
     restart: always


### PR DESCRIPTION
## Что фиксим

Диагностика живых prod ошибок:

- \`/api/explain\` **502** → Ollama fallback NotFound + OpenAI \`finish=Length, maxOutputTokens=712\` (reasoning съедает visible бюджет).
- \`/me/reading/sessions\` **400** → очередь в localStorage копила сессии старше 7 дней (сервер их reject-ит).
- \`/me/reading/sessions\` **503** → \`AchievementChecker\` throw-ит после успешной INSERT сессии → весь запрос падает.
- Translate медленный → **сервер вообще не кеширует** (только клиент IndexedDB на 7д, не шарится между юзерами). Плюс модель \`gpt-5-mini\` reasoning — overhead на хот-пати.

## Изменения

### Backend
- **Translate**: file cache по SHA256(src|tgt|text), 30д TTL (копия explain pattern). `docker-compose` volume + env path.
- **Explain**: `maxOutputTokens: 200 → 500`, retry с 1000 если LLM вернул пустое (reasoning overflow).
- **Sessions**: `AchievementChecker.CheckAfterSession` в try/catch — session всё равно save-ится, достижение просто warn-логится.
- **OPENAI_MODEL default**: `gpt-5-mini → gpt-4o-mini` (в docker-compose + .env.example + appsettings). Reasoning оставлен для Ollama (Distractor/BookMetadata).

### Frontend
- **useReadingSession**: в `flushPendingSessions` фильтруем сессии старше 6 дней (safety margin к серверному лимиту в 7д).
- **useExplain**: IndexedDB cache-слой (ключ hash(word|sentence|genre|lang), 30д TTL). Bump DB v8→v9, новый store `explains`.

## После деплоя

1. Пересоздать api: `docker compose up -d api` (пересчёт env).
2. Создать volume dir: `mkdir -p data/translate-cache && chmod 777 data/translate-cache`.
3. Проверить:
   - `curl POST /api/translate` с новым словом → 200, ~0.5-1с
   - тот же запрос ещё раз → 200, **0.05с** (cache hit)
   - `curl POST /api/explain` → 200 не 502

## Не вошло (P1)

- Per-job model override в OpenAiLlmService (`OpenAI:Explain:Model`) — избыточно пока глобальный gpt-4o-mini устраивает.
- \`readerApi({ mode, id })\` — устранение if-elseif на userbook/edition в 15+ местах. Отдельная PR архитектурного уровня.
- Underline investigation — клиент может ещё работать после relogin, повторим диагностику при репро.

## Test plan

- [ ] Backend build
- [ ] Frontend tsc + build
- [ ] После merge+deploy: переводы быстрые, explain работает, нет 503 в console
- [ ] Проверить что \`data/translate-cache\` создаётся и в нём появляются json-файлы