### PR TITLE
fix(reader): vocab translation overlay centering + no-flash on eviction

### DIFF
--- a/apps/web/src/components/reader/VocabTranslationOverlay.tsx
+++ b/apps/web/src/components/reader/VocabTranslationOverlay.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import type { WordMatch } from '../../lib/vocabHighlightEngine'
 
 interface VocabTranslationOverlayProps {
@@ -18,22 +19,24 @@ interface Placed {
   y: number
 }
 
-// Compute placements from Ranges. Viewport-coord transforms keep the overlay
-// element fixed and let the browser GPU-translate spans on scroll.
+// Compute placements in DOCUMENT coords (not viewport). The overlay wrapper
+// is position:absolute at document origin, so spans scroll naturally with
+// content — no per-scroll reposition. Legacy <mark>-wrapped translations had
+// the same property for free; we recover it via scrollX/scrollY offset.
 function placeMatches(matches: readonly WordMatch[]): Placed[] {
   const placed: Placed[] = []
+  const sx = window.scrollX
+  const sy = window.scrollY
   for (let i = 0; i < matches.length; i++) {
     const m = matches[i]
     if (!m.translation) continue
     const rect = m.range.getBoundingClientRect()
     if (rect.width === 0 && rect.height === 0) continue
     placed.push({
-      // Dedupe-safe key — same word can appear many times in a chapter.
       key: `${m.key}:${i}`,
       text: m.translation,
-      // Center horizontally above the word; nudge y up just above it.
-      x: rect.left + rect.width / 2,
-      y: rect.top - 2,
+      x: rect.left + sx + rect.width / 2,
+      y: rect.top + sy,
     })
   }
   return placed
@@ -51,20 +54,24 @@ export function VocabTranslationOverlay({
   const rafRef = useRef<number | null>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const stableMatches = useMemo(() => matches, [matches])
-
-  // Recompute whenever match set changes.
+  // Recompute whenever match set changes. Critical UX detail: during chapter
+  // eviction/remount, old Ranges are briefly detached and return zero rects.
+  // If we cleared placements in that window, translations would vanish until
+  // the mutation-observer-driven recompute finishes — looks like "flicker
+  // with delay" on scroll. Keep the last good placements during transient
+  // empty computes (matches still non-empty) so the overlay rides through.
   useEffect(() => {
     if (!visible) {
       setPlacements([])
       return
     }
-    const next = placeMatches(stableMatches)
+    const next = placeMatches(matches)
+    if (next.length === 0 && matches.length > 0) return
     setPlacements(next)
-  }, [stableMatches, visible])
+  }, [matches, visible])
 
-  // Recompute on scroll/resize/font-change. RAF-guarded + debounced so a
-  // rapid drag doesn't queue hundreds of setState calls.
+  // Recompute on resize/font-change. Scroll is NOT a trigger — document-coord
+  // placements ride the scroll naturally (like legacy <mark>-wrapped spans).
   useEffect(() => {
     if (!visible) return
 
@@ -74,25 +81,27 @@ export function VocabTranslationOverlay({
         if (rafRef.current !== null) cancelAnimationFrame(rafRef.current)
         rafRef.current = requestAnimationFrame(() => {
           rafRef.current = null
-          setPlacements(placeMatches(stableMatches))
+          const next = placeMatches(matches)
+          if (next.length === 0 && matches.length > 0) return
+          setPlacements(next)
         })
       }, reflowDebounceMs)
     }
 
-    window.addEventListener('scroll', schedule, { passive: true, capture: true })
     window.addEventListener('resize', schedule, { passive: true })
 
     return () => {
-      window.removeEventListener('scroll', schedule, { capture: true })
       window.removeEventListener('resize', schedule)
       if (debounceRef.current) clearTimeout(debounceRef.current)
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current)
     }
-  }, [stableMatches, visible, reflowDebounceMs])
+  }, [matches, visible, reflowDebounceMs])
 
   if (!visible || placements.length === 0) return null
 
-  return (
+  // Portal to body so the overlay's containing block is the initial one —
+  // (x, y) are document coords, independent of any positioned ancestor.
+  return createPortal(
     <div className="vocab-translation-overlay" data-vocab-overlay="true" aria-hidden="true">
       {placements.map((p) => (
         <span
@@ -108,6 +117,7 @@ export function VocabTranslationOverlay({
           {p.text}
         </span>
       ))}
-    </div>
+    </div>,
+    document.body,
   )
 }

--- a/apps/web/src/styles/vocab-highlights.css
+++ b/apps/web/src/styles/vocab-highlights.css
@@ -63,11 +63,13 @@
  * updates per-span transforms.
  */
 .vocab-translation-overlay {
-  position: fixed;
-  inset: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
   pointer-events: none;
   z-index: 1;
-  overflow: hidden;
 }
 
 .vocab-translation-overlay__item {
@@ -75,9 +77,9 @@
   top: 0;
   left: 0;
   white-space: nowrap;
-  font-size: 0.5em;
+  font-size: 11px;
   font-style: italic;
-  opacity: 0.5;
+  opacity: 0.55;
   line-height: 1;
   pointer-events: none;
   user-select: none;
@@ -85,7 +87,9 @@
   overflow: hidden;
   text-overflow: ellipsis;
   color: inherit;
-  transform: translate3d(var(--x, 0), var(--y, 0), 0);
+  /* (x,y) = word's top-center; -50%,-100% centers the span and lifts it
+     above the word (ruby-style superscript). */
+  transform: translate(var(--x, 0), var(--y, 0)) translate(-50%, -100%);
   will-change: transform;
   animation: vocab-translation-fade 0.25s ease-out;
 }


### PR DESCRIPTION
## Summary
- Translation was shifted right of word-center — added \`translate(-50%, -100%)\` to center horizontally and lift above.
- Overlay was viewport-positioned with a scroll listener → on scroll-triggered chapter eviction, old Ranges detached (zero rect) → placements emptied → translations disappeared → reappeared after mutation observer recompute. Now uses document coords via portal to body; scroll is a no-op for positioning. Also keeps last good placements if compute returns empty while matches are still non-empty, smoothing over the DOM-swap gap.
- Bumped font-size from 0.5em (too small in fixed container, ~8px) to 11px.

## Test plan
- [ ] Reader: scroll through 4+ chapters → scroll back → translations stay visible throughout, no flash
- [ ] Translations center over words (ruby-style superscript)
- [ ] Font-size change → overlay reflows
- [ ] Existing e2e (reader-vocab-highlights) still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)