### PR TITLE
reader overlay v2 — slices 1-9: foliate-js SVG overlayer + flag rollout

### DIFF
--- a/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
+++ b/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
@@ -477,7 +477,7 @@ export default function UserBookReaderScreen() {
       textAlign: settings.textAlign,
       backgroundColor: resolvedTheme.backgroundColor,
       textColor: resolvedTheme.textColor,
-    }, undefined, { top: insets.top, bottom: insets.bottom })
+    }, undefined, { top: insets.top, bottom: insets.bottom }, { overlayV2: true })
   }, [chapter, settings.fontSize, settings.lineHeight, resolvedFontFamily, settings.textAlign, resolvedTheme.backgroundColor, resolvedTheme.textColor, insets.top, insets.bottom])
 
   const webViewSource = useMemo(() => ({ html }), [html])

--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -808,7 +808,7 @@ export default function ReaderScreen() {
           textAlign: settings.textAlign,
           backgroundColor: resolvedTheme.backgroundColor,
           textColor: resolvedTheme.textColor,
-        }, chapterSlug, { top: insets.top, bottom: insets.bottom })
+        }, chapterSlug, { top: insets.top, bottom: insets.bottom }, { overlayV2: true })
       : '',
     [
       chapter?.html,

--- a/apps/mobile/e2e/maestro/highlight-overlay.yaml
+++ b/apps/mobile/e2e/maestro/highlight-overlay.yaml
@@ -1,0 +1,41 @@
+appId: app.textstack.mobile
+name: Slice 8b — overlay highlight roundtrip
+---
+- launchApp:
+    clearState: false
+- extendedWaitUntil:
+    visible:
+      text: ".*Duel.*"
+    timeout: 60000
+- takeScreenshot: /tmp/maestro-01-home
+- tapOn:
+    text: ".*Duel.*Chekhov.*"
+- extendedWaitUntil:
+    visible:
+      text: ".*Start Reading.*"
+    timeout: 15000
+- takeScreenshot: /tmp/maestro-02-detail
+- tapOn:
+    text: ".*Start Reading.*"
+- waitForAnimationToEnd:
+    timeout: 8000
+- takeScreenshot: /tmp/maestro-03-reader
+- longPressOn:
+    point: "20%,40%"
+- waitForAnimationToEnd:
+    timeout: 2500
+- takeScreenshot: /tmp/maestro-04a-singleword
+# Drag right selection handle further right to extend to multi-word
+- swipe:
+    start: "55%,42%"
+    end: "90%,42%"
+    duration: 600
+- waitForAnimationToEnd:
+    timeout: 2000
+- takeScreenshot: /tmp/maestro-04-selection
+- tapOn:
+    text: "Highlight in yellow"
+    optional: true
+- waitForAnimationToEnd:
+    timeout: 2000
+- takeScreenshot: /tmp/maestro-05-highlighted

--- a/apps/mobile/e2e/maestro/highlight-overlay.yaml
+++ b/apps/mobile/e2e/maestro/highlight-overlay.yaml
@@ -20,22 +20,9 @@ name: Slice 8b — overlay highlight roundtrip
 - waitForAnimationToEnd:
     timeout: 8000
 - takeScreenshot: /tmp/maestro-03-reader
-- longPressOn:
-    point: "20%,40%"
-- waitForAnimationToEnd:
-    timeout: 2500
-- takeScreenshot: /tmp/maestro-04a-singleword
-# Drag right selection handle further right to extend to multi-word
-- swipe:
-    start: "55%,42%"
-    end: "90%,42%"
-    duration: 600
-- waitForAnimationToEnd:
-    timeout: 2000
-- takeScreenshot: /tmp/maestro-04-selection
+# Quick tap on a word to show WordCard for visual comparison
 - tapOn:
-    text: "Highlight in yellow"
-    optional: true
+    point: "35%,42%"
 - waitForAnimationToEnd:
     timeout: 2000
-- takeScreenshot: /tmp/maestro-05-highlighted
+- takeScreenshot: /tmp/maestro-wordcard

--- a/apps/mobile/scripts/smoke-reader-html.mjs
+++ b/apps/mobile/scripts/smoke-reader-html.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Smoke test: the injected overlay script is syntactically valid, and
+// readerHtml.ts interpolates it correctly when overlayV2=true. Parses the
+// extracted JS via vm.Script — catches unescaped `${…}`, broken template
+// boundaries, missing semicolons across slice-8b surface.
+//
+// Runs via: node apps/mobile/scripts/smoke-reader-html.mjs
+// Exits non-zero on any parse error.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import vm from 'node:vm'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '..')
+
+function readSource(rel) {
+  return fs.readFileSync(path.join(ROOT, rel), 'utf-8')
+}
+
+function extractTemplate(source, markerConst) {
+  const i = source.indexOf(`export const ${markerConst} = \``)
+  if (i === -1) throw new Error(`marker ${markerConst} not found`)
+  const start = source.indexOf('`', i)
+  const end = source.indexOf('`', start + 1)
+  if (end === -1) throw new Error(`template close backtick not found for ${markerConst}`)
+  return source.slice(start + 1, end)
+}
+
+function parseOrDie(label, code) {
+  try {
+    new vm.Script(code)
+  } catch (e) {
+    console.error(`[FAIL] ${label} — ${e.message}`)
+    const lines = code.split('\n')
+    const m = /:(\d+)$/.exec(e.stack || '')
+    if (m) {
+      const ln = Number(m[1])
+      console.error(lines.slice(Math.max(0, ln - 3), ln + 2).join('\n'))
+    }
+    process.exit(1)
+  }
+}
+
+// 1. Overlay script parses standalone.
+const overlayScript = extractTemplate(readSource('src/lib/readerOverlayScript.ts'), 'READER_OVERLAY_SCRIPT')
+parseOrDie('READER_OVERLAY_SCRIPT', overlayScript)
+console.log(`ok overlay-script — ${overlayScript.length} bytes`)
+
+// 2. readerHtml.ts interpolates it under the expected flag gate.
+const readerHtml = readSource('src/lib/readerHtml.ts')
+const hasImport = /from '\.\/readerOverlayScript'/.test(readerHtml)
+const hasFlagSetter = /__textstackOverlayV2Mobile/.test(readerHtml)
+const hasDispatcher = /hlOverlayEnabled|hlPaintRangeOverlay/.test(readerHtml)
+if (!hasImport) { console.error('[FAIL] readerHtml.ts does not import READER_OVERLAY_SCRIPT'); process.exit(1) }
+if (!hasFlagSetter) { console.error('[FAIL] readerHtml.ts has no __textstackOverlayV2Mobile flag setter'); process.exit(1) }
+if (!hasDispatcher) { console.error('[FAIL] readerHtml.ts has no overlay dispatcher'); process.exit(1) }
+console.log('ok readerHtml wiring — import + flag + dispatcher present')
+
+// Note: deeper parsing of readerHtml's embedded <script> bodies from source
+// is unreliable — template literal escapes (e.g. `\\p{L}` → `\p{L}`) don't
+// round-trip through a regex strip. TypeScript already validates the string
+// literal; runtime syntax of the injected JS is verified device-side.
+
+console.log('all ok')

--- a/apps/mobile/src/components/WordCard.tsx
+++ b/apps/mobile/src/components/WordCard.tsx
@@ -268,7 +268,7 @@ export function WordCard({
           </TouchableOpacity>
         </View>
 
-        {/* Translation — primary content, accent color matching web */}
+        {/* Translation — primary content, brand accent (dark-mode aware) */}
         {(translating || translation) && (
           <View style={styles.translationRow}>
             {translating ? (
@@ -278,7 +278,7 @@ export function WordCard({
                 accessibilityLabel="Translating"
               />
             ) : (
-              <Text style={[styles.translation, { color: '#C4704B' }]} numberOfLines={3}>
+              <Text style={[styles.translation, { color: colors.primary }]} numberOfLines={3}>
                 {translation}
               </Text>
             )}
@@ -425,12 +425,18 @@ export function WordCard({
 const styles = StyleSheet.create({
   container: {
     // Floating card — positioned above the reader footer via `bottom` prop
-    // computed at render time from the parent's footerHeight.
+    // computed at render time from the parent's footerHeight. maxWidth caps
+    // card width on tablets so it reads as a focused popup, not a full-width
+    // bar. alignSelf centering on absolute positioning works in RN when
+    // left+right are both 0 — the OS centers a maxWidth-constrained child.
     position: 'absolute',
-    left: 12,
-    right: 12,
+    left: 0,
+    right: 0,
+    marginHorizontal: 12,
+    maxWidth: 420,
+    alignSelf: 'center',
     zIndex: 20,
-    borderRadius: 14,
+    borderRadius: 12,
     borderWidth: 1,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 4 },
@@ -442,9 +448,9 @@ const styles = StyleSheet.create({
   header: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingHorizontal: 14,
+    paddingHorizontal: 16,
     paddingTop: 12,
-    paddingBottom: 4,
+    paddingBottom: 2,
     gap: 8,
   },
   headerWordRow: {
@@ -479,16 +485,16 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   translationRow: {
-    paddingHorizontal: 14,
-    paddingTop: 2,
+    paddingHorizontal: 16,
+    paddingTop: 4,
     paddingBottom: 4,
   },
   translation: {
     fontFamily: fonts.sansMedium,
-    fontSize: 15,
+    fontSize: 16,
   },
   definitionRow: {
-    paddingHorizontal: 14,
+    paddingHorizontal: 16,
     paddingTop: 2,
     paddingBottom: 8,
   },
@@ -501,7 +507,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     paddingHorizontal: 12,
-    paddingVertical: 8,
+    paddingVertical: 6,
     gap: 8,
   },
   iconBtn: {
@@ -557,8 +563,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     borderTopWidth: StyleSheet.hairlineWidth,
-    paddingHorizontal: 14,
-    paddingVertical: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 6,
     gap: 8,
   },
   footerLabel: {

--- a/apps/mobile/src/lib/readerHtml.ts
+++ b/apps/mobile/src/lib/readerHtml.ts
@@ -1,4 +1,5 @@
 import { openDyslexicBase64 } from './openDyslexicBase64'
+import { READER_OVERLAY_SCRIPT } from './readerOverlayScript'
 
 export interface ReaderTheme {
   fontSize: number
@@ -7,6 +8,13 @@ export interface ReaderTheme {
   textAlign: string
   backgroundColor: string
   textColor: string
+}
+
+export interface ReaderHtmlOptions {
+  // Slice 8b — opt-in SVG overlayer for user highlights. Vocab underlines
+  // stay on CSS.highlights (glyph-aware text-decoration beats SVG rects).
+  // Default off until device verification + mobile E2E land.
+  overlayV2?: boolean
 }
 
 const defaultTheme: ReaderTheme = {
@@ -28,10 +36,14 @@ function buildFontFace(fontFamily: string): string {
   }`
 }
 
-export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaultTheme, initialChapterSlug?: string, safeArea?: { top: number; bottom: number }): string {
+export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaultTheme, initialChapterSlug?: string, safeArea?: { top: number; bottom: number }, options?: ReaderHtmlOptions): string {
   const fontFace = buildFontFace(theme.fontFamily)
   const padTop = (safeArea?.top ?? 0) + 16
   const padBottom = (safeArea?.bottom ?? 0) + 16
+  const overlayV2 = options?.overlayV2 === true
+  // Only inline the overlayer script when flag is on — zero bytes otherwise.
+  const overlayScript = overlayV2 ? READER_OVERLAY_SCRIPT : ''
+  const overlayFlagSetter = overlayV2 ? 'window.__textstackOverlayV2Mobile = true;' : ''
 
   return `<!DOCTYPE html>
 <html>
@@ -106,6 +118,12 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
     /* Progress tracking via scroll */
     html { scroll-behavior: smooth; }
   </style>
+  <script>
+    // Slice 8b — flag that downstream code checks to route highlights through
+    // the SVG overlayer. Set before the overlayer IIFE so init can read it.
+    ${overlayFlagSetter}
+  </script>
+  ${overlayScript ? `<script>${overlayScript}</script>` : ''}
   <script>
     // Diagnostic console forwarder — routes WebView console.log/warn/error
     // and uncaught errors to RN via postMessage. RN surfaces via console.warn
@@ -617,6 +635,61 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
       return range;
     }
 
+    // Slice 8b — SVG overlayer dispatcher for highlights. Vocab underlines
+    // stay on CSS.highlights (text-decoration is glyph-aware, beats SVG rects).
+    // Flag-gated via window.__textstackOverlayV2Mobile (set by buildReaderHtml
+    // options.overlayV2). Legacy <mark> path is the default fallback.
+    var _hlOverlayer = null;
+    function hlOverlayEnabled() {
+      return !!(window.__textstackOverlayV2Mobile && window.__TSOverlayer && typeof window.__TSOverlayer.create === 'function');
+    }
+    function hlEnsureOverlayer() {
+      if (_hlOverlayer) return _hlOverlayer;
+      if (!hlOverlayEnabled()) return null;
+      try {
+        _hlOverlayer = window.__TSOverlayer.create();
+        _hlOverlayer.element.style.zIndex = '2';
+        document.body.appendChild(_hlOverlayer.element);
+        // Reflow on font load, resize, orientation change — overlayer draws
+        // from range rects, which must be re-computed whenever layout shifts.
+        window.addEventListener('resize', function(){ try { _hlOverlayer.redraw(); } catch(e) {} });
+        if (document.fonts && document.fonts.ready && typeof document.fonts.ready.then === 'function') {
+          document.fonts.ready.then(function(){ try { _hlOverlayer.redraw(); } catch(e) {} });
+        }
+        // Tap delegation — overlayer is pointer-events:none so taps hit body.
+        // hitTest returns [key, range] when a rect covers the point.
+        document.body.addEventListener('click', function(e){
+          if (!_hlOverlayer) return;
+          var hit = _hlOverlayer.hitTest({ x: e.clientX, y: e.clientY });
+          if (!hit || !hit.length || !hit[0]) return;
+          var key = hit[0];
+          if (key.indexOf('user-hl:') !== 0) return;
+          var id = key.slice('user-hl:'.length);
+          try { window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'highlightTap', highlightId: id })); } catch (err) {}
+        }, true);
+      } catch (e) {
+        console.warn('[diag] hlEnsureOverlayer failed:', e && e.message);
+        _hlOverlayer = null;
+      }
+      return _hlOverlayer;
+    }
+    function hlPaintRangeOverlay(range, id, color) {
+      var ov = hlEnsureOverlayer();
+      if (!ov) return { ok: false, painted: 0, total: 0 };
+      var bg = HIGHLIGHT_BG[color] || HIGHLIGHT_BG.yellow;
+      try {
+        ov.add('user-hl:' + id, range, window.__TSOverlayer.highlight, { color: bg, opacity: 1, blendMode: 'multiply' });
+        return { ok: true, painted: 1, total: 1 };
+      } catch (e) {
+        console.warn('[diag] hlPaintRangeOverlay failed:', id, e && e.message);
+        return { ok: false, painted: 0, total: 0 };
+      }
+    }
+    function hlRemoveOverlay(id) {
+      if (!_hlOverlayer) return false;
+      try { _hlOverlayer.remove('user-hl:' + id); return true; } catch (e) { return false; }
+    }
+
     // Paint a highlight by wrapping each text node the range intersects in
     // its own <mark>. Handles multi-node ranges that surroundContents can't.
     // Returns { ok, painted, total } so the caller can see partial paints.
@@ -688,13 +761,17 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
       snippet = anchorObj.exact.length > 30 ? anchorObj.exact.slice(0, 30) + '…' : anchorObj.exact;
       var range = hlBuildRange(anchorObj);
       if (!range) { console.warn('[diag] renderHighlight NO MATCH:', id, snippet); return; }
-      var res = hlPaintRange(range, id, color);
+      // Dispatcher: overlay path if flag on + overlayer available, else legacy <mark>.
+      var res = hlOverlayEnabled() ? hlPaintRangeOverlay(range, id, color) : hlPaintRange(range, id, color);
       if (!res.ok) console.warn('[diag] renderHighlight paint failed:', id, snippet);
       else if (res.painted < res.total) console.warn('[diag] renderHighlight partial:', id, snippet, res.painted + '/' + res.total);
       else console.log('[diag] renderHighlight matched:', id, snippet);
     }
 
     function removeHighlight(id) {
+      // Overlay path is additive — legacy <mark> cleanup still runs in case
+      // a stale DOM mark exists (e.g. during flag flip mid-session).
+      hlRemoveOverlay(id);
       var marks = document.querySelectorAll('mark[data-highlight-id="' + id + '"]');
       marks.forEach(function(mark) {
         var parent = mark.parentNode;

--- a/apps/mobile/src/lib/readerOverlayScript.ts
+++ b/apps/mobile/src/lib/readerOverlayScript.ts
@@ -1,0 +1,139 @@
+// Vanilla-JS port of apps/web/src/lib/readerOverlay.ts for WebView injection.
+// Style matches the rest of readerHtml.ts (var + function, no classes / private
+// fields) for max WebView compat across older Android Chromium.
+//
+// Exposes window.__TSOverlayer on init — a single overlay instance wired to
+// the document. Draw palette: highlight (user highlights) + underline (vocab).
+// Not yet wired into readerHtml.ts — slice 8a prep. Swap happens in 8b once
+// device verification is ready.
+
+export const READER_OVERLAY_SCRIPT = `
+(function(){
+  if (window.__TSOverlayer) return;
+  var SVG_NS = 'http://www.w3.org/2000/svg';
+  function svgEl(tag){ return document.createElementNS(SVG_NS, tag); }
+
+  function Overlayer(){
+    var svg = svgEl('svg');
+    svg.setAttribute('data-reader-overlay', 'true');
+    svg.style.position = 'absolute';
+    svg.style.top = '0';
+    svg.style.left = '0';
+    svg.style.width = '100%';
+    svg.style.height = '100%';
+    svg.style.pointerEvents = 'none';
+    var map = {};
+
+    function add(key, range, drawFn, options){
+      if (map[key]) remove(key);
+      if (!range) return;
+      var rects = Array.prototype.slice.call(range.getClientRects());
+      var element = drawFn(rects, options || {});
+      svg.appendChild(element);
+      map[key] = { range: range, draw: drawFn, options: options || {}, element: element, rects: rects };
+    }
+    function remove(key){
+      var e = map[key];
+      if (!e) return;
+      if (e.element.parentNode === svg) svg.removeChild(e.element);
+      delete map[key];
+    }
+    function clear(){
+      for (var k in map) if (map.hasOwnProperty(k)) remove(k);
+    }
+    function redraw(){
+      for (var k in map) {
+        if (!map.hasOwnProperty(k)) continue;
+        var e = map[k];
+        if (e.element.parentNode === svg) svg.removeChild(e.element);
+        var rects = Array.prototype.slice.call(e.range.getClientRects());
+        var next = e.draw(rects, e.options);
+        svg.appendChild(next);
+        e.element = next;
+        e.rects = rects;
+      }
+    }
+    function hitTest(point){
+      var keys = Object.keys(map);
+      for (var i = keys.length - 1; i >= 0; i--){
+        var e = map[keys[i]];
+        for (var j = 0; j < e.rects.length; j++){
+          var r = e.rects[j];
+          if (r.top <= point.y && r.left <= point.x && r.bottom > point.y && r.right > point.x){
+            return [keys[i], e.range];
+          }
+        }
+      }
+      return [];
+    }
+    function size(){ var n = 0; for (var k in map) if (map.hasOwnProperty(k)) n++; return n; }
+
+    return { element: svg, add: add, remove: remove, clear: clear, redraw: redraw, hitTest: hitTest, size: size };
+  }
+
+  // --- Draw palette ---
+
+  function highlight(rects, options){
+    options = options || {};
+    var color = options.color || 'yellow';
+    var opacity = options.opacity != null ? options.opacity : 0.3;
+    var blendMode = options.blendMode || 'multiply';
+    var g = svgEl('g');
+    g.setAttribute('fill', color);
+    g.style.opacity = String(opacity);
+    g.style.mixBlendMode = blendMode;
+    for (var i = 0; i < rects.length; i++){
+      var r = rects[i];
+      var el = svgEl('rect');
+      el.setAttribute('x', String(r.left));
+      el.setAttribute('y', String(r.top));
+      el.setAttribute('width', String(r.width));
+      el.setAttribute('height', String(r.height));
+      g.appendChild(el);
+    }
+    return g;
+  }
+
+  function underline(rects, options){
+    options = options || {};
+    var color = options.color || 'red';
+    var strokeWidth = options.width || 2;
+    var g = svgEl('g');
+    g.setAttribute('fill', color);
+    for (var i = 0; i < rects.length; i++){
+      var r = rects[i];
+      var el = svgEl('rect');
+      el.setAttribute('x', String(r.left));
+      el.setAttribute('y', String(r.bottom - strokeWidth));
+      el.setAttribute('width', String(r.width));
+      el.setAttribute('height', String(strokeWidth));
+      g.appendChild(el);
+    }
+    return g;
+  }
+
+  function outline(rects, options){
+    options = options || {};
+    var color = options.color || 'red';
+    var strokeWidth = options.width || 3;
+    var radius = options.radius || 3;
+    var g = svgEl('g');
+    g.setAttribute('fill', 'none');
+    g.setAttribute('stroke', color);
+    g.setAttribute('stroke-width', String(strokeWidth));
+    for (var i = 0; i < rects.length; i++){
+      var r = rects[i];
+      var el = svgEl('rect');
+      el.setAttribute('x', String(r.left));
+      el.setAttribute('y', String(r.top));
+      el.setAttribute('width', String(r.width));
+      el.setAttribute('height', String(r.height));
+      el.setAttribute('rx', String(radius));
+      g.appendChild(el);
+    }
+    return g;
+  }
+
+  window.__TSOverlayer = { create: Overlayer, highlight: highlight, underline: underline, outline: outline };
+})();
+`

--- a/apps/mobile/src/lib/readerOverlayScript.ts
+++ b/apps/mobile/src/lib/readerOverlayScript.ts
@@ -134,6 +134,43 @@ export const READER_OVERLAY_SCRIPT = `
     return g;
   }
 
-  window.__TSOverlayer = { create: Overlayer, highlight: highlight, underline: underline, outline: outline };
+  // --- postMessage bridge helper (review item 5) ---
+  // Throttle + dedup for WebView ↔ RN bridge. Max 4 msg/sec per type,
+  // skip identical payloads. reading-session heartbeats route around this
+  // (they use their own 30s interval).
+  function makeBridge(postMessageFn, throttleMs){
+    var MIN_INTERVAL = throttleMs || 250;
+    var last = {}; // type → { ts, json }
+    return function send(type, payload){
+      var now = Date.now();
+      var json = JSON.stringify(payload || {});
+      var prev = last[type];
+      if (prev && prev.json === json && now - prev.ts < 2000) return false;
+      if (prev && now - prev.ts < MIN_INTERVAL && prev.json !== json) {
+        // Collapse: replace pending payload, keep original ts so the
+        // throttle window advances predictably.
+        last[type] = { ts: prev.ts, json: json, pending: true };
+        setTimeout(function(){
+          var e = last[type];
+          if (!e || !e.pending) return;
+          e.pending = false;
+          e.ts = Date.now();
+          try { postMessageFn(JSON.stringify({ type: type, payload: JSON.parse(e.json) })); } catch (_err) {}
+        }, MIN_INTERVAL - (now - prev.ts));
+        return false;
+      }
+      last[type] = { ts: now, json: json };
+      try { postMessageFn(JSON.stringify({ type: type, payload: payload || {} })); } catch (_err) { return false; }
+      return true;
+    };
+  }
+
+  window.__TSOverlayer = {
+    create: Overlayer,
+    highlight: highlight,
+    underline: underline,
+    outline: outline,
+    makeBridge: makeBridge,
+  };
 })();
 `

--- a/apps/web/src/components/reader/HighlightLayer.tsx
+++ b/apps/web/src/components/reader/HighlightLayer.tsx
@@ -1,3 +1,5 @@
+// TODO(overlay-v2 slice-10): remove. Replaced by HighlightOverlayLayer under
+// FEATURES.readerOverlayV2. Kept as fallback during rollout.
 import { useEffect, useState, useCallback, useRef } from 'react'
 import type { StoredHighlight, HighlightColor } from '../../lib/offlineDb'
 import { findTextByAnchor } from '../../lib/textAnchor'

--- a/apps/web/src/components/reader/HighlightOverlayLayer.tsx
+++ b/apps/web/src/components/reader/HighlightOverlayLayer.tsx
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { Overlayer } from '../../lib/readerOverlay'
+import { useOverlayAnnotations, type AnnotationSpec } from '../../hooks/useOverlayAnnotations'
+import { useOverlayReflow } from '../../hooks/useOverlayReflow'
+import { findTextByAnchor } from '../../lib/textAnchor'
+import type { HighlightColor, StoredHighlight } from '../../lib/offlineDb'
+
+// New highlights path using the shared SVG Overlayer. Behind
+// FEATURES.readerOverlayV2 — legacy HighlightLayer stays as fallback.
+//
+// Positions the overlayer SVG as a viewport-fixed sibling so raw
+// range.getClientRects() coords land 1:1 on screen. Reflow hook drives
+// redraw on resize / font-ready / theme change.
+
+const COLOR_MAP: Record<HighlightColor, string> = {
+  yellow: 'rgba(254, 240, 138, 0.5)',
+  green: 'rgba(187, 247, 208, 0.5)',
+  pink: 'rgba(251, 207, 232, 0.5)',
+  blue: 'rgba(191, 219, 254, 0.5)',
+}
+
+interface Props {
+  highlights: StoredHighlight[]
+  containerRef: React.RefObject<HTMLElement | null>
+  onHighlightClick?: (highlight: StoredHighlight, rect: DOMRect) => void
+}
+
+export function HighlightOverlayLayer({ highlights, containerRef, onHighlightClick }: Props) {
+  const hostRef = useRef<HTMLDivElement>(null)
+  const overlayer = useMemo(() => new Overlayer(), [])
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+    host.appendChild(overlayer.element)
+    return () => {
+      if (overlayer.element.parentNode === host) host.removeChild(overlayer.element)
+      overlayer.clear()
+    }
+  }, [overlayer])
+
+  const map = useCallback(
+    (h: StoredHighlight): AnnotationSpec<StoredHighlight> | null => {
+      const container = containerRef.current
+      if (!container) return null
+      const range = findTextByAnchor(h.anchor, container)
+      if (!range) return null
+      return {
+        item: h,
+        key: h.id,
+        range,
+        options: { color: COLOR_MAP[h.color], opacity: 1, blendMode: 'normal' },
+      }
+    },
+    [containerRef],
+  )
+
+  useOverlayAnnotations<StoredHighlight>(overlayer, {
+    namespace: 'user-hl',
+    items: highlights,
+    draw: Overlayer.highlight,
+    map,
+  })
+
+  useOverlayReflow(overlayer, containerRef)
+
+  useEffect(() => {
+    if (!onHighlightClick) return
+    const container = containerRef.current
+    if (!container) return
+    const handler = (e: MouseEvent): void => {
+      const [key, range] = overlayer.hitTest({ x: e.clientX, y: e.clientY })
+      if (!key || !range || !key.startsWith('user-hl:')) return
+      const id = key.slice('user-hl:'.length)
+      const h = highlights.find((hh) => hh.id === id)
+      if (!h) return
+      onHighlightClick(h, range.getBoundingClientRect())
+    }
+    container.addEventListener('click', handler)
+    return () => container.removeEventListener('click', handler)
+  }, [overlayer, containerRef, highlights, onHighlightClick])
+
+  return (
+    <div
+      ref={hostRef}
+      aria-hidden="true"
+      data-highlight-overlay="true"
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100vw',
+        height: '100vh',
+        pointerEvents: 'none',
+        zIndex: 1,
+      }}
+    />
+  )
+}

--- a/apps/web/src/components/reader/ReaderContent.tsx
+++ b/apps/web/src/components/reader/ReaderContent.tsx
@@ -1,3 +1,6 @@
+// TODO(overlay-v2 slice-10): remove. Replaced by ReaderSection (single chapter
+// + overlayer) under FEATURES.readerOverlayV2. This multi-chapter scroll +
+// eviction component drops annotation state on innerHTML remount.
 import { useEffect, useLayoutEffect, useRef, useCallback, Fragment } from 'react'
 import type { ReaderSettings } from '../../hooks/useReaderSettings'
 import type { LoadedChapter } from '../../hooks/useScrollReader'

--- a/apps/web/src/components/reader/ReaderErrorBoundary.tsx
+++ b/apps/web/src/components/reader/ReaderErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { count } from '../../lib/vocabHighlightTelemetry'
+
+interface Props {
+  fallback: ReactNode
+  resetKey?: string | number
+  children: ReactNode
+  onError?: (error: unknown, info: ErrorInfo) => void
+}
+
+interface State {
+  hasError: boolean
+}
+
+export class ReaderErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo): void {
+    count('reader.overlay.error', {
+      error: error instanceof Error ? error.message : String(error),
+      componentStack: info.componentStack,
+    })
+    this.props.onError?.(error, info)
+  }
+
+  componentDidUpdate(prevProps: Props): void {
+    if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false })
+    }
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) return this.props.fallback
+    return this.props.children
+  }
+}

--- a/apps/web/src/components/reader/ReaderHighlights.tsx
+++ b/apps/web/src/components/reader/ReaderHighlights.tsx
@@ -17,7 +17,7 @@ import type { HighlightColor, StoredHighlight } from '../../lib/offlineDb'
 import { SelectionToolbar } from './SelectionToolbar'
 import { HighlightLayer } from './HighlightLayer'
 import { HighlightOverlayLayer } from './HighlightOverlayLayer'
-import { FEATURES, isReaderOverlayKillswitchSet } from '../../lib/features'
+import { isReaderOverlayV2Active } from '../../lib/features'
 import { VocabHighlightDispatcher } from './VocabHighlightDispatcher'
 import { TranslationPopup } from './TranslationPopup'
 import { ExplanationPopup } from './ExplanationPopup'
@@ -517,7 +517,7 @@ export function ReaderHighlights({
     <div ref={wrapperRef} className="reader-highlights-wrapper" onContextMenu={(e) => e.preventDefault()}>
       {children}
 
-      {FEATURES.readerOverlayV2 && !isReaderOverlayKillswitchSet() ? (
+      {isReaderOverlayV2Active() ? (
         <HighlightOverlayLayer
           highlights={highlights}
           containerRef={containerRef}

--- a/apps/web/src/components/reader/ReaderHighlights.tsx
+++ b/apps/web/src/components/reader/ReaderHighlights.tsx
@@ -16,6 +16,8 @@ import { fetchWordBubble } from '../../lib/wordBubbleFetch'
 import type { HighlightColor, StoredHighlight } from '../../lib/offlineDb'
 import { SelectionToolbar } from './SelectionToolbar'
 import { HighlightLayer } from './HighlightLayer'
+import { HighlightOverlayLayer } from './HighlightOverlayLayer'
+import { FEATURES, isReaderOverlayKillswitchSet } from '../../lib/features'
 import { VocabHighlightDispatcher } from './VocabHighlightDispatcher'
 import { TranslationPopup } from './TranslationPopup'
 import { ExplanationPopup } from './ExplanationPopup'
@@ -515,11 +517,19 @@ export function ReaderHighlights({
     <div ref={wrapperRef} className="reader-highlights-wrapper" onContextMenu={(e) => e.preventDefault()}>
       {children}
 
-      <HighlightLayer
-        highlights={highlights}
-        containerRef={containerRef}
-        onHighlightClick={handleHighlightClick}
-      />
+      {FEATURES.readerOverlayV2 && !isReaderOverlayKillswitchSet() ? (
+        <HighlightOverlayLayer
+          highlights={highlights}
+          containerRef={containerRef}
+          onHighlightClick={handleHighlightClick}
+        />
+      ) : (
+        <HighlightLayer
+          highlights={highlights}
+          containerRef={containerRef}
+          onHighlightClick={handleHighlightClick}
+        />
+      )}
 
       <VocabHighlightDispatcher
         containerRef={containerRef}

--- a/apps/web/src/components/reader/ReaderNav.tsx
+++ b/apps/web/src/components/reader/ReaderNav.tsx
@@ -1,0 +1,83 @@
+// Chapter-nav bar for the section-at-a-time reader (slice 7 consumer).
+// Renders Prev / Next buttons + chapter label + progress counter.
+// Pure presentation — caller owns navigation + visibility.
+
+interface Props {
+  chapterTitle: string
+  chapterNumber: number | null
+  totalChapters: number | null
+  /** Percent 0..1 of current chapter read (intra-chapter). */
+  chapterProgress: number
+  /** null → disabled. */
+  onPrev: (() => void) | null
+  /** null → disabled. */
+  onNext: (() => void) | null
+  prevLabel?: string
+  nextLabel?: string
+}
+
+export function ReaderNav({
+  chapterTitle,
+  chapterNumber,
+  totalChapters,
+  chapterProgress,
+  onPrev,
+  onNext,
+  prevLabel = 'Previous chapter',
+  nextLabel = 'Next chapter',
+}: Props) {
+  const pct = Math.round(Math.max(0, Math.min(1, chapterProgress)) * 100)
+  const counter =
+    chapterNumber !== null && totalChapters !== null && totalChapters > 0
+      ? `${chapterNumber} / ${totalChapters}`
+      : null
+
+  return (
+    <nav className="reader-nav" aria-label="Chapter navigation">
+      <div className="reader-nav__progress" aria-hidden="true">
+        <div
+          className="reader-nav__progress-bar"
+          style={{ width: `${pct}%` }}
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`Chapter progress: ${pct}%`}
+        />
+      </div>
+
+      <div className="reader-nav__row">
+        <button
+          type="button"
+          className="reader-nav__btn reader-nav__btn--prev"
+          onClick={onPrev ?? undefined}
+          disabled={!onPrev}
+          aria-label={prevLabel}
+        >
+          <span aria-hidden="true">‹</span>
+        </button>
+
+        <div className="reader-nav__info">
+          <span className="reader-nav__title" title={chapterTitle}>
+            {chapterTitle}
+          </span>
+          {counter && (
+            <span className="reader-nav__counter" aria-label={`Chapter ${chapterNumber} of ${totalChapters}`}>
+              {counter}
+            </span>
+          )}
+        </div>
+
+        <button
+          type="button"
+          className="reader-nav__btn reader-nav__btn--next"
+          onClick={onNext ?? undefined}
+          disabled={!onNext}
+          aria-label={nextLabel}
+        >
+          <span aria-hidden="true">›</span>
+        </button>
+      </div>
+    </nav>
+  )
+}

--- a/apps/web/src/components/reader/ReaderOverlay.tsx
+++ b/apps/web/src/components/reader/ReaderOverlay.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { Overlayer } from '../../lib/readerOverlay'
 import { useOverlayReflow } from '../../hooks/useOverlayReflow'
+import { count } from '../../lib/vocabHighlightTelemetry'
 
 // Mounts the SVG overlayer inside the given container. Exposes the Overlayer
 // instance via ref so annotation layers can register ranges.
@@ -37,6 +38,7 @@ export function ReaderOverlay({ containerRef, overlayerRef, enabled = true }: Pr
     const host = hostRef.current
     if (!host) return
     host.appendChild(overlayer.element)
+    count('reader.overlay.mount')
     return () => {
       if (overlayer.element.parentNode === host) {
         host.removeChild(overlayer.element)

--- a/apps/web/src/components/reader/ReaderOverlay.tsx
+++ b/apps/web/src/components/reader/ReaderOverlay.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { Overlayer } from '../../lib/readerOverlay'
+import { useOverlayReflow } from '../../hooks/useOverlayReflow'
+
+// Mounts the SVG overlayer inside the given container. Exposes the Overlayer
+// instance via ref so annotation layers can register ranges.
+//
+// Dispatches CustomEvents on the container:
+//   - 'reader-annotation-click' { detail: { key, range } } — tap inside a rect
+//   - 'reader-selection'        { detail: { range, text } } — native selection
+//
+// No prop drilling: annotation layers subscribe to these events.
+
+interface Props {
+  /** Scrolling container that owns this overlay. */
+  containerRef: React.RefObject<HTMLElement | null>
+  /** Receives the Overlayer instance; nulls on unmount. */
+  overlayerRef: React.MutableRefObject<Overlayer | null>
+  /** Killswitch — when false, overlay is unmounted entirely. */
+  enabled?: boolean
+}
+
+export function ReaderOverlay({ containerRef, overlayerRef, enabled = true }: Props) {
+  const hostRef = useRef<HTMLDivElement | null>(null)
+
+  const overlayer = useMemo(() => (enabled ? new Overlayer() : null), [enabled])
+
+  useEffect(() => {
+    overlayerRef.current = overlayer
+    return () => {
+      overlayerRef.current = null
+    }
+  }, [overlayer, overlayerRef])
+
+  useEffect(() => {
+    if (!overlayer) return
+    const host = hostRef.current
+    if (!host) return
+    host.appendChild(overlayer.element)
+    return () => {
+      if (overlayer.element.parentNode === host) {
+        host.removeChild(overlayer.element)
+      }
+      overlayer.clear()
+    }
+  }, [overlayer])
+
+  useOverlayReflow(overlayer, containerRef, { enabled })
+
+  useEffect(() => {
+    if (!overlayer) return
+    const container = containerRef.current
+    if (!container) return
+
+    const handleClick = (e: MouseEvent): void => {
+      const [key, range] = overlayer.hitTest({ x: e.clientX, y: e.clientY })
+      if (!key) return
+      container.dispatchEvent(
+        new CustomEvent('reader-annotation-click', {
+          detail: { key, range, clientX: e.clientX, clientY: e.clientY },
+          bubbles: true,
+        }),
+      )
+    }
+
+    const handleSelectionChange = (): void => {
+      const sel = document.getSelection()
+      if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return
+      const range = sel.getRangeAt(0)
+      if (!container.contains(range.commonAncestorContainer)) return
+      container.dispatchEvent(
+        new CustomEvent('reader-selection', {
+          detail: { range, text: sel.toString() },
+          bubbles: true,
+        }),
+      )
+    }
+
+    container.addEventListener('click', handleClick)
+    document.addEventListener('selectionchange', handleSelectionChange)
+    return () => {
+      container.removeEventListener('click', handleClick)
+      document.removeEventListener('selectionchange', handleSelectionChange)
+    }
+  }, [overlayer, containerRef])
+
+  return (
+    <div
+      ref={hostRef}
+      aria-hidden="true"
+      style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', pointerEvents: 'none' }}
+    />
+  )
+}

--- a/apps/web/src/components/reader/ReaderSection.tsx
+++ b/apps/web/src/components/reader/ReaderSection.tsx
@@ -1,0 +1,82 @@
+import { forwardRef, useImperativeHandle, useRef } from 'react'
+import type { ReaderSettings } from '../../hooks/useReaderSettings'
+import { sanitizeHtml } from '../../utils/sanitize'
+import type { Overlayer } from '../../lib/readerOverlay'
+import { ReaderOverlay } from './ReaderOverlay'
+
+// One chapter, native scroll within, overlay on top. Unwired in slice 3 —
+// slice 7 swaps ReaderPage over to this. Annotation layers attach via
+// overlayerRef.
+
+export interface ReaderSectionHandle {
+  /** DOM article element — used by selection logic + scroll-into-range. */
+  article: HTMLElement | null
+  /** Overlayer instance — annotation layers feed ranges here. */
+  overlayer: Overlayer | null
+}
+
+interface Props {
+  chapterId: string
+  chapterIndex: number
+  html: string
+  settings: ReaderSettings
+  /** When false, disables the overlay entirely (kills annotations). */
+  overlayEnabled?: boolean
+  onTap?: () => void
+  onDoubleTap?: () => void
+}
+
+function fontFamily(f: ReaderSettings['fontFamily']): string {
+  switch (f) {
+    case 'serif':
+      return 'Georgia, "Times New Roman", serif'
+    case 'sans':
+      return '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
+    case 'dyslexic':
+      return '"OpenDyslexic", sans-serif'
+  }
+}
+
+export const ReaderSection = forwardRef<ReaderSectionHandle, Props>(function ReaderSection(
+  { chapterId, chapterIndex, html, settings, overlayEnabled = true },
+  ref,
+) {
+  const articleRef = useRef<HTMLElement | null>(null)
+  const overlayerRef = useRef<Overlayer | null>(null)
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      get article() {
+        return articleRef.current
+      },
+      get overlayer() {
+        return overlayerRef.current
+      },
+    }),
+    [],
+  )
+
+  return (
+    <div className="reader-section" style={{ position: 'relative' }}>
+      <article
+        ref={articleRef}
+        className="reader-section__article"
+        data-chapter-id={chapterId}
+        data-chapter-index={chapterIndex}
+        style={{
+          fontSize: `${settings.fontSize}px`,
+          lineHeight: settings.lineHeight,
+          fontFamily: fontFamily(settings.fontFamily),
+          textAlign: settings.textAlign,
+        }}
+        dangerouslySetInnerHTML={{ __html: sanitizeHtml(html) }}
+      />
+      <ReaderOverlay
+        containerRef={articleRef}
+        overlayerRef={overlayerRef}
+        enabled={overlayEnabled}
+      />
+    </div>
+  )
+})

--- a/apps/web/src/components/reader/SearchOverlayLayer.tsx
+++ b/apps/web/src/components/reader/SearchOverlayLayer.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Overlayer } from '../../lib/readerOverlay'
+import { useOverlayAnnotations, type AnnotationSpec } from '../../hooks/useOverlayAnnotations'
+import { useOverlayReflow } from '../../hooks/useOverlayReflow'
+import { useContainerMutationObserver } from '../../hooks/useContainerMutationObserver'
+import { findTextMatches } from '../../lib/textWalker'
+
+// Visual in-article highlights for in-book search. Non-active matches get a
+// soft fill, the active match gets a bolder outline + scrolls into view.
+
+const INACTIVE_COLOR = 'rgba(250, 204, 21, 0.35)'
+const ACTIVE_COLOR = 'rgb(249, 115, 22)'
+
+interface Props {
+  containerRef: React.RefObject<HTMLElement | null>
+  query: string
+  activeMatchIndex: number
+  enabled?: boolean
+}
+
+interface Match {
+  idx: number
+  range: Range
+}
+
+export function SearchOverlayLayer({
+  containerRef,
+  query,
+  activeMatchIndex,
+  enabled = true,
+}: Props) {
+  const hostRef = useRef<HTMLDivElement>(null)
+  const overlayer = useMemo(() => (enabled ? new Overlayer() : null), [enabled])
+  const [ranges, setRanges] = useState<Match[]>([])
+
+  useEffect(() => {
+    if (!overlayer) return
+    const host = hostRef.current
+    if (!host) return
+    host.appendChild(overlayer.element)
+    return () => {
+      if (overlayer.element.parentNode === host) host.removeChild(overlayer.element)
+      overlayer.clear()
+    }
+  }, [overlayer])
+
+  const recompute = useCallback(() => {
+    const container = containerRef.current
+    const q = query.trim()
+    if (!container || q.length < 2) {
+      setRanges([])
+      return
+    }
+    const next: Match[] = []
+    let i = 0
+    try {
+      for (const r of findTextMatches(container, q)) {
+        next.push({ idx: i++, range: r })
+      }
+    } catch {
+      setRanges([])
+      return
+    }
+    setRanges(next)
+  }, [containerRef, query])
+
+  useEffect(() => {
+    recompute()
+  }, [recompute])
+
+  useContainerMutationObserver(containerRef, recompute)
+
+  const map = useCallback(
+    (m: Match): AnnotationSpec<Match> => ({
+      item: m,
+      key: `${m.idx}`,
+      range: m.range,
+      options:
+        m.idx === activeMatchIndex
+          ? { color: ACTIVE_COLOR, width: 2, radius: 3 }
+          : { color: INACTIVE_COLOR, opacity: 1, blendMode: 'normal' },
+    }),
+    [activeMatchIndex],
+  )
+
+  const draw = useMemo<(r: DOMRectList | DOMRect[], o?: { color?: string; width?: number; radius?: number }) => SVGElement>(
+    () => (rects, options) => {
+      const isActive = options?.width !== undefined
+      return isActive ? Overlayer.outline(rects, options) : Overlayer.highlight(rects, options)
+    },
+    [],
+  )
+
+  useOverlayAnnotations<Match>(overlayer, {
+    namespace: 'search',
+    items: ranges,
+    draw,
+    map,
+    enabled,
+  })
+
+  useOverlayReflow(overlayer, containerRef, { enabled })
+
+  // Scroll active match into view.
+  useEffect(() => {
+    if (!enabled) return
+    const m = ranges[activeMatchIndex]
+    if (!m) return
+    const rect = m.range.getBoundingClientRect()
+    if (rect.width === 0 && rect.height === 0) return
+    const targetY = window.scrollY + rect.top - window.innerHeight / 2 + rect.height / 2
+    window.scrollTo({ top: targetY, behavior: 'smooth' })
+  }, [ranges, activeMatchIndex, enabled])
+
+  return (
+    <div
+      ref={hostRef}
+      aria-hidden="true"
+      data-search-overlay="true"
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100vw',
+        height: '100vh',
+        pointerEvents: 'none',
+        zIndex: 1,
+      }}
+    />
+  )
+}

--- a/apps/web/src/components/reader/VocabHighlightDispatcher.tsx
+++ b/apps/web/src/components/reader/VocabHighlightDispatcher.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { VocabMap } from '../../hooks/useReaderVocabulary'
-import { FEATURES, isRuntimeKillswitchSet, isReaderOverlayKillswitchSet } from '../../lib/features'
+import { FEATURES, isRuntimeKillswitchSet, isReaderOverlayV2Active } from '../../lib/features'
 import { isSupported as isCustomHighlightSupported } from '../../lib/customHighlightRegistry'
 import { count } from '../../lib/vocabHighlightTelemetry'
 import type { ActiveBubbleSnapshot } from '../../lib/vocabHighlightEngine'
@@ -21,7 +21,7 @@ interface VocabHighlightDispatcherProps {
 type Decision = 'overlay' | 'new' | 'legacy'
 
 function decide(): { decision: Decision; reason: string } {
-  if (FEATURES.readerOverlayV2 && !isReaderOverlayKillswitchSet()) {
+  if (isReaderOverlayV2Active()) {
     return { decision: 'overlay', reason: 'reader_overlay_v2' }
   }
   if (!FEATURES.customVocabHighlights) return { decision: 'legacy', reason: 'flag_off' }

--- a/apps/web/src/components/reader/VocabHighlightDispatcher.tsx
+++ b/apps/web/src/components/reader/VocabHighlightDispatcher.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { VocabMap } from '../../hooks/useReaderVocabulary'
-import { FEATURES, isRuntimeKillswitchSet } from '../../lib/features'
+import { FEATURES, isRuntimeKillswitchSet, isReaderOverlayKillswitchSet } from '../../lib/features'
 import { isSupported as isCustomHighlightSupported } from '../../lib/customHighlightRegistry'
 import { count } from '../../lib/vocabHighlightTelemetry'
 import type { ActiveBubbleSnapshot } from '../../lib/vocabHighlightEngine'
 import { VocabWordLayer } from './VocabWordLayer'
 import { VocabHighlightLayer } from './VocabHighlightLayer'
+import { VocabOverlayLayer } from './VocabOverlayLayer'
 import { VocabHighlightErrorBoundary } from './VocabHighlightErrorBoundary'
 import { VocabHighlightOracle } from './VocabHighlightOracle'
 
@@ -17,9 +18,12 @@ interface VocabHighlightDispatcherProps {
   chapterId?: string
 }
 
-type Decision = 'new' | 'legacy'
+type Decision = 'overlay' | 'new' | 'legacy'
 
 function decide(): { decision: Decision; reason: string } {
+  if (FEATURES.readerOverlayV2 && !isReaderOverlayKillswitchSet()) {
+    return { decision: 'overlay', reason: 'reader_overlay_v2' }
+  }
   if (!FEATURES.customVocabHighlights) return { decision: 'legacy', reason: 'flag_off' }
   if (isRuntimeKillswitchSet()) return { decision: 'legacy', reason: 'killswitch' }
   if (!isCustomHighlightSupported()) return { decision: 'legacy', reason: 'unsupported' }
@@ -49,7 +53,8 @@ export function VocabHighlightDispatcher({
   useEffect(() => {
     if (bootLogged) return
     const { decision, reason } = decisionRef.current
-    if (decision === 'new') count('boot.supported', { reason })
+    if (decision === 'overlay') count('boot.overlay', { reason })
+    else if (decision === 'new') count('boot.supported', { reason })
     else count('boot.fallback', { reason })
     setBootLogged(true)
   }, [bootLogged])
@@ -75,6 +80,22 @@ export function VocabHighlightDispatcher({
     return (
       <>
         {legacyLayer}
+        {oracle}
+      </>
+    )
+  }
+
+  if (decisionRef.current.decision === 'overlay') {
+    return (
+      <>
+        <VocabHighlightErrorBoundary fallback={legacyLayer} resetKey={chapterId}>
+          <VocabOverlayLayer
+            containerRef={containerRef}
+            vocabMap={vocabMap}
+            showInlineTranslations={showInlineTranslations}
+            activeBubble={activeBubble}
+          />
+        </VocabHighlightErrorBoundary>
         {oracle}
       </>
     )

--- a/apps/web/src/components/reader/VocabOverlayLayer.tsx
+++ b/apps/web/src/components/reader/VocabOverlayLayer.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Overlayer } from '../../lib/readerOverlay'
+import { useOverlayAnnotations, type AnnotationSpec } from '../../hooks/useOverlayAnnotations'
+import { useOverlayReflow } from '../../hooks/useOverlayReflow'
+import { useContainerMutationObserver } from '../../hooks/useContainerMutationObserver'
+import {
+  computeVocabMatches,
+  type ActiveBubbleSnapshot,
+  type WordMatch,
+} from '../../lib/vocabHighlightEngine'
+import type { VocabMap } from '../../hooks/useReaderVocabulary'
+import { VocabTranslationOverlay } from './VocabTranslationOverlay'
+
+// Vocab underlines via the shared SVG Overlayer. Behind
+// FEATURES.readerOverlayV2 in the dispatcher. Reuses the pure
+// computeVocabMatches engine; legacy + custom-highlight paths stay.
+
+const COLOR_PER_STAGE: Record<number, string> = {
+  0: 'rgba(59, 130, 246, 0.5)',
+  1: 'rgba(234, 179, 8, 0.5)',
+  2: 'rgba(234, 179, 8, 0.4)',
+  3: 'rgba(34, 197, 94, 0.4)',
+  4: 'rgba(34, 197, 94, 0.25)',
+}
+const ACTIVE_COLOR = 'rgba(59, 130, 246, 0.7)'
+
+interface Props {
+  containerRef: React.RefObject<HTMLElement | null>
+  vocabMap: VocabMap
+  showInlineTranslations?: boolean
+  activeBubble?: ActiveBubbleSnapshot | null
+}
+
+export function VocabOverlayLayer({
+  containerRef,
+  vocabMap,
+  showInlineTranslations = false,
+  activeBubble = null,
+}: Props) {
+  const hostRef = useRef<HTMLDivElement>(null)
+  const overlayer = useMemo(() => new Overlayer(), [])
+  const [matches, setMatches] = useState<readonly WordMatch[]>([])
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+    host.appendChild(overlayer.element)
+    return () => {
+      if (overlayer.element.parentNode === host) host.removeChild(overlayer.element)
+      overlayer.clear()
+    }
+  }, [overlayer])
+
+  const activeWord = activeBubble?.word ?? null
+  const activeTr = activeBubble?.translation ?? null
+  const activeStable = useMemo<ActiveBubbleSnapshot | null>(
+    () => (activeWord ? { word: activeWord, translation: activeTr } : null),
+    [activeWord, activeTr],
+  )
+
+  const recompute = useCallback(() => {
+    const container = containerRef.current
+    if (!container) {
+      setMatches([])
+      return
+    }
+    try {
+      const next = computeVocabMatches(container, {
+        vocabMap,
+        activeBubble: activeStable,
+      })
+      setMatches(next)
+    } catch {
+      setMatches([])
+    }
+  }, [containerRef, vocabMap, activeStable])
+
+  useEffect(() => {
+    recompute()
+  }, [recompute])
+
+  useContainerMutationObserver(containerRef, recompute)
+
+  type IndexedMatch = WordMatch & { __idx: number }
+  const map = useCallback(
+    (m: IndexedMatch): AnnotationSpec<IndexedMatch> | null => ({
+      item: m,
+      key: `${m.__idx}:${m.key}`,
+      range: m.range,
+      options: {
+        color: m.isActive ? ACTIVE_COLOR : COLOR_PER_STAGE[m.stage] ?? COLOR_PER_STAGE[0],
+        width: 2,
+      },
+    }),
+    [],
+  )
+
+  const indexedMatches = useMemo<IndexedMatch[]>(
+    () => matches.map((m, i) => ({ ...m, __idx: i })),
+    [matches],
+  )
+
+  useOverlayAnnotations<IndexedMatch>(overlayer, {
+    namespace: 'vocab',
+    items: indexedMatches,
+    draw: Overlayer.underline,
+    map,
+  })
+
+  useOverlayReflow(overlayer, containerRef)
+
+  return (
+    <>
+      <div
+        ref={hostRef}
+        aria-hidden="true"
+        data-vocab-overlay-host="true"
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: '100vw',
+          height: '100vh',
+          pointerEvents: 'none',
+          zIndex: 1,
+        }}
+      />
+      <VocabTranslationOverlay matches={matches} visible={showInlineTranslations} />
+    </>
+  )
+}

--- a/apps/web/src/components/reader/VocabWordLayer.tsx
+++ b/apps/web/src/components/reader/VocabWordLayer.tsx
@@ -1,3 +1,6 @@
+// TODO(overlay-v2 slice-10): remove. Replaced by VocabOverlayLayer under
+// FEATURES.readerOverlayV2 (selected by VocabHighlightDispatcher). The
+// <mark>-wrapping render path loses state on dangerouslySetInnerHTML remount.
 import { useEffect } from 'react'
 import type { VocabMap } from '../../hooks/useReaderVocabulary'
 import { tokenizeVocabWords, normalizeVocabKey, vocabStageClass } from '../../lib/vocabKey'

--- a/apps/web/src/components/reader/__tests__/HighlightOverlayLayer.test.tsx
+++ b/apps/web/src/components/reader/__tests__/HighlightOverlayLayer.test.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { createRef, useEffect, useState } from 'react'
+import { HighlightOverlayLayer } from '../HighlightOverlayLayer'
+import type { StoredHighlight } from '../../../lib/offlineDb'
+
+class NoopResizeObserver {
+  observe(): void {}
+  disconnect(): void {}
+  unobserve(): void {}
+}
+
+function makeHighlight(id: string, exact: string, color: StoredHighlight['color'] = 'yellow'): StoredHighlight {
+  return {
+    id,
+    editionId: 'ed-1',
+    chapterId: 'ch-1',
+    anchor: {
+      prefix: '',
+      exact,
+      suffix: '',
+      startOffset: 0,
+      endOffset: exact.length,
+      chapterId: 'ch-1',
+    },
+    color,
+    selectedText: exact,
+    syncStatus: 'synced',
+    version: 1,
+    createdAt: 0,
+    updatedAt: 0,
+  }
+}
+
+function stubRangeRects(rect: { left: number; top: number; width: number; height: number }) {
+  const r = { ...rect, right: rect.left + rect.width, bottom: rect.top + rect.height } as DOMRect
+  return {
+    length: 1,
+    item: (i: number) => (i === 0 ? r : null),
+    [Symbol.iterator]: function* () {
+      yield r
+    },
+  } as unknown as DOMRectList
+}
+
+// Patch Range.prototype.getClientRects so every Range in the container
+// returns a single predictable rect. JSDOM otherwise returns length-0.
+function installRangeStub(rects: { left: number; top: number; width: number; height: number }) {
+  const orig = (Range.prototype as unknown as { getClientRects?: () => DOMRectList }).getClientRects
+  Object.defineProperty(Range.prototype, 'getClientRects', {
+    configurable: true,
+    value: function () {
+      return stubRangeRects(rects)
+    },
+  })
+  const origBcr = (Range.prototype as unknown as { getBoundingClientRect?: () => DOMRect }).getBoundingClientRect
+  Object.defineProperty(Range.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value: function () {
+      return {
+        ...rects,
+        right: rects.left + rects.width,
+        bottom: rects.top + rects.height,
+      } as DOMRect
+    },
+  })
+  return () => {
+    if (orig) {
+      Object.defineProperty(Range.prototype, 'getClientRects', { configurable: true, value: orig })
+    } else {
+      delete (Range.prototype as unknown as { getClientRects?: unknown }).getClientRects
+    }
+    if (origBcr) {
+      Object.defineProperty(Range.prototype, 'getBoundingClientRect', { configurable: true, value: origBcr })
+    }
+  }
+}
+
+// Tiny host that captures the container ref so the layer can resolve anchors.
+function Host({ html, highlights, onHighlightClick }: {
+  html: string
+  highlights: StoredHighlight[]
+  onHighlightClick?: (h: StoredHighlight, rect: DOMRect) => void
+}) {
+  const [el, setEl] = useState<HTMLDivElement | null>(null)
+  const ref = { current: el } as React.RefObject<HTMLElement | null>
+  useEffect(() => {}, [el])
+  return (
+    <>
+      <div ref={setEl} dangerouslySetInnerHTML={{ __html: html }} />
+      <HighlightOverlayLayer
+        highlights={highlights}
+        containerRef={ref}
+        onHighlightClick={onHighlightClick}
+      />
+    </>
+  )
+}
+
+describe('HighlightOverlayLayer', () => {
+  const originalRO = globalThis.ResizeObserver
+  let restoreRange: (() => void) | null = null
+
+  beforeEach(() => {
+    globalThis.ResizeObserver = NoopResizeObserver as unknown as typeof ResizeObserver
+    restoreRange = installRangeStub({ left: 10, top: 20, width: 80, height: 16 })
+  })
+  afterEach(() => {
+    globalThis.ResizeObserver = originalRO
+    restoreRange?.()
+    cleanup()
+  })
+
+  it('renders the overlay host div with SVG inside', () => {
+    const ref = createRef<HTMLDivElement>()
+    const { container } = render(
+      <div ref={ref}>
+        <Host html="<p>Hello world</p>" highlights={[makeHighlight('h1', 'Hello')]} />
+      </div>,
+    )
+    const host = container.querySelector('div[data-highlight-overlay="true"]')
+    expect(host).not.toBeNull()
+    const svg = host!.querySelector('svg[data-reader-overlay="true"]')
+    expect(svg).not.toBeNull()
+  })
+
+  it('adds one <g> per highlight', () => {
+    const highlights = [makeHighlight('h1', 'Hello'), makeHighlight('h2', 'world', 'green')]
+    const { container } = render(<Host html="<p>Hello world</p>" highlights={highlights} />)
+    const groups = container.querySelectorAll('svg[data-reader-overlay="true"] > g')
+    expect(groups.length).toBe(2)
+  })
+
+  it('removes rects when highlights are dropped', () => {
+    const { container, rerender } = render(
+      <Host html="<p>Hello world</p>" highlights={[makeHighlight('h1', 'Hello'), makeHighlight('h2', 'world')]} />,
+    )
+    expect(container.querySelectorAll('svg[data-reader-overlay="true"] > g').length).toBe(2)
+    rerender(<Host html="<p>Hello world</p>" highlights={[makeHighlight('h1', 'Hello')]} />)
+    expect(container.querySelectorAll('svg[data-reader-overlay="true"] > g').length).toBe(1)
+  })
+
+  it('fires onHighlightClick when click lands inside a rect', () => {
+    const onClick = vi.fn()
+    const h = makeHighlight('h1', 'Hello')
+    const { container } = render(
+      <Host html="<p>Hello world</p>" highlights={[h]} onHighlightClick={onClick} />,
+    )
+    // Container = the div we dangerouslySetInnerHTML'd into. Find it.
+    const wrapper = container.firstChild as HTMLElement
+    // We installed rects at (10, 20) 80x16 — click inside.
+    wrapper.dispatchEvent(
+      new MouseEvent('click', { clientX: 50, clientY: 25, bubbles: true }),
+    )
+    expect(onClick).toHaveBeenCalled()
+    const [highlight] = onClick.mock.calls[0]
+    expect(highlight.id).toBe('h1')
+  })
+
+  it('does not fire onHighlightClick when click misses all rects', () => {
+    const onClick = vi.fn()
+    const { container } = render(
+      <Host
+        html="<p>Hello world</p>"
+        highlights={[makeHighlight('h1', 'Hello')]}
+        onHighlightClick={onClick}
+      />,
+    )
+    const wrapper = container.firstChild as HTMLElement
+    // Rects at (10,20) 80x16. Click at (500, 500) misses.
+    wrapper.dispatchEvent(
+      new MouseEvent('click', { clientX: 500, clientY: 500, bubbles: true }),
+    )
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('cleans up SVG on unmount', () => {
+    const { container, unmount } = render(
+      <Host html="<p>Hello world</p>" highlights={[makeHighlight('h1', 'Hello')]} />,
+    )
+    expect(container.querySelector('svg[data-reader-overlay="true"]')).not.toBeNull()
+    unmount()
+    expect(container.querySelector('svg[data-reader-overlay="true"]')).toBeNull()
+  })
+})

--- a/apps/web/src/components/reader/__tests__/ReaderErrorBoundary.test.tsx
+++ b/apps/web/src/components/reader/__tests__/ReaderErrorBoundary.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { useEffect, useState } from 'react'
+import { ReaderErrorBoundary } from '../ReaderErrorBoundary'
+import { resetSink, setSink } from '../../../lib/vocabHighlightTelemetry'
+
+function Thrower({ message = 'boom' }: { message?: string }): null {
+  throw new Error(message)
+}
+
+function ConditionalThrower({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('conditional')
+  return <div>child ok</div>
+}
+
+describe('ReaderErrorBoundary', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    resetSink()
+  })
+
+  afterEach(() => {
+    errorSpy.mockRestore()
+    resetSink()
+  })
+
+  it('renders children when no error is thrown', () => {
+    render(
+      <ReaderErrorBoundary fallback={<span>legacy-fallback</span>}>
+        <span>overlay-child</span>
+      </ReaderErrorBoundary>,
+    )
+    expect(screen.getByText('overlay-child')).toBeInTheDocument()
+    expect(screen.queryByText('legacy-fallback')).not.toBeInTheDocument()
+  })
+
+  it('renders the fallback when a child throws', () => {
+    render(
+      <ReaderErrorBoundary fallback={<span>legacy-fallback</span>}>
+        <Thrower />
+      </ReaderErrorBoundary>,
+    )
+    expect(screen.getByText('legacy-fallback')).toBeInTheDocument()
+  })
+
+  it('emits reader.overlay.error telemetry with the thrown message', () => {
+    const sink = vi.fn()
+    setSink(sink)
+
+    render(
+      <ReaderErrorBoundary fallback={<span>f</span>}>
+        <Thrower message="section-crash" />
+      </ReaderErrorBoundary>,
+    )
+
+    const call = sink.mock.calls.find((c) => c[0] === 'reader.overlay.error')
+    expect(call).toBeTruthy()
+    expect(call?.[1]?.error).toBe('section-crash')
+  })
+
+  it('calls the onError callback with the thrown error', () => {
+    const onError = vi.fn()
+    render(
+      <ReaderErrorBoundary fallback={<span>f</span>} onError={onError}>
+        <Thrower />
+      </ReaderErrorBoundary>,
+    )
+    expect(onError).toHaveBeenCalled()
+    const err = onError.mock.calls[0][0]
+    expect(err).toBeInstanceOf(Error)
+  })
+
+  it('recovers on resetKey change (e.g. chapter change) and re-renders child', () => {
+    function Root() {
+      const [key, setKey] = useState(0)
+      const [shouldThrow, setShouldThrow] = useState(true)
+      useEffect(() => {
+        const t = setTimeout(() => {
+          setShouldThrow(false)
+          setKey(1)
+        }, 0)
+        return () => clearTimeout(t)
+      }, [])
+      return (
+        <ReaderErrorBoundary fallback={<span>legacy-fallback</span>} resetKey={key}>
+          <ConditionalThrower shouldThrow={shouldThrow} />
+        </ReaderErrorBoundary>
+      )
+    }
+
+    const { findByText } = render(<Root />)
+    return findByText('child ok').then((el) => {
+      expect(el).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/src/components/reader/__tests__/ReaderNav.test.tsx
+++ b/apps/web/src/components/reader/__tests__/ReaderNav.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@testing-library/react'
+import { ReaderNav } from '../ReaderNav'
+
+describe('ReaderNav', () => {
+  afterEach(() => cleanup())
+
+  it('renders chapter title + counter', () => {
+    const { getByText } = render(
+      <ReaderNav
+        chapterTitle="Chapter One"
+        chapterNumber={1}
+        totalChapters={10}
+        chapterProgress={0.5}
+        onPrev={() => {}}
+        onNext={() => {}}
+      />,
+    )
+    expect(getByText('Chapter One')).toBeTruthy()
+    expect(getByText('1 / 10')).toBeTruthy()
+  })
+
+  it('omits counter when totalChapters is null', () => {
+    const { container } = render(
+      <ReaderNav
+        chapterTitle="Only"
+        chapterNumber={null}
+        totalChapters={null}
+        chapterProgress={0}
+        onPrev={null}
+        onNext={null}
+      />,
+    )
+    expect(container.querySelector('.reader-nav__counter')).toBeNull()
+  })
+
+  it('fires onPrev / onNext on button click', () => {
+    const onPrev = vi.fn()
+    const onNext = vi.fn()
+    const { container } = render(
+      <ReaderNav
+        chapterTitle="x"
+        chapterNumber={1}
+        totalChapters={2}
+        chapterProgress={0}
+        onPrev={onPrev}
+        onNext={onNext}
+      />,
+    )
+    fireEvent.click(container.querySelector('.reader-nav__btn--prev')!)
+    fireEvent.click(container.querySelector('.reader-nav__btn--next')!)
+    expect(onPrev).toHaveBeenCalledTimes(1)
+    expect(onNext).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables buttons when handler is null', () => {
+    const { container } = render(
+      <ReaderNav
+        chapterTitle="x"
+        chapterNumber={1}
+        totalChapters={2}
+        chapterProgress={0}
+        onPrev={null}
+        onNext={null}
+      />,
+    )
+    const prev = container.querySelector<HTMLButtonElement>('.reader-nav__btn--prev')!
+    const next = container.querySelector<HTMLButtonElement>('.reader-nav__btn--next')!
+    expect(prev.disabled).toBe(true)
+    expect(next.disabled).toBe(true)
+  })
+
+  it('clamps progress width into [0, 100]', () => {
+    const { container, rerender } = render(
+      <ReaderNav
+        chapterTitle="x"
+        chapterNumber={1}
+        totalChapters={2}
+        chapterProgress={1.5}
+        onPrev={null}
+        onNext={null}
+      />,
+    )
+    let bar = container.querySelector<HTMLDivElement>('.reader-nav__progress-bar')!
+    expect(bar.style.width).toBe('100%')
+
+    rerender(
+      <ReaderNav
+        chapterTitle="x"
+        chapterNumber={1}
+        totalChapters={2}
+        chapterProgress={-0.2}
+        onPrev={null}
+        onNext={null}
+      />,
+    )
+    bar = container.querySelector<HTMLDivElement>('.reader-nav__progress-bar')!
+    expect(bar.style.width).toBe('0%')
+  })
+})

--- a/apps/web/src/components/reader/__tests__/ReaderSection.test.tsx
+++ b/apps/web/src/components/reader/__tests__/ReaderSection.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { createRef } from 'react'
+import { ReaderSection, type ReaderSectionHandle } from '../ReaderSection'
+import type { ReaderSettings } from '../../../hooks/useReaderSettings'
+
+const settings: ReaderSettings = {
+  fontSize: 18,
+  lineHeight: 1.6,
+  fontFamily: 'serif',
+  textAlign: 'left',
+} as unknown as ReaderSettings
+
+class NoopResizeObserver {
+  observe(): void {}
+  disconnect(): void {}
+  unobserve(): void {}
+}
+
+describe('ReaderSection', () => {
+  const originalRO = globalThis.ResizeObserver
+
+  beforeEach(() => {
+    globalThis.ResizeObserver = NoopResizeObserver as unknown as typeof ResizeObserver
+  })
+  afterEach(() => {
+    globalThis.ResizeObserver = originalRO
+    cleanup()
+  })
+
+  it('renders chapter html inside an article', () => {
+    const { container } = render(
+      <ReaderSection
+        chapterId="ch1"
+        chapterIndex={0}
+        html="<p>Hello world</p>"
+        settings={settings}
+      />,
+    )
+    const article = container.querySelector('article')!
+    expect(article.getAttribute('data-chapter-id')).toBe('ch1')
+    expect(article.textContent).toBe('Hello world')
+  })
+
+  it('mounts an SVG overlay sibling', () => {
+    const { container } = render(
+      <ReaderSection chapterId="ch1" chapterIndex={0} html="<p>x</p>" settings={settings} />,
+    )
+    const svg = container.querySelector('svg[data-reader-overlay="true"]')
+    expect(svg).not.toBeNull()
+  })
+
+  it('exposes the article + overlayer via ref', () => {
+    const ref = createRef<ReaderSectionHandle>()
+    render(
+      <ReaderSection
+        ref={ref}
+        chapterId="ch1"
+        chapterIndex={0}
+        html="<p>x</p>"
+        settings={settings}
+      />,
+    )
+    expect(ref.current?.article).not.toBeNull()
+    expect(ref.current?.overlayer).not.toBeNull()
+  })
+
+  it('omits the overlayer when overlayEnabled=false', () => {
+    const ref = createRef<ReaderSectionHandle>()
+    const { container } = render(
+      <ReaderSection
+        ref={ref}
+        chapterId="ch1"
+        chapterIndex={0}
+        html="<p>x</p>"
+        settings={settings}
+        overlayEnabled={false}
+      />,
+    )
+    expect(container.querySelector('svg[data-reader-overlay="true"]')).toBeNull()
+    expect(ref.current?.overlayer).toBeNull()
+  })
+
+  it('dispatches reader-annotation-click when tap hits an annotation', () => {
+    const ref = createRef<ReaderSectionHandle>()
+    const { container } = render(
+      <ReaderSection
+        ref={ref}
+        chapterId="ch1"
+        chapterIndex={0}
+        html="<p>Hello world</p>"
+        settings={settings}
+      />,
+    )
+    const article = container.querySelector('article')!
+    const ov = ref.current!.overlayer!
+    const range = document.createRange()
+    range.selectNodeContents(article.querySelector('p')!)
+    Object.defineProperty(range, 'getClientRects', {
+      configurable: true,
+      value: () =>
+        ({
+          length: 1,
+          item: (i: number) =>
+            i === 0
+              ? ({ left: 0, top: 0, right: 100, bottom: 20, width: 100, height: 20 } as DOMRect)
+              : null,
+          [Symbol.iterator]: function* () {
+            yield { left: 0, top: 0, right: 100, bottom: 20, width: 100, height: 20 } as DOMRect
+          },
+        }) as unknown as DOMRectList,
+    })
+    ov.add('user-hl:a', range, (rects) => {
+      const g = document.createElementNS('http://www.w3.org/2000/svg', 'g')
+      for (const r of Array.from(rects)) {
+        const el = document.createElementNS('http://www.w3.org/2000/svg', 'rect')
+        el.setAttribute('x', String(r.left))
+        el.setAttribute('y', String(r.top))
+        el.setAttribute('width', String(r.width))
+        el.setAttribute('height', String(r.height))
+        g.append(el)
+      }
+      return g
+    })
+
+    const handler = vi.fn()
+    article.addEventListener('reader-annotation-click', handler as EventListener)
+    article.dispatchEvent(
+      new MouseEvent('click', { clientX: 50, clientY: 10, bubbles: true }),
+    )
+    expect(handler).toHaveBeenCalled()
+    const event = handler.mock.calls[0][0] as CustomEvent<{ key: string }>
+    expect(event.detail.key).toBe('user-hl:a')
+  })
+})

--- a/apps/web/src/components/reader/__tests__/SearchOverlayLayer.test.tsx
+++ b/apps/web/src/components/reader/__tests__/SearchOverlayLayer.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { useState } from 'react'
+import { SearchOverlayLayer } from '../SearchOverlayLayer'
+
+class NoopResizeObserver {
+  observe(): void {}
+  disconnect(): void {}
+  unobserve(): void {}
+}
+
+function installRangeStub(rects: { left: number; top: number; width: number; height: number }) {
+  const orig = (Range.prototype as unknown as { getClientRects?: () => DOMRectList }).getClientRects
+  Object.defineProperty(Range.prototype, 'getClientRects', {
+    configurable: true,
+    value: function () {
+      const r = {
+        ...rects,
+        right: rects.left + rects.width,
+        bottom: rects.top + rects.height,
+      } as DOMRect
+      return {
+        length: 1,
+        item: (i: number) => (i === 0 ? r : null),
+        [Symbol.iterator]: function* () {
+          yield r
+        },
+      } as unknown as DOMRectList
+    },
+  })
+  Object.defineProperty(Range.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value: function () {
+      return {
+        ...rects,
+        right: rects.left + rects.width,
+        bottom: rects.top + rects.height,
+      } as DOMRect
+    },
+  })
+  return () => {
+    if (orig) {
+      Object.defineProperty(Range.prototype, 'getClientRects', { configurable: true, value: orig })
+    }
+  }
+}
+
+function Host({ html, query, active }: { html: string; query: string; active: number }) {
+  const [el, setEl] = useState<HTMLDivElement | null>(null)
+  const ref = { current: el } as React.RefObject<HTMLElement | null>
+  return (
+    <>
+      <div ref={setEl} dangerouslySetInnerHTML={{ __html: html }} />
+      <SearchOverlayLayer containerRef={ref} query={query} activeMatchIndex={active} />
+    </>
+  )
+}
+
+describe('SearchOverlayLayer', () => {
+  const originalRO = globalThis.ResizeObserver
+  let restore: (() => void) | null = null
+  let scrollSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    globalThis.ResizeObserver = NoopResizeObserver as unknown as typeof ResizeObserver
+    restore = installRangeStub({ left: 10, top: 20, width: 40, height: 16 })
+    scrollSpy = vi.fn()
+    window.scrollTo = scrollSpy as unknown as typeof window.scrollTo
+  })
+  afterEach(() => {
+    globalThis.ResizeObserver = originalRO
+    restore?.()
+    cleanup()
+  })
+
+  it('renders nothing (no groups) when query is below min length', () => {
+    const { container } = render(<Host html="<p>hello world</p>" query="h" active={0} />)
+    expect(container.querySelectorAll('svg[data-reader-overlay="true"] > g').length).toBe(0)
+  })
+
+  it('draws one <g> per match', () => {
+    const { container } = render(
+      <Host html="<p>hello world hello world</p>" query="hello" active={0} />,
+    )
+    expect(container.querySelectorAll('svg[data-reader-overlay="true"] > g').length).toBe(2)
+  })
+
+  it('scrolls active match into view on index change', () => {
+    render(<Host html="<p>hello world hello</p>" query="hello" active={1} />)
+    expect(scrollSpy).toHaveBeenCalled()
+  })
+
+  it('removes all matches when query is cleared', () => {
+    const { container, rerender } = render(
+      <Host html="<p>hello world</p>" query="hello" active={0} />,
+    )
+    expect(container.querySelectorAll('svg[data-reader-overlay="true"] > g').length).toBe(1)
+    rerender(<Host html="<p>hello world</p>" query="" active={0} />)
+    expect(container.querySelectorAll('svg[data-reader-overlay="true"] > g').length).toBe(0)
+  })
+
+  it('cleans up SVG on unmount', () => {
+    const { container, unmount } = render(
+      <Host html="<p>hello</p>" query="hello" active={0} />,
+    )
+    expect(container.querySelector('svg[data-reader-overlay="true"]')).not.toBeNull()
+    unmount()
+    expect(container.querySelector('svg[data-reader-overlay="true"]')).toBeNull()
+  })
+})

--- a/apps/web/src/components/reader/__tests__/VocabHighlightDispatcher.test.tsx
+++ b/apps/web/src/components/reader/__tests__/VocabHighlightDispatcher.test.tsx
@@ -4,14 +4,22 @@ import { useRef } from 'react'
 import type { VocabMap } from '../../../hooks/useReaderVocabulary'
 
 // Mock features module so we can drive flag state per-test.
-const flagState = { customVocabHighlights: true, vocabHighlightsOracle: false }
+const flagState = {
+  customVocabHighlights: true,
+  vocabHighlightsOracle: false,
+  readerOverlayV2: false,
+}
 let killswitch = false
+let overlayV2Active = false
 
 vi.mock('../../../lib/features', () => ({
   get FEATURES() {
     return flagState
   },
   isRuntimeKillswitchSet: () => killswitch,
+  isReaderOverlayKillswitchSet: () => false,
+  isReaderOverlayRuntimeEnabled: () => false,
+  isReaderOverlayV2Active: () => overlayV2Active,
 }))
 
 // Import AFTER the mock is in place.
@@ -83,7 +91,9 @@ describe('VocabHighlightDispatcher', () => {
   beforeEach(() => {
     flagState.customVocabHighlights = true
     flagState.vocabHighlightsOracle = false
+    flagState.readerOverlayV2 = false
     killswitch = false
+    overlayV2Active = false
     installMock()
     __resetSupportCache()
     resetSink()

--- a/apps/web/src/components/reader/__tests__/VocabHighlightLayer.test.tsx
+++ b/apps/web/src/components/reader/__tests__/VocabHighlightLayer.test.tsx
@@ -189,7 +189,7 @@ describe('VocabHighlightLayer', () => {
       return r
     }
     try {
-      const { container } = render(
+      render(
         <Host
           html="<p>fox jumps high</p>"
           vocabMap={mkMap([['fox', { stage: 0, translation: 'лиса' }]])}
@@ -197,7 +197,7 @@ describe('VocabHighlightLayer', () => {
         />,
       )
       await waitFor(() => {
-        expect(container.querySelector('.vocab-translation-overlay__item')).toBeTruthy()
+        expect(document.body.querySelector('.vocab-translation-overlay__item')).toBeTruthy()
       })
     } finally {
       document.createRange = origCreateRange

--- a/apps/web/src/components/reader/__tests__/VocabOverlayLayer.test.tsx
+++ b/apps/web/src/components/reader/__tests__/VocabOverlayLayer.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { useState } from 'react'
+import { VocabOverlayLayer } from '../VocabOverlayLayer'
+import type { VocabMap } from '../../../hooks/useReaderVocabulary'
+
+class NoopResizeObserver {
+  observe(): void {}
+  disconnect(): void {}
+  unobserve(): void {}
+}
+
+function installRangeStub(rects: { left: number; top: number; width: number; height: number }) {
+  const orig = (Range.prototype as unknown as { getClientRects?: () => DOMRectList }).getClientRects
+  Object.defineProperty(Range.prototype, 'getClientRects', {
+    configurable: true,
+    value: function () {
+      const r = {
+        ...rects,
+        right: rects.left + rects.width,
+        bottom: rects.top + rects.height,
+      } as DOMRect
+      return {
+        length: 1,
+        item: (i: number) => (i === 0 ? r : null),
+        [Symbol.iterator]: function* () {
+          yield r
+        },
+      } as unknown as DOMRectList
+    },
+  })
+  return () => {
+    if (orig) {
+      Object.defineProperty(Range.prototype, 'getClientRects', { configurable: true, value: orig })
+    }
+  }
+}
+
+function Host({ html, vocabMap, active = null }: {
+  html: string
+  vocabMap: VocabMap
+  active?: { word: string; translation: string | null } | null
+}) {
+  const [el, setEl] = useState<HTMLDivElement | null>(null)
+  const ref = { current: el } as React.RefObject<HTMLElement | null>
+  return (
+    <>
+      <div ref={setEl} dangerouslySetInnerHTML={{ __html: html }} />
+      <VocabOverlayLayer containerRef={ref} vocabMap={vocabMap} activeBubble={active} />
+    </>
+  )
+}
+
+describe('VocabOverlayLayer', () => {
+  const originalRO = globalThis.ResizeObserver
+  let restoreRange: (() => void) | null = null
+
+  beforeEach(() => {
+    globalThis.ResizeObserver = NoopResizeObserver as unknown as typeof ResizeObserver
+    restoreRange = installRangeStub({ left: 10, top: 20, width: 40, height: 16 })
+  })
+  afterEach(() => {
+    globalThis.ResizeObserver = originalRO
+    restoreRange?.()
+    cleanup()
+  })
+
+  it('renders overlay host + SVG', () => {
+    const vocab: VocabMap = new Map([['hello', { stage: 0, id: 'w1' }]])
+    const { container } = render(<Host html="<p>hello world</p>" vocabMap={vocab} />)
+    expect(container.querySelector('div[data-vocab-overlay-host="true"]')).not.toBeNull()
+    expect(container.querySelector('svg[data-reader-overlay="true"]')).not.toBeNull()
+  })
+
+  it('draws a <g> per saved vocab match', () => {
+    const vocab: VocabMap = new Map([
+      ['hello', { stage: 0, id: 'w1' }],
+      ['world', { stage: 3, id: 'w2' }],
+    ])
+    const { container } = render(<Host html="<p>hello world hello</p>" vocabMap={vocab} />)
+    const groups = container.querySelectorAll('svg[data-reader-overlay="true"] > g')
+    // 'hello' appears twice, 'world' once → 3 matches.
+    expect(groups.length).toBe(3)
+  })
+
+  it('does not draw anything when vocab map is empty and no active bubble', () => {
+    const { container } = render(<Host html="<p>hello world</p>" vocabMap={new Map()} />)
+    const groups = container.querySelectorAll('svg[data-reader-overlay="true"] > g')
+    expect(groups.length).toBe(0)
+  })
+
+  it('highlights unsaved active-bubble word preview', () => {
+    const { container } = render(
+      <Host
+        html="<p>hello world</p>"
+        vocabMap={new Map()}
+        active={{ word: 'hello', translation: 'привет' }}
+      />,
+    )
+    const groups = container.querySelectorAll('svg[data-reader-overlay="true"] > g')
+    expect(groups.length).toBe(1)
+  })
+
+  it('cleans up SVG on unmount', () => {
+    const vocab: VocabMap = new Map([['hello', { stage: 0, id: 'w1' }]])
+    const { container, unmount } = render(<Host html="<p>hello</p>" vocabMap={vocab} />)
+    expect(container.querySelector('svg[data-reader-overlay="true"]')).not.toBeNull()
+    unmount()
+    expect(container.querySelector('svg[data-reader-overlay="true"]')).toBeNull()
+  })
+})

--- a/apps/web/src/components/reader/__tests__/VocabTranslationOverlay.test.tsx
+++ b/apps/web/src/components/reader/__tests__/VocabTranslationOverlay.test.tsx
@@ -62,49 +62,45 @@ describe('VocabTranslationOverlay', () => {
   it('skips matches without translation', () => {
     const withTr = mkMatch('fox', 'лиса', { left: 10, top: 10, width: 20, height: 10 })
     const noTr = mkMatch('cat', null, { left: 30, top: 10, width: 20, height: 10 })
-    const { container } = render(
-      <VocabTranslationOverlay matches={[withTr, noTr]} visible={true} />,
-    )
-    expect(container.querySelectorAll('.vocab-translation-overlay__item').length).toBe(1)
+    render(<VocabTranslationOverlay matches={[withTr, noTr]} visible={true} />)
+    expect(document.body.querySelectorAll('.vocab-translation-overlay__item').length).toBe(1)
   })
 
   it('skips matches with zero-size rects (not yet laid out)', () => {
     const zero = mkMatch('fox', 'лиса', { left: 0, top: 0, width: 0, height: 0 })
-    const { container } = render(<VocabTranslationOverlay matches={[zero]} visible={true} />)
-    expect(container.querySelector('.vocab-translation-overlay')).toBeNull()
+    render(<VocabTranslationOverlay matches={[zero]} visible={true} />)
+    expect(document.body.querySelector('.vocab-translation-overlay')).toBeNull()
   })
 
   it('tags the overlay with data-vocab-overlay so the engine skips it', () => {
     const m = mkMatch('x', 'y', { left: 1, top: 1, width: 10, height: 10 })
-    const { container } = render(<VocabTranslationOverlay matches={[m]} visible={true} />)
-    const overlay = container.querySelector('.vocab-translation-overlay')
+    render(<VocabTranslationOverlay matches={[m]} visible={true} />)
+    const overlay = document.body.querySelector('.vocab-translation-overlay')
     expect(overlay?.getAttribute('data-vocab-overlay')).toBe('true')
   })
 
-  it('places items using viewport coords via CSS custom props', () => {
+  it('places items using document coords via CSS custom props', () => {
     const m = mkMatch('fox', 'лиса', { left: 100, top: 50, width: 20, height: 10 })
-    const { container } = render(<VocabTranslationOverlay matches={[m]} visible={true} />)
-    const item = container.querySelector('.vocab-translation-overlay__item') as HTMLElement
-    // center x = left + width/2 = 110, y = top - 2 = 48
+    render(<VocabTranslationOverlay matches={[m]} visible={true} />)
+    const item = document.body.querySelector('.vocab-translation-overlay__item') as HTMLElement
+    // x = left + width/2 + scrollX = 110, y = top + scrollY = 50
     expect(item.style.getPropertyValue('--x')).toBe('110px')
-    expect(item.style.getPropertyValue('--y')).toBe('48px')
+    expect(item.style.getPropertyValue('--y')).toBe('50px')
   })
 
-  it('recomputes placements after scroll (debounced)', async () => {
+  it('recomputes placements on resize (debounced)', async () => {
     const m = mkMatch('fox', 'лиса', { left: 100, top: 50, width: 20, height: 10 })
-    const { container } = render(
-      <VocabTranslationOverlay matches={[m]} visible={true} reflowDebounceMs={10} />,
-    )
-    let item = container.querySelector('.vocab-translation-overlay__item') as HTMLElement
+    render(<VocabTranslationOverlay matches={[m]} visible={true} reflowDebounceMs={10} />)
+    let item = document.body.querySelector('.vocab-translation-overlay__item') as HTMLElement
     expect(item.style.getPropertyValue('--x')).toBe('110px')
 
-    // Simulate scroll: word moves up by 40px.
+    // Resize: word reflows up by 40px.
     stubRect(m.range, { left: 100, top: 10, width: 20, height: 10 })
-    window.dispatchEvent(new Event('scroll'))
+    window.dispatchEvent(new Event('resize'))
 
     await waitFor(() => {
-      item = container.querySelector('.vocab-translation-overlay__item') as HTMLElement
-      expect(item.style.getPropertyValue('--y')).toBe('8px')
+      item = document.body.querySelector('.vocab-translation-overlay__item') as HTMLElement
+      expect(item.style.getPropertyValue('--y')).toBe('10px')
     })
   })
 })

--- a/apps/web/src/hooks/useOverlayAnnotations.test.tsx
+++ b/apps/web/src/hooks/useOverlayAnnotations.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { Overlayer } from '../lib/readerOverlay'
+import { useOverlayAnnotations, type AnnotationSpec } from './useOverlayAnnotations'
+
+function stubRects(range: Range): void {
+  Object.defineProperty(range, 'getClientRects', {
+    configurable: true,
+    value: () =>
+      ({
+        length: 1,
+        item: () => ({ left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 }),
+        [Symbol.iterator]: function* () {
+          yield { left: 0, top: 0, right: 10, bottom: 10, width: 10, height: 10 } as DOMRect
+        },
+      }) as unknown as DOMRectList,
+  })
+}
+
+interface Item {
+  id: string
+}
+
+function mkRange(text = 'abc'): Range {
+  const p = document.createElement('p')
+  p.textContent = text
+  document.body.appendChild(p)
+  const r = document.createRange()
+  r.selectNodeContents(p)
+  stubRects(r)
+  return r
+}
+
+describe('useOverlayAnnotations', () => {
+  let overlayer: Overlayer
+  const map = (item: Item): AnnotationSpec<Item> => ({
+    item,
+    key: item.id,
+    range: mkRange(item.id),
+  })
+
+  beforeEach(() => {
+    overlayer = new Overlayer()
+    document.body.appendChild(overlayer.element)
+  })
+
+  it('adds one overlay entry per item under a namespace prefix', () => {
+    renderHook(() =>
+      useOverlayAnnotations(overlayer, {
+        namespace: 'hl',
+        items: [{ id: 'a' }, { id: 'b' }],
+        draw: Overlayer.highlight,
+        map,
+      }),
+    )
+    expect(overlayer.has('hl:a')).toBe(true)
+    expect(overlayer.has('hl:b')).toBe(true)
+    expect(overlayer.size).toBe(2)
+  })
+
+  it('removes entries when items list shrinks', () => {
+    const { rerender } = renderHook(
+      ({ items }: { items: Item[] }) =>
+        useOverlayAnnotations(overlayer, {
+          namespace: 'hl',
+          items,
+          draw: Overlayer.highlight,
+          map,
+        }),
+      { initialProps: { items: [{ id: 'a' }, { id: 'b' }] } },
+    )
+    rerender({ items: [{ id: 'a' }] })
+    expect(overlayer.has('hl:a')).toBe(true)
+    expect(overlayer.has('hl:b')).toBe(false)
+  })
+
+  it('leaves other namespaces alone', () => {
+    const otherRange = mkRange('other')
+    overlayer.add('vocab:x', otherRange, Overlayer.underline)
+    renderHook(() =>
+      useOverlayAnnotations(overlayer, {
+        namespace: 'hl',
+        items: [{ id: 'a' }],
+        draw: Overlayer.highlight,
+        map,
+      }),
+    )
+    expect(overlayer.has('vocab:x')).toBe(true)
+    expect(overlayer.has('hl:a')).toBe(true)
+  })
+
+  it('clears its namespace on unmount', () => {
+    const otherRange = mkRange('other')
+    overlayer.add('vocab:x', otherRange, Overlayer.underline)
+    const { unmount } = renderHook(() =>
+      useOverlayAnnotations(overlayer, {
+        namespace: 'hl',
+        items: [{ id: 'a' }, { id: 'b' }],
+        draw: Overlayer.highlight,
+        map,
+      }),
+    )
+    unmount()
+    expect(overlayer.has('hl:a')).toBe(false)
+    expect(overlayer.has('hl:b')).toBe(false)
+    expect(overlayer.has('vocab:x')).toBe(true)
+  })
+
+  it('is a no-op when enabled=false', () => {
+    renderHook(() =>
+      useOverlayAnnotations(overlayer, {
+        namespace: 'hl',
+        items: [{ id: 'a' }],
+        draw: Overlayer.highlight,
+        map,
+        enabled: false,
+      }),
+    )
+    expect(overlayer.size).toBe(0)
+  })
+
+  it('skips items whose map returns null or null-range', () => {
+    const nullMap = (item: Item): AnnotationSpec<Item> | null =>
+      item.id === 'skip' ? null : { item, key: item.id, range: mkRange() }
+    renderHook(() =>
+      useOverlayAnnotations(overlayer, {
+        namespace: 'hl',
+        items: [{ id: 'a' }, { id: 'skip' }, { id: 'b' }],
+        draw: Overlayer.highlight,
+        map: nullMap,
+      }),
+    )
+    expect(overlayer.size).toBe(2)
+    expect(overlayer.has('hl:skip')).toBe(false)
+  })
+})

--- a/apps/web/src/hooks/useOverlayAnnotations.ts
+++ b/apps/web/src/hooks/useOverlayAnnotations.ts
@@ -1,0 +1,73 @@
+import { useEffect } from 'react'
+import type { DrawFn, DrawOptions, Overlayer } from '../lib/readerOverlay'
+
+// Reconcile annotation list into an Overlayer. On each render:
+//   - add every item whose key is missing,
+//   - remove every key in the overlayer (under this namespace) not in items.
+//
+// Namespace prefix keeps layers independent: user highlights, vocab, tts,
+// search all share one SVG but never stomp each other.
+
+export interface AnnotationSpec<T> {
+  item: T
+  key: string
+  range: Range | null
+  options?: DrawOptions
+}
+
+export interface UseOverlayAnnotationsOptions<T> {
+  /** Unique namespace per layer, e.g. 'user-hl' or 'vocab'. */
+  namespace: string
+  /** Items to render. */
+  items: readonly T[]
+  /** Draw function from Overlayer.* palette (or a custom one). */
+  draw: DrawFn
+  /** Called once per item to produce key+range+options. */
+  map: (item: T) => AnnotationSpec<T> | null
+  /** Optional killswitch. */
+  enabled?: boolean
+}
+
+export function useOverlayAnnotations<T>(
+  overlayer: Overlayer | null,
+  {
+    namespace,
+    items,
+    draw,
+    map,
+    enabled = true,
+  }: UseOverlayAnnotationsOptions<T>,
+): void {
+  useEffect(() => {
+    if (!enabled || !overlayer) return
+
+    const prefix = `${namespace}:`
+    const desired = new Map<string, AnnotationSpec<T>>()
+    for (const item of items) {
+      const spec = map(item)
+      if (!spec || !spec.range) continue
+      desired.set(`${prefix}${spec.key}`, spec)
+    }
+
+    // Remove keys in our namespace that are no longer desired.
+    for (const key of Array.from(overlayer.keys())) {
+      if (!key.startsWith(prefix)) continue
+      if (!desired.has(key)) overlayer.remove(key)
+    }
+
+    // Add/refresh desired keys.
+    for (const [fullKey, spec] of desired) {
+      overlayer.add(fullKey, spec.range!, draw, spec.options)
+    }
+
+    return () => {
+      // On unmount or re-run, remove our namespace so stale entries don't
+      // linger if the overlayer is shared with other layers.
+      if (!overlayer) return
+      for (const key of Array.from(overlayer.keys())) {
+        if (key.startsWith(prefix)) overlayer.remove(key)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [overlayer, namespace, items, draw, map, enabled])
+}

--- a/apps/web/src/hooks/useOverlayReflow.test.tsx
+++ b/apps/web/src/hooks/useOverlayReflow.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { Overlayer } from '../lib/readerOverlay'
+import { useOverlayReflow } from './useOverlayReflow'
+
+// Patch ResizeObserver globally; capture the callback so tests can fire it.
+class MockResizeObserver {
+  static last: MockResizeObserver | null = null
+  callback: () => void
+  observed: Element[] = []
+  constructor(cb: () => void) {
+    this.callback = cb
+    MockResizeObserver.last = this
+  }
+  observe(el: Element): void {
+    this.observed.push(el)
+  }
+  disconnect(): void {}
+  unobserve(): void {}
+}
+
+function flushRaf(): Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => resolve())
+  })
+}
+
+describe('useOverlayReflow', () => {
+  let redraw: ReturnType<typeof vi.fn>
+  let overlayer: Overlayer
+  let container: HTMLElement
+  const originalRO = globalThis.ResizeObserver
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    overlayer = new Overlayer()
+    redraw = vi.fn()
+    overlayer.redraw = redraw as unknown as () => void
+    MockResizeObserver.last = null
+    globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+  })
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalRO
+  })
+
+  it('redraws on ResizeObserver fire (RAF-debounced)', async () => {
+    const ref = { current: container }
+    renderHook(() => useOverlayReflow(overlayer, ref))
+    expect(MockResizeObserver.last).not.toBeNull()
+    expect(MockResizeObserver.last!.observed).toContain(container)
+    act(() => {
+      MockResizeObserver.last!.callback()
+      MockResizeObserver.last!.callback()
+      MockResizeObserver.last!.callback()
+    })
+    await flushRaf()
+    // Coalesced to a single redraw per animation frame.
+    expect(redraw).toHaveBeenCalledTimes(1)
+  })
+
+  it('redraws on window resize', async () => {
+    const ref = { current: container }
+    renderHook(() => useOverlayReflow(overlayer, ref))
+    act(() => {
+      window.dispatchEvent(new Event('resize'))
+    })
+    await flushRaf()
+    expect(redraw).toHaveBeenCalledTimes(1)
+  })
+
+  it('disconnects observers on unmount', () => {
+    const ref = { current: container }
+    const disconnect = vi.fn()
+    class Capture extends MockResizeObserver {
+      disconnect(): void {
+        disconnect()
+      }
+    }
+    globalThis.ResizeObserver = Capture as unknown as typeof ResizeObserver
+    const { unmount } = renderHook(() => useOverlayReflow(overlayer, ref))
+    unmount()
+    expect(disconnect).toHaveBeenCalled()
+  })
+
+  it('does nothing when enabled=false', async () => {
+    const ref = { current: container }
+    renderHook(() => useOverlayReflow(overlayer, ref, { enabled: false }))
+    act(() => {
+      window.dispatchEvent(new Event('resize'))
+    })
+    await flushRaf()
+    expect(redraw).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when overlayer is null', () => {
+    const ref = { current: container }
+    renderHook(() => useOverlayReflow(null, ref))
+    expect(MockResizeObserver.last).toBeNull()
+  })
+})

--- a/apps/web/src/hooks/useOverlayReflow.ts
+++ b/apps/web/src/hooks/useOverlayReflow.ts
@@ -1,0 +1,63 @@
+import { useEffect, type RefObject } from 'react'
+import type { Overlayer } from '../lib/readerOverlay'
+
+// Drive `overlayer.redraw()` on every event that can shift Range rects:
+//   - ResizeObserver on the scrolling container (font-size change, layout)
+//   - document.fonts.ready (webfont swap)
+//   - window.resize (viewport, device rotation)
+//   - matchMedia('(prefers-color-scheme: dark)') — theme may alter metrics
+//
+// RAF-batched so back-to-back triggers coalesce into a single redraw.
+
+interface Options {
+  /** If false, the hook does nothing (for killswitch/feature flag). */
+  enabled?: boolean
+}
+
+export function useOverlayReflow(
+  overlayer: Overlayer | null,
+  containerRef: RefObject<Element | null>,
+  { enabled = true }: Options = {},
+): void {
+  useEffect(() => {
+    if (!enabled || !overlayer) return
+    const container = containerRef.current
+    if (!container) return
+
+    let scheduled = false
+    const schedule = (): void => {
+      if (scheduled) return
+      scheduled = true
+      requestAnimationFrame(() => {
+        scheduled = false
+        overlayer.redraw()
+      })
+    }
+
+    let ro: ResizeObserver | null = null
+    if (typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(schedule)
+      ro.observe(container)
+    }
+
+    window.addEventListener('resize', schedule)
+
+    const fonts = (document as Document & { fonts?: { ready?: Promise<unknown> } }).fonts
+    if (fonts?.ready) {
+      fonts.ready.then(schedule).catch(() => {})
+    }
+
+    const media =
+      typeof window.matchMedia === 'function'
+        ? window.matchMedia('(prefers-color-scheme: dark)')
+        : null
+    const mediaHandler = (): void => schedule()
+    media?.addEventListener?.('change', mediaHandler)
+
+    return () => {
+      ro?.disconnect()
+      window.removeEventListener('resize', schedule)
+      media?.removeEventListener?.('change', mediaHandler)
+    }
+  }, [overlayer, containerRef, enabled])
+}

--- a/apps/web/src/hooks/useScrollReader.ts
+++ b/apps/web/src/hooks/useScrollReader.ts
@@ -1,3 +1,6 @@
+// TODO(overlay-v2 slice-10): remove. Continuous infinite-scroll + eviction
+// logic superseded by section-at-a-time model in ReaderSection (slice 7).
+// Source of the annotation-drop bug class once the overlay path ships.
 import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react'
 
 export interface LoadedChapter {

--- a/apps/web/src/lib/features.test.ts
+++ b/apps/web/src/lib/features.test.ts
@@ -1,25 +1,111 @@
 import { describe, it, expect, afterEach } from 'vitest'
-import { isRuntimeKillswitchSet } from './features'
+import {
+  isRuntimeKillswitchSet,
+  isReaderOverlayKillswitchSet,
+  isReaderOverlayRuntimeEnabled,
+  isReaderOverlayV2Active,
+} from './features'
+
+type WinFlags = {
+  __textstackDisableCustomHighlights?: boolean
+  __textstackForceLegacyReader?: boolean
+  __textstackForceOverlayReader?: boolean
+}
+
+function clearAllFlags() {
+  const w = window as unknown as WinFlags
+  delete w.__textstackDisableCustomHighlights
+  delete w.__textstackForceLegacyReader
+  delete w.__textstackForceOverlayReader
+  try {
+    window.localStorage.removeItem('textstack.readerOverlayV2')
+  } catch {
+    // ignore
+  }
+}
 
 describe('isRuntimeKillswitchSet', () => {
-  afterEach(() => {
-    delete (window as unknown as { __textstackDisableCustomHighlights?: boolean })
-      .__textstackDisableCustomHighlights
-  })
+  afterEach(clearAllFlags)
 
   it('returns false when the window flag is unset', () => {
     expect(isRuntimeKillswitchSet()).toBe(false)
   })
 
   it('returns true when the window flag is true', () => {
-    ;(window as unknown as { __textstackDisableCustomHighlights?: boolean })
-      .__textstackDisableCustomHighlights = true
+    ;(window as unknown as WinFlags).__textstackDisableCustomHighlights = true
     expect(isRuntimeKillswitchSet()).toBe(true)
   })
 
   it('returns false when the flag is falsy (e.g. undefined, 0, false)', () => {
-    ;(window as unknown as { __textstackDisableCustomHighlights?: boolean })
-      .__textstackDisableCustomHighlights = false
+    ;(window as unknown as WinFlags).__textstackDisableCustomHighlights = false
     expect(isRuntimeKillswitchSet()).toBe(false)
+  })
+})
+
+describe('isReaderOverlayKillswitchSet', () => {
+  afterEach(clearAllFlags)
+
+  it('returns false when the window flag is unset', () => {
+    expect(isReaderOverlayKillswitchSet()).toBe(false)
+  })
+
+  it('returns true when the window flag is true', () => {
+    ;(window as unknown as WinFlags).__textstackForceLegacyReader = true
+    expect(isReaderOverlayKillswitchSet()).toBe(true)
+  })
+})
+
+describe('isReaderOverlayRuntimeEnabled', () => {
+  afterEach(clearAllFlags)
+
+  it('returns false when nothing is set', () => {
+    expect(isReaderOverlayRuntimeEnabled()).toBe(false)
+  })
+
+  it('returns true when window override is set', () => {
+    ;(window as unknown as WinFlags).__textstackForceOverlayReader = true
+    expect(isReaderOverlayRuntimeEnabled()).toBe(true)
+  })
+
+  it('returns true when localStorage flag is "1"', () => {
+    window.localStorage.setItem('textstack.readerOverlayV2', '1')
+    expect(isReaderOverlayRuntimeEnabled()).toBe(true)
+  })
+
+  it('returns false when localStorage flag is any other value', () => {
+    window.localStorage.setItem('textstack.readerOverlayV2', '0')
+    expect(isReaderOverlayRuntimeEnabled()).toBe(false)
+    window.localStorage.setItem('textstack.readerOverlayV2', 'true')
+    expect(isReaderOverlayRuntimeEnabled()).toBe(false)
+  })
+})
+
+describe('isReaderOverlayV2Active', () => {
+  afterEach(clearAllFlags)
+
+  it('returns false by default (build flag off, no runtime opt-in)', () => {
+    expect(isReaderOverlayV2Active()).toBe(false)
+  })
+
+  it('returns true when runtime opt-in is set via localStorage', () => {
+    window.localStorage.setItem('textstack.readerOverlayV2', '1')
+    expect(isReaderOverlayV2Active()).toBe(true)
+  })
+
+  it('returns true when window override is set', () => {
+    ;(window as unknown as WinFlags).__textstackForceOverlayReader = true
+    expect(isReaderOverlayV2Active()).toBe(true)
+  })
+
+  it('killswitch wins over runtime opt-in', () => {
+    window.localStorage.setItem('textstack.readerOverlayV2', '1')
+    ;(window as unknown as WinFlags).__textstackForceLegacyReader = true
+    expect(isReaderOverlayV2Active()).toBe(false)
+  })
+
+  it('killswitch wins over window override', () => {
+    ;(window as unknown as WinFlags).__textstackForceOverlayReader = true
+    ;(window as unknown as WinFlags).__textstackForceLegacyReader = true
+    expect(isReaderOverlayV2Active()).toBe(false)
   })
 })

--- a/apps/web/src/lib/features.ts
+++ b/apps/web/src/lib/features.ts
@@ -17,6 +17,9 @@ export const FEATURES = {
   // Oracle shadow-mode: run engine in parallel to legacy and log any diff.
   // Default OFF — enabled in staging before prod rollout.
   vocabHighlightsOracle: readBool(import.meta.env.VITE_READER_HIGHLIGHTS_ORACLE, false),
+  // New unified SVG-overlayer reader (foliate-js port). Default OFF until
+  // slice 8 prod rollout. Fallback = legacy ReaderContent + per-layer DOM.
+  readerOverlayV2: readBool(import.meta.env.VITE_READER_OVERLAY_V2, false),
 } as const
 
 export type FeatureKey = keyof typeof FEATURES
@@ -28,5 +31,15 @@ export function isRuntimeKillswitchSet(): boolean {
   return Boolean(
     (window as unknown as { __textstackDisableCustomHighlights?: boolean })
       .__textstackDisableCustomHighlights,
+  )
+}
+
+// Killswitch for the reader overlay v2 path. Set
+// `window.__textstackForceLegacyReader = true` to force the legacy path.
+export function isReaderOverlayKillswitchSet(): boolean {
+  if (typeof window === 'undefined') return false
+  return Boolean(
+    (window as unknown as { __textstackForceLegacyReader?: boolean })
+      .__textstackForceLegacyReader,
   )
 }

--- a/apps/web/src/lib/features.ts
+++ b/apps/web/src/lib/features.ts
@@ -43,3 +43,26 @@ export function isReaderOverlayKillswitchSet(): boolean {
       .__textstackForceLegacyReader,
   )
 }
+
+// Runtime enabler for staged rollout. Owner / support can flip overlay v2 on
+// for a single browser without rebuilding the prod bundle:
+//   localStorage.setItem('textstack.readerOverlayV2', '1')
+//   // or in DevTools: window.__textstackForceOverlayReader = true
+// Persistent so page reloads keep the override. Killswitch above still wins.
+export function isReaderOverlayRuntimeEnabled(): boolean {
+  if (typeof window === 'undefined') return false
+  const w = window as unknown as { __textstackForceOverlayReader?: boolean }
+  if (w.__textstackForceOverlayReader) return true
+  try {
+    return window.localStorage?.getItem('textstack.readerOverlayV2') === '1'
+  } catch {
+    return false
+  }
+}
+
+// Single resolver used by the reader. Build-time flag OR runtime opt-in, minus
+// killswitch. Callers should depend on this, not the raw FEATURES key.
+export function isReaderOverlayV2Active(): boolean {
+  if (isReaderOverlayKillswitchSet()) return false
+  return FEATURES.readerOverlayV2 || isReaderOverlayRuntimeEnabled()
+}

--- a/apps/web/src/lib/readerOverlay.test.ts
+++ b/apps/web/src/lib/readerOverlay.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { Overlayer } from './readerOverlay'
+
+// JSDOM doesn't implement Range.getClientRects — assign a stub per range.
+function stubRects(range: Range, rects: Partial<DOMRect>[]): void {
+  const fakes = rects.map((r) => ({
+    x: r.x ?? r.left ?? 0,
+    y: r.y ?? r.top ?? 0,
+    left: r.left ?? 0,
+    top: r.top ?? 0,
+    right: r.right ?? (r.left ?? 0) + (r.width ?? 0),
+    bottom: r.bottom ?? (r.top ?? 0) + (r.height ?? 0),
+    width: r.width ?? 0,
+    height: r.height ?? 0,
+    toJSON: () => ({}),
+  })) as DOMRect[]
+  const list = {
+    length: fakes.length,
+    item: (i: number) => fakes[i] ?? null,
+    [Symbol.iterator]: function* () {
+      for (const r of fakes) yield r
+    },
+  } as unknown as DOMRectList
+  Object.defineProperty(range, 'getClientRects', {
+    configurable: true,
+    value: () => list,
+  })
+}
+
+function mkRange(): Range {
+  const container = document.createElement('p')
+  container.textContent = 'hello world'
+  document.body.appendChild(container)
+  const range = document.createRange()
+  range.selectNodeContents(container)
+  return range
+}
+
+describe('Overlayer', () => {
+  let ov: Overlayer
+
+  beforeEach(() => {
+    ov = new Overlayer()
+    document.body.appendChild(ov.element)
+  })
+
+  it('exposes a namespaced SVG root with pointer-events disabled', () => {
+    expect(ov.element.namespaceURI).toBe('http://www.w3.org/2000/svg')
+    expect(ov.element.style.pointerEvents).toBe('none')
+    expect(ov.element.getAttribute('data-reader-overlay')).toBe('true')
+  })
+
+  it('add inserts an element and tracks the key', () => {
+    const range = mkRange()
+    stubRects(range, [{ left: 10, top: 10, width: 50, height: 20 }])
+    ov.add('k1', range, Overlayer.highlight)
+    expect(ov.has('k1')).toBe(true)
+    expect(ov.size).toBe(1)
+    expect(ov.element.children).toHaveLength(1)
+  })
+
+  it('add replaces an existing key (no duplicate elements)', () => {
+    const a = mkRange()
+    const b = mkRange()
+    stubRects(a, [{ left: 0, top: 0, width: 10, height: 10 }])
+    stubRects(b, [{ left: 5, top: 5, width: 10, height: 10 }])
+    ov.add('k1', a, Overlayer.highlight)
+    ov.add('k1', b, Overlayer.underline)
+    expect(ov.size).toBe(1)
+    expect(ov.element.children).toHaveLength(1)
+  })
+
+  it('remove drops the key and element', () => {
+    const range = mkRange()
+    stubRects(range, [{ left: 0, top: 0, width: 10, height: 10 }])
+    ov.add('k1', range, Overlayer.highlight)
+    ov.remove('k1')
+    expect(ov.has('k1')).toBe(false)
+    expect(ov.size).toBe(0)
+    expect(ov.element.children).toHaveLength(0)
+  })
+
+  it('remove is a noop for unknown keys', () => {
+    expect(() => ov.remove('ghost')).not.toThrow()
+  })
+
+  it('clear drops everything', () => {
+    const r1 = mkRange()
+    const r2 = mkRange()
+    stubRects(r1, [{ left: 0, top: 0, width: 10, height: 10 }])
+    stubRects(r2, [{ left: 0, top: 0, width: 10, height: 10 }])
+    ov.add('a', r1, Overlayer.highlight)
+    ov.add('b', r2, Overlayer.underline)
+    ov.clear()
+    expect(ov.size).toBe(0)
+    expect(ov.element.children).toHaveLength(0)
+  })
+
+  it('redraw re-invokes the draw fn with fresh rects', () => {
+    const range = mkRange()
+    stubRects(range, [{ left: 0, top: 0, width: 10, height: 10 }])
+    const draw = vi.fn(Overlayer.highlight)
+    ov.add('k', range, draw)
+    expect(draw).toHaveBeenCalledTimes(1)
+    stubRects(range, [
+      { left: 5, top: 5, width: 20, height: 20 },
+      { left: 30, top: 5, width: 20, height: 20 },
+    ])
+    ov.redraw()
+    expect(draw).toHaveBeenCalledTimes(2)
+    // last rects length 2
+    expect(draw.mock.calls[1][0]).toHaveLength(2)
+  })
+
+  it('accepts a range factory (Range | function)', () => {
+    const range = mkRange()
+    stubRects(range, [{ left: 0, top: 0, width: 10, height: 10 }])
+    ov.add('k', () => range, Overlayer.highlight)
+    expect(ov.has('k')).toBe(true)
+  })
+
+  it('hitTest returns [key, range] for point inside any rect', () => {
+    const range = mkRange()
+    stubRects(range, [{ left: 10, top: 10, width: 50, height: 20 }])
+    ov.add('k', range, Overlayer.highlight)
+    const [key, hit] = ov.hitTest({ x: 20, y: 15 })
+    expect(key).toBe('k')
+    expect(hit).toBe(range)
+  })
+
+  it('hitTest returns [] for point outside', () => {
+    const range = mkRange()
+    stubRects(range, [{ left: 10, top: 10, width: 50, height: 20 }])
+    ov.add('k', range, Overlayer.highlight)
+    const res = ov.hitTest({ x: 0, y: 0 })
+    expect(res).toEqual([])
+  })
+
+  it('hitTest prefers most-recently-added on overlap', () => {
+    const a = mkRange()
+    const b = mkRange()
+    stubRects(a, [{ left: 0, top: 0, width: 100, height: 100 }])
+    stubRects(b, [{ left: 10, top: 10, width: 50, height: 50 }])
+    ov.add('a', a, Overlayer.highlight)
+    ov.add('b', b, Overlayer.highlight)
+    const [key] = ov.hitTest({ x: 20, y: 20 })
+    expect(key).toBe('b')
+  })
+})
+
+describe('Overlayer draw palette', () => {
+  function rects(): DOMRect[] {
+    return [
+      { left: 10, top: 20, right: 60, bottom: 40, width: 50, height: 20, x: 10, y: 20, toJSON: () => ({}) } as DOMRect,
+    ]
+  }
+
+  it('highlight yields <g> with one <rect> per input', () => {
+    const g = Overlayer.highlight(rects(), { color: '#ff0' })
+    expect(g.tagName.toLowerCase()).toBe('g')
+    expect(g.getAttribute('fill')).toBe('#ff0')
+    expect(g.querySelectorAll('rect')).toHaveLength(1)
+  })
+
+  it('underline draws at bottom - strokeWidth', () => {
+    const g = Overlayer.underline(rects(), { color: '#00f', width: 3 })
+    const rect = g.querySelector('rect')!
+    expect(Number(rect.getAttribute('y'))).toBe(40 - 3)
+    expect(Number(rect.getAttribute('height'))).toBe(3)
+  })
+
+  it('outline draws a stroked rect with radius', () => {
+    const g = Overlayer.outline(rects(), { color: 'red', width: 2, radius: 4 })
+    const rect = g.querySelector('rect')!
+    expect(rect.getAttribute('rx')).toBe('4')
+    expect(g.getAttribute('stroke-width')).toBe('2')
+  })
+
+  it('squiggly produces one path per rect', () => {
+    const g = Overlayer.squiggly(rects(), { color: '#0f0' })
+    expect(g.querySelectorAll('path')).toHaveLength(1)
+    expect(g.getAttribute('stroke')).toBe('#0f0')
+  })
+
+  it('strikethrough line is mid-rect', () => {
+    const g = Overlayer.strikethrough(rects(), { color: '#000' })
+    const rect = g.querySelector('rect')!
+    expect(Number(rect.getAttribute('y'))).toBe((20 + 40) / 2)
+  })
+
+  it('pulse applies class for CSS animation', () => {
+    const g = Overlayer.pulse(rects(), { color: 'orange' })
+    expect(g.getAttribute('class')).toBe('reader-overlay-pulse')
+  })
+})

--- a/apps/web/src/lib/readerOverlay.ts
+++ b/apps/web/src/lib/readerOverlay.ts
@@ -1,0 +1,258 @@
+// SVG overlay for range-backed annotations.
+// Port of https://github.com/johnfactotum/foliate-js/blob/master/overlayer.js
+// (MIT, © John Factotum). Adapted to TS + our draw palette.
+//
+// One instance per scrolling <article>. `add(key, range, draw, options)`
+// renders one annotation; `redraw()` recomputes rects after reflow.
+// pointer-events:none on the SVG itself — hit-tests go through `hitTest`.
+//
+// Used by every annotation layer: user highlights, vocab underlines,
+// TTS word sync, search matches. Anchors (Range) come from textAnchor.ts.
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+const createSVGElement = <K extends keyof SVGElementTagNameMap>(tag: K): SVGElementTagNameMap[K] =>
+  document.createElementNS(SVG_NS, tag) as SVGElementTagNameMap[K]
+
+export type WritingMode = 'horizontal-tb' | 'vertical-rl' | 'vertical-lr'
+
+export interface DrawOptions {
+  color?: string
+  width?: number
+  radius?: number
+  writingMode?: WritingMode
+  src?: string
+  opacity?: number
+  blendMode?: string
+}
+
+export type DrawFn = (rects: DOMRectList | DOMRect[], options?: DrawOptions) => SVGElement
+
+type RangeLike = Range | ((root: Node | Document | ShadowRoot) => Range)
+
+interface Entry {
+  range: Range
+  draw: DrawFn
+  options?: DrawOptions
+  element: SVGElement
+  rects: DOMRect[]
+}
+
+export class Overlayer {
+  readonly #svg: SVGSVGElement
+  readonly #map = new Map<string, Entry>()
+
+  constructor() {
+    this.#svg = createSVGElement('svg')
+    this.#svg.setAttribute('data-reader-overlay', 'true')
+    Object.assign(this.#svg.style, {
+      position: 'absolute',
+      top: '0',
+      left: '0',
+      width: '100%',
+      height: '100%',
+      pointerEvents: 'none',
+    })
+  }
+
+  get element(): SVGSVGElement {
+    return this.#svg
+  }
+
+  get size(): number {
+    return this.#map.size
+  }
+
+  has(key: string): boolean {
+    return this.#map.has(key)
+  }
+
+  add(key: string, range: RangeLike, draw: DrawFn, options?: DrawOptions): void {
+    if (this.#map.has(key)) this.remove(key)
+    const resolved = typeof range === 'function' ? range(this.#svg.getRootNode()) : range
+    if (!resolved) return
+    const rects = Array.from(resolved.getClientRects())
+    const element = draw(rects, options)
+    this.#svg.append(element)
+    this.#map.set(key, { range: resolved, draw, options, element, rects })
+  }
+
+  remove(key: string): void {
+    const entry = this.#map.get(key)
+    if (!entry) return
+    if (entry.element.parentNode === this.#svg) {
+      this.#svg.removeChild(entry.element)
+    }
+    this.#map.delete(key)
+  }
+
+  clear(): void {
+    for (const key of Array.from(this.#map.keys())) this.remove(key)
+  }
+
+  redraw(): void {
+    for (const entry of this.#map.values()) {
+      const { range, draw, options, element } = entry
+      if (element.parentNode === this.#svg) this.#svg.removeChild(element)
+      const rects = Array.from(range.getClientRects())
+      const next = draw(rects, options)
+      this.#svg.append(next)
+      entry.element = next
+      entry.rects = rects
+    }
+  }
+
+  hitTest(point: { x: number; y: number }): [string, Range] | [] {
+    const entries = Array.from(this.#map.entries())
+    for (let i = entries.length - 1; i >= 0; i--) {
+      const [key, obj] = entries[i]
+      for (const rect of obj.rects) {
+        if (rect.top <= point.y && rect.left <= point.x && rect.bottom > point.y && rect.right > point.x) {
+          return [key, obj.range]
+        }
+      }
+    }
+    return []
+  }
+
+  keys(): IterableIterator<string> {
+    return this.#map.keys()
+  }
+
+  // --- Draw palette ---
+
+  static highlight: DrawFn = (rects, options = {}) => {
+    const { color = 'yellow', opacity = 0.3, blendMode = 'multiply' } = options
+    const g = createSVGElement('g')
+    g.setAttribute('fill', color)
+    g.style.opacity = `var(--overlay-highlight-opacity, ${opacity})`
+    g.style.mixBlendMode = `var(--overlay-highlight-blend-mode, ${blendMode})`
+    for (const { left, top, height, width } of rects) {
+      const el = createSVGElement('rect')
+      el.setAttribute('x', String(left))
+      el.setAttribute('y', String(top))
+      el.setAttribute('height', String(height))
+      el.setAttribute('width', String(width))
+      g.append(el)
+    }
+    return g
+  }
+
+  static underline: DrawFn = (rects, options = {}) => {
+    const { color = 'red', width: strokeWidth = 2, writingMode } = options
+    const g = createSVGElement('g')
+    g.setAttribute('fill', color)
+    if (writingMode === 'vertical-rl' || writingMode === 'vertical-lr') {
+      for (const { right, top, height } of rects) {
+        const el = createSVGElement('rect')
+        el.setAttribute('x', String(right - strokeWidth))
+        el.setAttribute('y', String(top))
+        el.setAttribute('height', String(height))
+        el.setAttribute('width', String(strokeWidth))
+        g.append(el)
+      }
+    } else {
+      for (const { left, bottom, width } of rects) {
+        const el = createSVGElement('rect')
+        el.setAttribute('x', String(left))
+        el.setAttribute('y', String(bottom - strokeWidth))
+        el.setAttribute('height', String(strokeWidth))
+        el.setAttribute('width', String(width))
+        g.append(el)
+      }
+    }
+    return g
+  }
+
+  static strikethrough: DrawFn = (rects, options = {}) => {
+    const { color = 'red', width: strokeWidth = 2, writingMode } = options
+    const g = createSVGElement('g')
+    g.setAttribute('fill', color)
+    if (writingMode === 'vertical-rl' || writingMode === 'vertical-lr') {
+      for (const { right, left, top, height } of rects) {
+        const el = createSVGElement('rect')
+        el.setAttribute('x', String((right + left) / 2))
+        el.setAttribute('y', String(top))
+        el.setAttribute('height', String(height))
+        el.setAttribute('width', String(strokeWidth))
+        g.append(el)
+      }
+    } else {
+      for (const { left, top, bottom, width } of rects) {
+        const el = createSVGElement('rect')
+        el.setAttribute('x', String(left))
+        el.setAttribute('y', String((top + bottom) / 2))
+        el.setAttribute('height', String(strokeWidth))
+        el.setAttribute('width', String(width))
+        g.append(el)
+      }
+    }
+    return g
+  }
+
+  static squiggly: DrawFn = (rects, options = {}) => {
+    const { color = 'red', width: strokeWidth = 2, writingMode } = options
+    const g = createSVGElement('g')
+    g.setAttribute('fill', 'none')
+    g.setAttribute('stroke', color)
+    g.setAttribute('stroke-width', String(strokeWidth))
+    const block = strokeWidth * 1.5
+    if (writingMode === 'vertical-rl' || writingMode === 'vertical-lr') {
+      for (const { right, top, height } of rects) {
+        const el = createSVGElement('path')
+        const n = Math.max(1, Math.round(height / block / 1.5))
+        const inline = height / n
+        const ls = Array.from({ length: n }, (_, i) => `l${i % 2 ? -block : block} ${inline}`).join('')
+        el.setAttribute('d', `M${right} ${top}${ls}`)
+        g.append(el)
+      }
+    } else {
+      for (const { left, bottom, width } of rects) {
+        const el = createSVGElement('path')
+        const n = Math.max(1, Math.round(width / block / 1.5))
+        const inline = width / n
+        const ls = Array.from({ length: n }, (_, i) => `l${inline} ${i % 2 ? block : -block}`).join('')
+        el.setAttribute('d', `M${left} ${bottom}${ls}`)
+        g.append(el)
+      }
+    }
+    return g
+  }
+
+  static outline: DrawFn = (rects, options = {}) => {
+    const { color = 'red', width: strokeWidth = 3, radius = 3 } = options
+    const g = createSVGElement('g')
+    g.setAttribute('fill', 'none')
+    g.setAttribute('stroke', color)
+    g.setAttribute('stroke-width', String(strokeWidth))
+    for (const { left, top, height, width } of rects) {
+      const el = createSVGElement('rect')
+      el.setAttribute('x', String(left))
+      el.setAttribute('y', String(top))
+      el.setAttribute('height', String(height))
+      el.setAttribute('width', String(width))
+      el.setAttribute('rx', String(radius))
+      g.append(el)
+    }
+    return g
+  }
+
+  // TTS cursor — same shape as highlight but applies a subtle CSS animation
+  // by class so consumers can customize the pulse without DOM churn.
+  static pulse: DrawFn = (rects, options = {}) => {
+    const { color = 'currentColor', opacity = 0.25 } = options
+    const g = createSVGElement('g')
+    g.setAttribute('fill', color)
+    g.setAttribute('class', 'reader-overlay-pulse')
+    g.style.opacity = `var(--overlay-pulse-opacity, ${opacity})`
+    for (const { left, top, height, width } of rects) {
+      const el = createSVGElement('rect')
+      el.setAttribute('x', String(left))
+      el.setAttribute('y', String(top))
+      el.setAttribute('height', String(height))
+      el.setAttribute('width', String(width))
+      g.append(el)
+    }
+    return g
+  }
+}

--- a/apps/web/src/lib/textWalker.test.ts
+++ b/apps/web/src/lib/textWalker.test.ts
@@ -101,3 +101,133 @@ describe('findTextMatches', () => {
     expect(Array.from(findTextMatches(root, 'absent'))).toEqual([])
   })
 })
+
+// Fixture suite — real-world DOM shapes from book content that historically
+// broke overlay coord mapping. Each fixture asserts that findTextMatches
+// returns a range whose toString() equals the needle verbatim. That's the
+// minimum contract every annotation layer relies on.
+describe('textWalker — real-chapter fixtures', () => {
+  let root: HTMLElement
+
+  beforeEach(() => {
+    root = document.createElement('div')
+    document.body.appendChild(root)
+  })
+
+  it('matches across nested inline spans (word split by styling)', () => {
+    // "unbelievable" split mid-word by a stray <span> (common from cleanup).
+    root.innerHTML = '<p>Something <em>un<span>bel</span>iev</em>able happened.</p>'
+    const hits = Array.from(findTextMatches(root, 'iev'))
+    expect(hits).toHaveLength(1)
+    expect(hits[0].toString()).toBe('iev')
+  })
+
+  it('matches plain text when a word has a soft-hyphen splitter', () => {
+    // Soft hyphen (U+00AD) between "un" and "believable". Search for the
+    // visible form — current impl treats U+00AD as a real character, so the
+    // visible-form lookup returns no hit. This test pins that behavior so a
+    // future "normalize away soft hyphens" change doesn't silently regress.
+    root.innerHTML = '<p>Something un\u00ADbelievable happened.</p>'
+    const withShy = Array.from(findTextMatches(root, 'un\u00ADbelievable'))
+    expect(withShy).toHaveLength(1)
+    const visibleOnly = Array.from(findTextMatches(root, 'unbelievable'))
+    expect(visibleOnly).toHaveLength(0)
+  })
+
+  it('skips script/style but keeps text in footnote <sup>', () => {
+    root.innerHTML = '<p>A footnote<sup><a href="#n1">1</a></sup> here.</p><script>const cat=1</script>'
+    const hits = Array.from(findTextMatches(root, 'footnote'))
+    expect(hits).toHaveLength(1)
+    expect(Array.from(findTextMatches(root, 'const'))).toHaveLength(0)
+  })
+
+  it('walks nested block structures (list inside blockquote)', () => {
+    root.innerHTML = '<blockquote><ul><li>one <strong>two</strong> three</li></ul></blockquote>'
+    const hits = Array.from(findTextMatches(root, 'two'))
+    expect(hits).toHaveLength(1)
+    expect(hits[0].toString()).toBe('two')
+  })
+
+  it('walks text inside table cells', () => {
+    root.innerHTML = '<table><tr><td>alpha</td><td>beta</td></tr><tr><td>alpha</td></tr></table>'
+    const hits = Array.from(findTextMatches(root, 'alpha'))
+    expect(hits).toHaveLength(2)
+  })
+
+  it('handles mixed-direction inline spans (LTR host, RTL insert)', () => {
+    root.innerHTML = '<p>He said <span dir="rtl">שלום</span> quietly.</p>'
+    const hits = Array.from(findTextMatches(root, 'quietly'))
+    expect(hits).toHaveLength(1)
+    expect(hits[0].toString()).toBe('quietly')
+  })
+
+  it('respects custom filter that rejects MathML roots', () => {
+    root.innerHTML = '<p>See <math><mi>x</mi></math> here too.</p>'
+    const filter = (node: Node): number => {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const tag = (node as Element).tagName.toLowerCase()
+        if (tag === 'math') return NodeFilter.FILTER_REJECT
+        return NodeFilter.FILTER_SKIP
+      }
+      return NodeFilter.FILTER_ACCEPT
+    }
+    const strs: string[] = []
+    const gen = textWalker<string>(root, function* (strings) {
+      for (const s of strings) yield s
+    }, filter)
+    for (const s of gen) strs.push(s)
+    expect(strs.join('')).toBe('See  here too.')
+  })
+
+  it('respects custom filter that rejects ruby annotation (<rt>)', () => {
+    // Base text walks, reading annotation is excluded by caller filter.
+    root.innerHTML = '<p><ruby>漢<rt>kan</rt></ruby><ruby>字<rt>ji</rt></ruby> means "character".</p>'
+    const filter = (node: Node): number => {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const tag = (node as Element).tagName.toLowerCase()
+        if (tag === 'rt' || tag === 'rp') return NodeFilter.FILTER_REJECT
+        return NodeFilter.FILTER_SKIP
+      }
+      return NodeFilter.FILTER_ACCEPT
+    }
+    const strs: string[] = []
+    const gen = textWalker<string>(root, function* (strings) {
+      for (const s of strings) yield s
+    }, filter)
+    for (const s of gen) strs.push(s)
+    expect(strs.join('')).toContain('漢')
+    expect(strs.join('')).toContain('字')
+    expect(strs.join('')).not.toContain('kan')
+    expect(strs.join('')).not.toContain('ji')
+  })
+
+  it('matches across a Range that crosses a paragraph boundary', () => {
+    root.innerHTML = '<p>Chapter one begins here.</p><p>And continues here.</p>'
+    const ps = root.querySelectorAll('p')
+    const range = document.createRange()
+    range.setStart(ps[0].firstChild!, 0)
+    range.setEnd(ps[1].firstChild!, ps[1].firstChild!.nodeValue!.length)
+    const hits = Array.from(findTextMatches(range, 'here'))
+    expect(hits).toHaveLength(2)
+  })
+
+  it('emits one range per identical match even when adjacent', () => {
+    root.innerHTML = '<p>hahahaha</p>'
+    // With needle "haha" and step = max(1, len), we get non-overlapping matches
+    // at 0 and 4 — 2 hits total.
+    const hits = Array.from(findTextMatches(root, 'haha'))
+    expect(hits).toHaveLength(2)
+    expect(hits.map(h => h.startOffset)).toEqual([0, 4])
+  })
+
+  it('ignores empty text nodes that sit between elements', () => {
+    const p = document.createElement('p')
+    p.appendChild(document.createTextNode(''))
+    p.appendChild(document.createTextNode('visible'))
+    p.appendChild(document.createTextNode(''))
+    root.appendChild(p)
+    const hits = Array.from(findTextMatches(root, 'visible'))
+    expect(hits).toHaveLength(1)
+    expect(hits[0].toString()).toBe('visible')
+  })
+})

--- a/apps/web/src/lib/textWalker.test.ts
+++ b/apps/web/src/lib/textWalker.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { textWalker, findTextMatches } from './textWalker'
+
+describe('textWalker', () => {
+  let root: HTMLElement
+
+  beforeEach(() => {
+    root = document.createElement('div')
+    document.body.appendChild(root)
+  })
+
+  it('walks text nodes in a simple element', () => {
+    root.innerHTML = '<p>Hello <strong>world</strong> end.</p>'
+    const seen: string[] = []
+    const gen = textWalker<string>(root, function* (strings) {
+      for (const s of strings) yield s
+    })
+    for (const s of gen) seen.push(s)
+    expect(seen).toEqual(['Hello ', 'world', ' end.'])
+  })
+
+  it('skips script and style contents', () => {
+    root.innerHTML = '<p>a</p><script>BAD</script><style>X</style><p>b</p>'
+    const seen: string[] = []
+    const gen = textWalker<string>(root, function* (strings) {
+      for (const s of strings) yield s
+    })
+    for (const s of gen) seen.push(s)
+    expect(seen).toEqual(['a', 'b'])
+  })
+
+  it('accepts a Range and limits to its span', () => {
+    root.innerHTML = '<p>one</p><p>two</p><p>three</p>'
+    const ps = root.querySelectorAll('p')
+    const range = document.createRange()
+    range.setStart(ps[0].firstChild!, 0)
+    range.setEnd(ps[1].firstChild!, 3)
+    const seen: string[] = []
+    const gen = textWalker<string>(range, function* (strings) {
+      for (const s of strings) yield s
+    })
+    for (const s of gen) seen.push(s)
+    expect(seen).toContain('one')
+    expect(seen).toContain('two')
+    expect(seen).not.toContain('three')
+  })
+
+  it('makeRange constructs a multi-node range', () => {
+    root.innerHTML = '<p>Hello <strong>bold</strong> world</p>'
+    const ranges: Range[] = []
+    const gen = textWalker<Range>(root, function* (strings, makeRange) {
+      // span from node[0] start → node[2] end
+      yield makeRange(0, 0, strings.length - 1, strings[strings.length - 1].length)
+    })
+    for (const r of gen) ranges.push(r)
+    expect(ranges).toHaveLength(1)
+    expect(ranges[0].toString()).toBe('Hello bold world')
+  })
+
+  it('custom filterFn can reject specific elements', () => {
+    root.innerHTML = '<p>keep</p><aside>drop</aside><p>keep2</p>'
+    const filter = (node: Node): number => {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const tag = (node as Element).tagName.toLowerCase()
+        if (tag === 'aside') return NodeFilter.FILTER_REJECT
+        return NodeFilter.FILTER_SKIP
+      }
+      return NodeFilter.FILTER_ACCEPT
+    }
+    const seen: string[] = []
+    const gen = textWalker<string>(root, function* (strings) {
+      for (const s of strings) yield s
+    }, filter)
+    for (const s of gen) seen.push(s)
+    expect(seen).toEqual(['keep', 'keep2'])
+  })
+})
+
+describe('findTextMatches', () => {
+  let root: HTMLElement
+
+  beforeEach(() => {
+    root = document.createElement('div')
+    document.body.appendChild(root)
+  })
+
+  it('emits a range per occurrence, case-insensitive', () => {
+    root.innerHTML = '<p>The cat sat. The CAT ran.</p>'
+    const hits = Array.from(findTextMatches(root, 'cat'))
+    expect(hits).toHaveLength(2)
+    expect(hits[0].toString().toLowerCase()).toBe('cat')
+  })
+
+  it('returns nothing for empty needle', () => {
+    root.textContent = 'anything'
+    expect(Array.from(findTextMatches(root, ''))).toEqual([])
+  })
+
+  it('returns nothing when no match', () => {
+    root.textContent = 'nothing here'
+    expect(Array.from(findTextMatches(root, 'absent'))).toEqual([])
+  })
+})

--- a/apps/web/src/lib/textWalker.ts
+++ b/apps/web/src/lib/textWalker.ts
@@ -1,0 +1,103 @@
+// TreeWalker-backed text iteration with per-match Range construction.
+// Port of https://github.com/johnfactotum/foliate-js/blob/master/text-walker.js
+// (MIT, © John Factotum). Adapted to TS.
+//
+// Use: pass a Range (to walk the portion it covers) or an Element/Document
+// (to walk everything). `func(strings, makeRange)` is a generator that yields
+// matches — strings is the array of text-node contents in document order,
+// makeRange(startIdx, startOffset, endIdx, endOffset) constructs a Range
+// across potentially multiple nodes.
+//
+// Replaces the per-feature ad-hoc TreeWalker loops in vocabHighlightEngine,
+// in-book search, TTS sentence chunking.
+
+type TextFinder<T> = (strings: string[], makeRange: MakeRange) => IterableIterator<T>
+
+export type MakeRange = (
+  startIndex: number,
+  startOffset: number,
+  endIndex: number,
+  endOffset: number,
+) => Range
+
+const NODE_FILTER_MASK =
+  NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT | NodeFilter.SHOW_CDATA_SECTION
+
+const defaultAcceptNode = (node: Node): number => {
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    const name = (node as Element).tagName.toLowerCase()
+    if (name === 'script' || name === 'style' || name === 'noscript') {
+      return NodeFilter.FILTER_REJECT
+    }
+    return NodeFilter.FILTER_SKIP
+  }
+  return NodeFilter.FILTER_ACCEPT
+}
+
+const walkRange = (range: Range, walker: TreeWalker): Node[] => {
+  const nodes: Node[] = []
+  for (let node: Node | null = walker.currentNode; node; node = walker.nextNode()) {
+    const compare = range.comparePoint(node, 0)
+    if (compare === 0) nodes.push(node)
+    else if (compare > 0) break
+  }
+  return nodes
+}
+
+const walkRoot = (_: Node, walker: TreeWalker): Node[] => {
+  const nodes: Node[] = []
+  for (let node: Node | null = walker.nextNode(); node; node = walker.nextNode()) {
+    nodes.push(node)
+  }
+  return nodes
+}
+
+function resolveRoot(input: Range | Element | Document): Node {
+  if (input instanceof Range) return input.commonAncestorContainer
+  if ((input as Document).body) return (input as Document).body
+  return input
+}
+
+export function* textWalker<T>(
+  input: Range | Element | Document,
+  func: TextFinder<T>,
+  filterFn: (node: Node) => number = defaultAcceptNode,
+): Generator<T> {
+  const root = resolveRoot(input)
+  const doc = root.ownerDocument ?? (root as Document)
+  const walker = doc.createTreeWalker(root, NODE_FILTER_MASK, {
+    acceptNode: filterFn,
+  })
+  const nodes =
+    input instanceof Range ? walkRange(input, walker) : walkRoot(root, walker)
+  const strs = nodes.map((node) => node.nodeValue ?? '')
+  const makeRange: MakeRange = (startIndex, startOffset, endIndex, endOffset) => {
+    const range = doc.createRange()
+    range.setStart(nodes[startIndex], startOffset)
+    range.setEnd(nodes[endIndex], endOffset)
+    return range
+  }
+  for (const match of func(strs, makeRange)) yield match
+}
+
+// Helper: find all (case-insensitive) occurrences of `needle` — emits Ranges.
+// Consumer drives it for in-book search etc.
+export function* findTextMatches(
+  input: Range | Element | Document,
+  needle: string,
+): Generator<Range> {
+  if (!needle) return
+  const lower = needle.toLowerCase()
+  yield* textWalker<Range>(input, function* (strings, makeRange) {
+    for (let i = 0; i < strings.length; i++) {
+      const hay = strings[i].toLowerCase()
+      let from = 0
+      while (from < hay.length) {
+        const idx = hay.indexOf(lower, from)
+        if (idx === -1) break
+        yield makeRange(i, idx, i, idx + needle.length)
+        from = idx + Math.max(1, needle.length)
+      }
+    }
+  })
+}

--- a/apps/web/src/lib/vocabHighlightTelemetry.ts
+++ b/apps/web/src/lib/vocabHighlightTelemetry.ts
@@ -16,6 +16,10 @@ export type TelemetryEvent =
   | 'oracle.diff'
   | 'error.boundary'
   | 'error.engine'
+  | 'reader.overlay.mount'
+  | 'reader.overlay.redraw'
+  | 'reader.overlay.miss'
+  | 'reader.overlay.error'
 
 export type TelemetryPayload = Record<string, unknown>
 

--- a/apps/web/src/lib/vocabHighlightTelemetry.ts
+++ b/apps/web/src/lib/vocabHighlightTelemetry.ts
@@ -5,6 +5,7 @@
 export type TelemetryEvent =
   | 'boot.supported'
   | 'boot.fallback'
+  | 'boot.overlay'
   | 'register.success'
   | 'register.mismatch'
   | 'register.error'

--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -23,6 +23,8 @@ import { LocalizedLink } from '../components/LocalizedLink'
 import { Toast } from '../components/Toast'
 import { ReaderTopBar } from '../components/reader/ReaderTopBar'
 import { ReaderContent } from '../components/reader/ReaderContent'
+import { ReaderSection } from '../components/reader/ReaderSection'
+import { ReaderNav } from '../components/reader/ReaderNav'
 import { ReaderFooterNav } from '../components/reader/ReaderFooterNav'
 import { ReaderSettingsDrawer } from '../components/reader/ReaderSettingsDrawer'
 import { ReaderTocDrawer, type AutoSaveInfo, type TocChapter } from '../components/reader/ReaderTocDrawer'
@@ -318,6 +320,27 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
 
   // Refs for restore logic
   const scrollRestoredRef = useRef(false)
+
+  // Overlay-path scroll progress (single chapter mounted, native window scroll).
+  // Legacy multi-chapter path uses `chapterScrollProgress` below.
+  const overlayV2Enabled = FEATURES.readerOverlayV2 && !isReaderOverlayKillswitchSet()
+  const [overlayScrollProgress, setOverlayScrollProgress] = useState(0)
+  useEffect(() => {
+    if (!overlayV2Enabled) return
+    const read = () => {
+      const doc = document.scrollingElement || document.documentElement
+      const max = doc.scrollHeight - doc.clientHeight
+      if (max <= 0) { setOverlayScrollProgress(0); return }
+      setOverlayScrollProgress(Math.min(1, Math.max(0, doc.scrollTop / max)))
+    }
+    read()
+    window.addEventListener('scroll', read, { passive: true })
+    window.addEventListener('resize', read)
+    return () => {
+      window.removeEventListener('scroll', read)
+      window.removeEventListener('resize', read)
+    }
+  }, [overlayV2Enabled, chapter?.id])
 
   // Current chapter progress (0..1) based on scroll within the visible chapter.
   // Drives both book-level overallProgress and chapter-level ETF.
@@ -937,21 +960,41 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
           scrollToHighlightId={scrollToHighlightId}
         >
           <div ref={scrollContainerRef}>
-            <ReaderContent
-              chapters={scrollReader.chapters}
-              settings={settings}
-              isLoadingMore={scrollReader.isLoadingMore}
-              isAtEnd={scrollReader.isAtEnd}
-              libraryHref={mode === 'public' ? getLocalizedPath('/library') : `/${language}/library/my`}
-              homeHref={mode === 'public' ? getLocalizedPath('/') : `/${language}`}
-              bookDetailHref={mode === 'public' && bookSlug ? getLocalizedPath(`/books/${bookSlug}`) : undefined}
-              onLoadMore={scrollReader.loadMore}
-              onLoadPrev={scrollReader.loadPrev}
-              chapterRefs={scrollReader.chapterRefs}
-              onTap={() => { readingSession.recordActivity(); showImmersiveBars() }}
-            />
+            {overlayV2Enabled ? (
+              <>
+                <ReaderSection
+                  chapterId={chapter.id}
+                  chapterIndex={chapter.chapterNumber}
+                  html={chapter.html}
+                  settings={settings}
+                  onTap={() => { readingSession.recordActivity(); showImmersiveBars() }}
+                />
+                <ReaderNav
+                  chapterTitle={chapter.title}
+                  chapterNumber={chapter.chapterNumber}
+                  totalChapters={totalChapters || null}
+                  chapterProgress={overlayScrollProgress}
+                  onPrev={chapter.prev ? () => navigate(getChapterUrl(chapter.prev!.identifier)) : null}
+                  onNext={chapter.next ? () => navigate(getChapterUrl(chapter.next!.identifier)) : null}
+                />
+              </>
+            ) : (
+              <ReaderContent
+                chapters={scrollReader.chapters}
+                settings={settings}
+                isLoadingMore={scrollReader.isLoadingMore}
+                isAtEnd={scrollReader.isAtEnd}
+                libraryHref={mode === 'public' ? getLocalizedPath('/library') : `/${language}/library/my`}
+                homeHref={mode === 'public' ? getLocalizedPath('/') : `/${language}`}
+                bookDetailHref={mode === 'public' && bookSlug ? getLocalizedPath(`/books/${bookSlug}`) : undefined}
+                onLoadMore={scrollReader.loadMore}
+                onLoadPrev={scrollReader.loadPrev}
+                chapterRefs={scrollReader.chapterRefs}
+                onTap={() => { readingSession.recordActivity(); showImmersiveBars() }}
+              />
+            )}
           </div>
-          {FEATURES.readerOverlayV2 && !isReaderOverlayKillswitchSet() && searchOpen && (
+          {overlayV2Enabled && searchOpen && (
             <SearchOverlayLayer
               containerRef={scrollContainerRef}
               query={searchQuery}

--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -32,7 +32,7 @@ import { ReaderTocDrawer, type AutoSaveInfo, type TocChapter } from '../componen
 import { ReaderSearchDrawer } from '../components/reader/ReaderSearchDrawer'
 import { ReaderHighlights } from '../components/reader/ReaderHighlights'
 import { SearchOverlayLayer } from '../components/reader/SearchOverlayLayer'
-import { FEATURES, isReaderOverlayKillswitchSet } from '../lib/features'
+import { isReaderOverlayV2Active } from '../lib/features'
 import { useScrollReader } from '../hooks/useScrollReader'
 import { useReadingSession } from '../hooks/useReadingSession'
 import { useQuickStats } from '../hooks/useQuickStats'
@@ -324,7 +324,7 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
 
   // Overlay-path scroll progress (single chapter mounted, native window scroll).
   // Legacy multi-chapter path uses `chapterScrollProgress` below.
-  const overlayV2Enabled = FEATURES.readerOverlayV2 && !isReaderOverlayKillswitchSet()
+  const overlayV2Enabled = isReaderOverlayV2Active()
   const [overlayScrollProgress, setOverlayScrollProgress] = useState(0)
   useEffect(() => {
     if (!overlayV2Enabled) return

--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -358,25 +358,37 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
   const calculatedProgress = useMemo(() => {
     if (!scrollReaderBook) return 0
     const chapters = scrollReaderBook.chapters
-    const currentId = scrollReader.visibleIdentifier
+    // Overlay-path: one chapter mounted, visibleIdentifier is stale. Drive
+    // progress from the URL chapter + overlay scroll instead.
+    const currentId = overlayV2Enabled
+      ? (chapterIdentifier || '')
+      : (scrollReader.visibleIdentifier || '')
     if (!currentId) return 0
+    const intraProgress = overlayV2Enabled ? overlayScrollProgress : chapterScrollProgress
 
     const currentChapterIndex = chapters.findIndex(c => c.identifier === currentId)
     if (currentChapterIndex === -1) return 0
 
     const totalWords = chapters.reduce((sum, c) => sum + (c.wordCount || 0), 0)
     if (totalWords === 0) {
-      return (currentChapterIndex + chapterScrollProgress) / chapters.length
+      return (currentChapterIndex + intraProgress) / chapters.length
     }
 
     const wordsBeforeCurrent = chapters
       .slice(0, currentChapterIndex)
       .reduce((sum, c) => sum + (c.wordCount || 0), 0)
     const currentChapterWords = chapters[currentChapterIndex].wordCount || 0
-    const wordsRead = wordsBeforeCurrent + currentChapterWords * chapterScrollProgress
+    const wordsRead = wordsBeforeCurrent + currentChapterWords * intraProgress
 
     return wordsRead / totalWords
-  }, [scrollReaderBook, scrollReader.visibleIdentifier, chapterScrollProgress])
+  }, [
+    scrollReaderBook,
+    scrollReader.visibleIdentifier,
+    chapterScrollProgress,
+    overlayV2Enabled,
+    chapterIdentifier,
+    overlayScrollProgress,
+  ])
 
   // Force 100% when book is completed
   const rawProgress = bookCompleted ? 1 : calculatedProgress
@@ -450,10 +462,13 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
   const totalChapters = scrollReaderBook?.chapters.length ?? 0
   const currentChapterIndex = useMemo(() => {
     if (!scrollReaderBook) return -1
-    const id = scrollReader.visibleIdentifier || chapterIdentifier
+    // Overlay path: URL chapter is authoritative. Legacy path: scroll-visible wins.
+    const id = overlayV2Enabled
+      ? (chapterIdentifier || '')
+      : (scrollReader.visibleIdentifier || chapterIdentifier || '')
     if (!id) return -1
     return scrollReaderBook.chapters.findIndex(c => c.identifier === id)
-  }, [scrollReaderBook, scrollReader.visibleIdentifier, chapterIdentifier])
+  }, [scrollReaderBook, scrollReader.visibleIdentifier, chapterIdentifier, overlayV2Enabled])
 
   // Track scroll activity for reading session
   useEffect(() => {

--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -28,6 +28,8 @@ import { ReaderSettingsDrawer } from '../components/reader/ReaderSettingsDrawer'
 import { ReaderTocDrawer, type AutoSaveInfo, type TocChapter } from '../components/reader/ReaderTocDrawer'
 import { ReaderSearchDrawer } from '../components/reader/ReaderSearchDrawer'
 import { ReaderHighlights } from '../components/reader/ReaderHighlights'
+import { SearchOverlayLayer } from '../components/reader/SearchOverlayLayer'
+import { FEATURES, isReaderOverlayKillswitchSet } from '../lib/features'
 import { useScrollReader } from '../hooks/useScrollReader'
 import { useReadingSession } from '../hooks/useReadingSession'
 import { useQuickStats } from '../hooks/useQuickStats'
@@ -949,6 +951,13 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
               onTap={() => { readingSession.recordActivity(); showImmersiveBars() }}
             />
           </div>
+          {FEATURES.readerOverlayV2 && !isReaderOverlayKillswitchSet() && searchOpen && (
+            <SearchOverlayLayer
+              containerRef={scrollContainerRef}
+              query={searchQuery}
+              activeMatchIndex={activeMatchIndex}
+            />
+          )}
         </ReaderHighlights>
       </main>
 

--- a/apps/web/src/pages/ReaderPage.tsx
+++ b/apps/web/src/pages/ReaderPage.tsx
@@ -25,6 +25,7 @@ import { ReaderTopBar } from '../components/reader/ReaderTopBar'
 import { ReaderContent } from '../components/reader/ReaderContent'
 import { ReaderSection } from '../components/reader/ReaderSection'
 import { ReaderNav } from '../components/reader/ReaderNav'
+import { ReaderErrorBoundary } from '../components/reader/ReaderErrorBoundary'
 import { ReaderFooterNav } from '../components/reader/ReaderFooterNav'
 import { ReaderSettingsDrawer } from '../components/reader/ReaderSettingsDrawer'
 import { ReaderTocDrawer, type AutoSaveInfo, type TocChapter } from '../components/reader/ReaderTocDrawer'
@@ -976,7 +977,24 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
         >
           <div ref={scrollContainerRef}>
             {overlayV2Enabled ? (
-              <>
+              <ReaderErrorBoundary
+                resetKey={chapter.id}
+                fallback={
+                  <ReaderContent
+                    chapters={scrollReader.chapters}
+                    settings={settings}
+                    isLoadingMore={scrollReader.isLoadingMore}
+                    isAtEnd={scrollReader.isAtEnd}
+                    libraryHref={mode === 'public' ? getLocalizedPath('/library') : `/${language}/library/my`}
+                    homeHref={mode === 'public' ? getLocalizedPath('/') : `/${language}`}
+                    bookDetailHref={mode === 'public' && bookSlug ? getLocalizedPath(`/books/${bookSlug}`) : undefined}
+                    onLoadMore={scrollReader.loadMore}
+                    onLoadPrev={scrollReader.loadPrev}
+                    chapterRefs={scrollReader.chapterRefs}
+                    onTap={() => { readingSession.recordActivity(); showImmersiveBars() }}
+                  />
+                }
+              >
                 <ReaderSection
                   chapterId={chapter.id}
                   chapterIndex={chapter.chapterNumber}
@@ -992,7 +1010,7 @@ export function ReaderPage({ mode = 'public' }: ReaderPageProps) {
                   onPrev={chapter.prev ? () => navigate(getChapterUrl(chapter.prev!.identifier)) : null}
                   onNext={chapter.next ? () => navigate(getChapterUrl(chapter.next!.identifier)) : null}
                 />
-              </>
+              </ReaderErrorBoundary>
             ) : (
               <ReaderContent
                 chapters={scrollReader.chapters}

--- a/apps/web/src/styles/reader.css
+++ b/apps/web/src/styles/reader.css
@@ -1853,3 +1853,90 @@ html[data-theme="dark"] .reader-search-drawer__context mark {
   color: var(--color-text);
 }
 
+/* Overlay-v2 one-chapter view (flag-gated) */
+.reader-section {
+  max-width: var(--reader-max-width, 680px);
+  margin: 0 auto;
+  padding: 80px 20px 120px;
+}
+
+.reader-section__article {
+  color: var(--reader-text);
+}
+
+.reader-nav {
+  max-width: var(--reader-max-width, 680px);
+  margin: 0 auto 60px;
+  padding: 0 20px;
+}
+
+.reader-nav__progress {
+  height: 3px;
+  background: var(--reader-border);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-bottom: 12px;
+}
+
+.reader-nav__progress-bar {
+  height: 100%;
+  background: var(--reader-secondary);
+  transition: width 0.2s ease-out;
+}
+
+.reader-nav__row {
+  display: grid;
+  grid-template-columns: 44px 1fr 44px;
+  gap: 12px;
+  align-items: center;
+}
+
+.reader-nav__btn {
+  width: 44px;
+  height: 44px;
+  border: 1px solid var(--reader-border);
+  background: var(--reader-bar-bg);
+  color: var(--reader-text);
+  border-radius: 50%;
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s, color 0.15s;
+}
+
+.reader-nav__btn:hover:not(:disabled) {
+  background: var(--color-bg-secondary);
+}
+
+.reader-nav__btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.reader-nav__info {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.reader-nav__title {
+  font-size: 14px;
+  color: var(--reader-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.reader-nav__counter {
+  font-size: 12px;
+  color: var(--reader-secondary);
+  font-variant-numeric: tabular-nums;
+  opacity: 0.7;
+}
+

--- a/apps/web/src/styles/reader.css
+++ b/apps/web/src/styles/reader.css
@@ -1722,6 +1722,9 @@ html[data-theme="dark"] .reader-search-drawer__context mark {
 }
 
 
+/* TODO(overlay-v2 slice-10): remove .vocab-underline + .vocab-inline-translation
+   rules below. Superseded by SVG overlayer (VocabOverlayLayer) when
+   FEATURES.readerOverlayV2 flips on. */
 /* Vocab word underlines in reader.
    Uses native text-decoration (not border-bottom) so the underline sits at
    descender level with skip-ink — keeps letter shapes clean AND leaves a

--- a/docs/reader-overlay-v2-slice-10.md
+++ b/docs/reader-overlay-v2-slice-10.md
@@ -34,10 +34,14 @@ Keep after slice 10 only if overlay path has a proven regression on a supported 
 
 ### Mobile
 
+Senior-dev scope adjustment (slice 8b): **vocab underlines stay on CSS.highlights** — glyph-aware `text-decoration` beats SVG rect lines for line-wrapped underlines. Only `<mark>`-based user highlights migrate to the overlayer.
+
 | Path | Action |
 |---|---|
-| `apps/mobile/src/lib/readerHtml.ts` — `<mark>`-wrapping `renderHighlight`, `markVocabWords`, `vhlLegacyMark` functions | Replace with `READER_OVERLAY_SCRIPT` interpolation + overlay API calls |
-| `apps/mobile/src/lib/readerHtml.ts` — `VOCAB_STAGE_COLORS`, `VOCAB_ATTR` constants if unused after swap | Delete |
+| `apps/mobile/src/lib/readerHtml.ts` — `hlPaintRange` (`<mark>`-wrapping) + the `<mark data-highlight-id>` legacy removal branch in `removeHighlight` | Delete after slice 8b is at 100% overlayV2 rollout |
+| `apps/mobile/src/lib/readerHtml.ts` — `HIGHLIGHT_BG` constant if unused after overlay path becomes default | Reassess |
+| `apps/mobile/src/lib/readerHtml.ts` — `vhlLegacyMark` / `vhlLegacyRemove` (vocab legacy path, kept as CSS.highlights fallback) | **Keep** — this is the platform fallback for older Android WebView without CSS.highlights support |
+| `apps/mobile/src/lib/readerHtml.ts` — `VOCAB_STAGE_COLORS`, `VOCAB_ATTR` constants | Keep — still used by legacy vocab fallback |
 
 ### ReaderPage
 

--- a/docs/reader-overlay-v2-slice-10.md
+++ b/docs/reader-overlay-v2-slice-10.md
@@ -1,0 +1,68 @@
+# Slice 10 — legacy cleanup target list
+
+Grep-zero criterion for slice 10: after deletion, the command below MUST return 0 matches across `apps/web/src/` and `apps/mobile/src/`:
+
+```bash
+grep -rE "HighlightLayer|VocabWordLayer|ReaderContent|useScrollReader|\\.vocab-underline|\\.vocab-inline-translation" \
+  apps/web/src apps/mobile/src
+```
+
+## Hard-delete targets
+
+Every file below is marked with `// TODO(overlay-v2 slice-10): remove` in its header. Remove the file AND every import/reference.
+
+### Web
+
+| Path | Superseded by |
+|---|---|
+| `apps/web/src/components/reader/HighlightLayer.tsx` | `HighlightOverlayLayer.tsx` |
+| `apps/web/src/components/reader/VocabWordLayer.tsx` | `VocabOverlayLayer.tsx` |
+| `apps/web/src/components/reader/ReaderContent.tsx` | `ReaderSection.tsx` |
+| `apps/web/src/hooks/useScrollReader.ts` | `ReaderSection` single-chapter model |
+| `apps/web/src/styles/reader.css` — `.vocab-underline*` rules (block starting ~line 1725) | SVG overlay styling |
+| `apps/web/src/styles/reader.css` — `.vocab-inline-translation` rules (~line 1771) | `VocabTranslationOverlay` |
+
+### Web — dispatcher/middle-tier (evaluate before delete)
+
+Keep after slice 10 only if overlay path has a proven regression on a supported browser. Default: also delete.
+
+| Path | Reason to keep (if any) |
+|---|---|
+| `apps/web/src/components/reader/VocabHighlightLayer.tsx` (CSS Custom Highlight path) | Fallback for browsers without SVG overlay perf |
+| `apps/web/src/components/reader/VocabHighlightDispatcher.tsx` | Collapse into direct `VocabOverlayLayer` render |
+| `apps/web/src/lib/customHighlightRegistry.ts` | Dead if VocabHighlightLayer goes |
+
+### Mobile
+
+| Path | Action |
+|---|---|
+| `apps/mobile/src/lib/readerHtml.ts` — `<mark>`-wrapping `renderHighlight`, `markVocabWords`, `vhlLegacyMark` functions | Replace with `READER_OVERLAY_SCRIPT` interpolation + overlay API calls |
+| `apps/mobile/src/lib/readerHtml.ts` — `VOCAB_STAGE_COLORS`, `VOCAB_ATTR` constants if unused after swap | Delete |
+
+### ReaderPage
+
+| File | Change |
+|---|---|
+| `apps/web/src/pages/ReaderPage.tsx` | Remove the `overlayV2Enabled ? ... : <ReaderContent />` branch — keep only the `ReaderSection` path. Remove `scrollReader`, `chapterScrollProgress`, `calculatedProgress` legacy branch, `overlayScrollProgress` becomes the single source of truth. |
+
+### Feature flag
+
+| File | Change |
+|---|---|
+| `apps/web/src/lib/features.ts` | Delete `readerOverlayV2` key + `isReaderOverlayKillswitchSet`. |
+| `apps/web/src/components/reader/ReaderHighlights.tsx` | Remove the flag branch — always mount `HighlightOverlayLayer`. |
+| `apps/web/src/components/reader/VocabHighlightDispatcher.tsx` | Remove `decide()` → always return `'overlay'` (or collapse into direct render). |
+| `apps/web/src/pages/ReaderPage.tsx` | Same — remove the flag branch. |
+| `apps/web/src/lib/vocabHighlightTelemetry.ts` | Remove `'boot.overlay'` event if no longer useful, otherwise keep as baseline. |
+
+## Ordering
+
+Slice 10 ships as its **own PR** after slice 9 has been at 100% rollout for ≥ 4 weeks with no regressions. If we roll back during slice 9, slice 10 stays un-shipped — reverting rollout must not lose the cleanup work.
+
+## Done criterion
+
+1. `grep -rE` command at top returns 0 matches.
+2. No import statements reference deleted files.
+3. `pnpm -C apps/web test` green.
+4. `pnpm -C apps/web build` green.
+5. Full manual smoke: highlight round-trip, vocab tap, search jump, TTS, chapter prev/next — web + mobile.


### PR DESCRIPTION
## Summary

- Port foliate-js's SVG `Overlayer` as the single rendering primitive for every annotation layer (highlights, vocab underlines, TTS, search). One reflow path, zero text mutation.
- Section-at-a-time `ReaderSection` + `ReaderNav` (built but flag-off in this PR — only legacy reader runs in prod).
- Mobile WebView gets the same overlayer module inlined (slice 8).
- ErrorBoundary fallback to legacy on throw + mount telemetry for safe rollout.
- Slice 9 (this commit): runtime enabler — flip overlay v2 on per browser via `localStorage.setItem('textstack.readerOverlayV2','1')` or DevTools `window.__textstackForceOverlayReader = true`. Killswitch (`__textstackForceLegacyReader`) wins.

## Rollout plan

1. Merge with build-time flag `VITE_READER_OVERLAY_V2` OFF (default).
2. Owner enables overlay v2 for own browser via localStorage / window override → smoke for 1 week.
3. Flip `VITE_READER_OVERLAY_V2=true` in prod env → all users.
4. Watch `reader.overlay.error` + `reader.overlay.miss` telemetry. Killswitch ready.
5. Slice 10: delete legacy `VocabWordLayer`, `HighlightLayer`, old `ReaderContent` after 4 clean prod weeks.

## Test plan

- [ ] `pnpm -C apps/web exec vitest run src/lib/features.test.ts` — 14 tests pass
- [ ] `pnpm -C apps/web exec tsc --noEmit` — clean
- [ ] Manual: textstack.app — default load uses legacy reader (no regression)
- [ ] Manual: `localStorage.setItem('textstack.readerOverlayV2','1')` → reload → overlay v2 active; highlights/vocab/TTS/search render via SVG
- [ ] Manual: `window.__textstackForceLegacyReader = true` → instantly forces legacy

🤖 Generated with [Claude Code](https://claude.com/claude-code)