### PR TITLE
hotfix(api): /api/dictionary, /api/explain, /api/site 404 in prod

### DIFF
--- a/backend/src/Api/Endpoints/DictionaryEndpoints.cs
+++ b/backend/src/Api/Endpoints/DictionaryEndpoints.cs
@@ -7,7 +7,7 @@ public static class DictionaryEndpoints
 {
     public static void MapDictionaryEndpoints(this WebApplication app)
     {
-        var group = app.MapGroup("/api/dictionary").WithTags("Dictionary");
+        var group = app.MapGroup("/dictionary").WithTags("Dictionary");
 
         group.MapGet("/{lang}/{word}", LookupWord).WithName("LookupWord").RequireRateLimiting("dictionary");
     }

--- a/backend/src/Api/Endpoints/ExplainEndpoints.cs
+++ b/backend/src/Api/Endpoints/ExplainEndpoints.cs
@@ -12,7 +12,7 @@ public static class ExplainEndpoints
 {
     public static void MapExplainEndpoints(this WebApplication app)
     {
-        var group = app.MapGroup("/api/explain").WithTags("Explain");
+        var group = app.MapGroup("/explain").WithTags("Explain");
         group.MapPost("", Explain).WithName("Explain").RequireRateLimiting("explain");
     }
 

--- a/backend/src/Api/Endpoints/SiteEndpoints.cs
+++ b/backend/src/Api/Endpoints/SiteEndpoints.cs
@@ -7,7 +7,7 @@ public static class SiteEndpoints
 {
     public static void MapSiteEndpoints(this WebApplication app)
     {
-        var group = app.MapGroup("/api/site").WithTags("Site");
+        var group = app.MapGroup("/site").WithTags("Site");
 
         group.MapGet("/context", GetSiteContext).WithName("GetSiteContext");
         group.MapGet("/language", GetLanguageContext).WithName("GetLanguageContext");

--- a/tests/TextStack.IntegrationTests/DictionaryEndpointTests.cs
+++ b/tests/TextStack.IntegrationTests/DictionaryEndpointTests.cs
@@ -16,12 +16,12 @@ public class DictionaryEndpointTests : IClassFixture<LiveApiFixture>
         _fixture = fixture;
     }
 
-    #region GET /api/dictionary/{lang}/{word}
+    #region GET /dictionary/{lang}/{word}
 
     [Fact]
     public async Task LookupWord_ValidEnglishWord_Returns200()
     {
-        var request = _fixture.CreateRequest(HttpMethod.Get, "/api/dictionary/en/hello");
+        var request = _fixture.CreateRequest(HttpMethod.Get, "/dictionary/en/hello");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // External API might be unavailable
@@ -43,7 +43,7 @@ public class DictionaryEndpointTests : IClassFixture<LiveApiFixture>
     [Fact]
     public async Task LookupWord_NonExistentWord_Returns404()
     {
-        var request = _fixture.CreateRequest(HttpMethod.Get, "/api/dictionary/en/asdfghjklzxcv");
+        var request = _fixture.CreateRequest(HttpMethod.Get, "/dictionary/en/asdfghjklzxcv");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // External API might be unavailable
@@ -60,7 +60,7 @@ public class DictionaryEndpointTests : IClassFixture<LiveApiFixture>
     [Fact]
     public async Task LookupWord_EmptyWord_Returns400()
     {
-        var request = _fixture.CreateRequest(HttpMethod.Get, "/api/dictionary/en/");
+        var request = _fixture.CreateRequest(HttpMethod.Get, "/dictionary/en/");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // Empty path segment might result in 404 from routing
@@ -74,7 +74,7 @@ public class DictionaryEndpointTests : IClassFixture<LiveApiFixture>
     public async Task LookupWord_WordTooLong_Returns400()
     {
         var longWord = new string('a', 150);
-        var request = _fixture.CreateRequest(HttpMethod.Get, $"/api/dictionary/en/{longWord}");
+        var request = _fixture.CreateRequest(HttpMethod.Get, $"/dictionary/en/{longWord}");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -83,7 +83,7 @@ public class DictionaryEndpointTests : IClassFixture<LiveApiFixture>
     [Fact]
     public async Task LookupWord_ReturnsPhonetic()
     {
-        var request = _fixture.CreateRequest(HttpMethod.Get, "/api/dictionary/en/book");
+        var request = _fixture.CreateRequest(HttpMethod.Get, "/dictionary/en/book");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (response.StatusCode != HttpStatusCode.OK)
@@ -101,7 +101,7 @@ public class DictionaryEndpointTests : IClassFixture<LiveApiFixture>
     [Fact]
     public async Task LookupWord_ReturnsPartOfSpeech()
     {
-        var request = _fixture.CreateRequest(HttpMethod.Get, "/api/dictionary/en/run");
+        var request = _fixture.CreateRequest(HttpMethod.Get, "/dictionary/en/run");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         if (response.StatusCode != HttpStatusCode.OK)
@@ -119,7 +119,7 @@ public class DictionaryEndpointTests : IClassFixture<LiveApiFixture>
     public async Task LookupWord_DifferentLanguage_Returns200()
     {
         // German word
-        var request = _fixture.CreateRequest(HttpMethod.Get, "/api/dictionary/de/hallo");
+        var request = _fixture.CreateRequest(HttpMethod.Get, "/dictionary/de/hallo");
         var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
 
         // External API might not support all languages or be unavailable


### PR DESCRIPTION
## Summary
- 3 prod endpoints return 404 right now — nginx `proxy_pass http://textstack_api/` strips `/api/`, but these three endpoints register their routes via `MapGroup("/api/...")`. Root cause verified via `curl` against prod.
- Impact:
  - `/api/dictionary/{lang}/{word}` — WordCard (web + mobile) silently missing phonetic + definition
  - `/api/explain` — contextual LLM explanations dead
  - `/api/site/context` — `SiteContext` falls back to null; feature flags / ads-enabled / indexing pull hardcoded defaults instead of DB
- Fix: normalize to `/dictionary`, `/explain`, `/site` (same convention the other endpoints — `/books`, `/tts`, `/translate` compat — already use).
- Integration tests updated to new paths (they hit API directly via `LiveApiFixture`, no nginx in front).

## Test plan
- [ ] CI backend build + integration tests green
- [ ] After deploy: `curl -I https://textstack.app/api/dictionary/en/hello` → 200
- [ ] After deploy: `curl -I https://textstack.app/api/site/context` → 200
- [ ] After deploy: WordCard in reader shows phonetic + definition on tap
- [ ] After deploy: check `SiteContext` loads (browser network tab — no 404 on page load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)