### PR TITLE
mobile reader: pre-launch polish pass (10 commits)

### DIFF
--- a/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
+++ b/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
@@ -553,6 +553,9 @@ export default function UserBookReaderScreen() {
           originWhitelist={['*']}
           scrollEnabled
           showsVerticalScrollIndicator={false}
+          // GPU-composited page on Android — library reader parity.
+          androidLayerType="hardware"
+          overScrollMode="never"
         />
 
         {/* Top bar — after WebView so it renders on top */}

--- a/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
+++ b/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
@@ -641,10 +641,43 @@ export default function UserBookReaderScreen() {
             <View style={[styles.progressBar, { backgroundColor: colors.border }]}>
               <View style={[styles.progressFill, { width: `${Math.round(progress * 100)}%`, backgroundColor: colors.primary }]} />
             </View>
-            <Text style={[styles.progressText, { color: colors.textSecondary }]}>
-              {Math.round(progress * 100)}%
-              {totalChapters > 1 && currentChapterIndex >= 0 ? `   ${currentChapterIndex + 1} / ${totalChapters}` : ''}
-            </Text>
+            <View style={styles.footerRow}>
+              <TouchableOpacity
+                onPress={() => chapter?.prev && navigateChapter(chapter.prev.slug)}
+                disabled={!chapter?.prev}
+                style={styles.chevronBtn}
+                accessibilityLabel="Previous chapter"
+                accessibilityRole="button"
+              >
+                <Text style={[styles.chevron, { color: chapter?.prev ? colors.text : colors.textSecondary, opacity: chapter?.prev ? 1 : 0.3 }]}>‹</Text>
+              </TouchableOpacity>
+
+              <View style={styles.footerInfo}>
+                <Text style={[styles.footerChapter, { color: colors.text }]} numberOfLines={1}>
+                  {chapter?.title || ''}
+                </Text>
+                <View style={styles.footerMeta}>
+                  {totalChapters > 1 && currentChapterIndex >= 0 && (
+                    <Text style={[styles.footerCounter, { color: colors.textSecondary }]}>
+                      {currentChapterIndex + 1} / {totalChapters}
+                    </Text>
+                  )}
+                  <Text style={[styles.footerPercent, { color: colors.textSecondary }]}>
+                    {Math.round(progress * 100)}%
+                  </Text>
+                </View>
+              </View>
+
+              <TouchableOpacity
+                onPress={() => chapter?.next && navigateChapter(chapter.next.slug)}
+                disabled={!chapter?.next}
+                style={styles.chevronBtn}
+                accessibilityLabel="Next chapter"
+                accessibilityRole="button"
+              >
+                <Text style={[styles.chevron, { color: chapter?.next ? colors.text : colors.textSecondary, opacity: chapter?.next ? 1 : 0.3 }]}>›</Text>
+              </TouchableOpacity>
+            </View>
           </View>
         </Animated.View>
 
@@ -802,4 +835,12 @@ const styles = StyleSheet.create({
     marginTop: 4,
     fontFamily: fonts.sans,
   },
+  footerRow: { flexDirection: 'row', alignItems: 'center', paddingTop: 4, minHeight: 48 },
+  chevronBtn: { width: 44, height: 44, justifyContent: 'center' as const, alignItems: 'center' as const },
+  chevron: { fontSize: 28, fontFamily: fonts.sans, lineHeight: 28 },
+  footerInfo: { flex: 1, alignItems: 'center' as const, paddingHorizontal: 4 },
+  footerChapter: { fontSize: 13, fontFamily: fonts.sansMedium, fontWeight: '500' as const, textAlign: 'center' as const },
+  footerMeta: { flexDirection: 'row', alignItems: 'center' as const, gap: 12, marginTop: 2 },
+  footerCounter: { fontSize: 11, fontFamily: fonts.sans, fontVariant: ['tabular-nums'] },
+  footerPercent: { fontSize: 11, fontFamily: fonts.sans, fontVariant: ['tabular-nums'] },
 })

--- a/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
+++ b/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
@@ -323,7 +323,7 @@ export default function UserBookReaderScreen() {
     } catch (err) {
       if (__DEV__) console.warn('[user-book-reader] postMessage handler threw', err, event?.nativeEvent?.data)
     }
-  }, [chapter, bookId, chapterSlug, settings.autoLookup, isAuthenticated, notifyWordSaved])
+  }, [chapter, bookId, chapterSlug, settings.autoLookup, isAuthenticated, language, toggleBars, showBars, hideBars, notifyWordSaved, showToast])
 
   const handleSaveWord = async () => {
     if (!selection || !isAuthenticated) return

--- a/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
+++ b/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
@@ -532,7 +532,7 @@ export default function UserBookReaderScreen() {
   return (
     <>
       <Stack.Screen options={{ headerShown: false }} />
-      <StatusBar hidden={!barsVisible} />
+      <StatusBar hidden={!barsVisible} style={settings.theme === 'dark' ? 'light' : 'dark'} />
       <View style={[styles.container, { backgroundColor: barBg }]}>
         {/* WebView first — overlay bars rendered after so they sit on top of native layer */}
         <WebView
@@ -557,6 +557,8 @@ export default function UserBookReaderScreen() {
           androidLayerType="hardware"
           overScrollMode="never"
           bounces={false}
+          menuItems={[]}
+          cacheEnabled={false}
           // Intercept in-book links; route external URLs out to the OS
           // browser so the WebView keeps its injected script + DOM.
           onShouldStartLoadWithRequest={(req) => {

--- a/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
+++ b/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
-import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Animated } from 'react-native'
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Animated, Linking } from 'react-native'
 import { WebView } from 'react-native-webview'
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router'
 import { userBooksApi, vocabularyApi, highlightsApi, t } from '@textstack/shared'
@@ -556,6 +556,18 @@ export default function UserBookReaderScreen() {
           // GPU-composited page on Android — library reader parity.
           androidLayerType="hardware"
           overScrollMode="never"
+          bounces={false}
+          // Intercept in-book links; route external URLs out to the OS
+          // browser so the WebView keeps its injected script + DOM.
+          onShouldStartLoadWithRequest={(req) => {
+            const { url, navigationType } = req
+            if (url === 'about:blank' || url.startsWith('data:') || url.startsWith('file:')) return true
+            if (navigationType === 'click' && (url.startsWith('http://') || url.startsWith('https://'))) {
+              Linking.openURL(url).catch(() => {})
+              return false
+            }
+            return false
+          }}
         />
 
         {/* Top bar — after WebView so it renders on top */}

--- a/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
+++ b/apps/mobile/app/my-books/read/[bookId]/[chapterSlug].tsx
@@ -146,6 +146,9 @@ export default function UserBookReaderScreen() {
 
   useEffect(() => { if (chapter) startHideTimer() }, [chapter, startHideTimer])
 
+  // Clear pending hide-bars timer on unmount.
+  useEffect(() => () => { if (hideTimerRef.current) clearTimeout(hideTimerRef.current) }, [])
+
   const { updateProgress: updateSessionProgress, sessionStartedAt } = useReadingSession({
     editionId: null,
     userBookId: bookId || null,

--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -1101,15 +1101,48 @@ export default function ReaderScreen() {
           )
         )}
 
-        {/* Footer — progress bar + info */}
+        {/* Footer — progress bar + chevrons + chapter title + counter (PWA parity) */}
         <Animated.View style={[styles.footer, { backgroundColor: barBg, borderTopColor: barText + '15', paddingBottom: insets.bottom, opacity: barsAnim, transform: [{ translateY: footerTranslateY }] }]} pointerEvents={barsVisible ? 'auto' : 'none'}>
           <View style={[styles.progressBar, { backgroundColor: colors.border }]}>
             <View style={[styles.progressFill, { width: `${Math.round(progress * 100)}%`, backgroundColor: barText + '40' }]} />
           </View>
-          <Text style={[styles.footerProgress, { color: barText + '99', textAlign: 'center', paddingVertical: 8, paddingHorizontal: 16 }]}>
-            {Math.round(progress * 100)}%
-            {totalChapters > 1 && currentChapterIndex >= 0 ? `   ${currentChapterIndex + 1} / ${totalChapters}` : ''}
-          </Text>
+          <View style={styles.footerRow}>
+            <TouchableOpacity
+              onPress={() => chapter?.prev && navigateChapter(chapter.prev.slug)}
+              disabled={!chapter?.prev}
+              style={styles.chevronBtn}
+              accessibilityLabel="Previous chapter"
+              accessibilityRole="button"
+            >
+              <Text style={[styles.chevron, { color: barText + (chapter?.prev ? 'CC' : '40') }]}>‹</Text>
+            </TouchableOpacity>
+
+            <View style={styles.footerInfo}>
+              <Text style={[styles.footerChapter, { color: barText }]} numberOfLines={1}>
+                {chapter?.title || ''}
+              </Text>
+              <View style={styles.footerMeta}>
+                {totalChapters > 1 && currentChapterIndex >= 0 && (
+                  <Text style={[styles.footerCounter, { color: barText + '99' }]}>
+                    {currentChapterIndex + 1} / {totalChapters}
+                  </Text>
+                )}
+                <Text style={[styles.footerPercent, { color: barText + '99' }]}>
+                  {Math.round(progress * 100)}%
+                </Text>
+              </View>
+            </View>
+
+            <TouchableOpacity
+              onPress={() => chapter?.next && navigateChapter(chapter.next.slug)}
+              disabled={!chapter?.next}
+              style={styles.chevronBtn}
+              accessibilityLabel="Next chapter"
+              accessibilityRole="button"
+            >
+              <Text style={[styles.chevron, { color: barText + (chapter?.next ? 'CC' : '40') }]}>›</Text>
+            </TouchableOpacity>
+          </View>
         </Animated.View>
 
         {/* First-run tap-to-save hint — self-gated by AsyncStorage flag */}
@@ -1322,7 +1355,14 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
     elevation: 2,
   },
-  footerProgress: { fontSize: 14, fontFamily: fonts.sans, fontVariant: ['tabular-nums'] },
+  footerRow: { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 4, paddingVertical: 4, minHeight: 48 },
+  chevronBtn: { width: 44, height: 44, justifyContent: 'center', alignItems: 'center' },
+  chevron: { fontSize: 28, fontFamily: fonts.sans, lineHeight: 28 },
+  footerInfo: { flex: 1, alignItems: 'center', paddingHorizontal: 4 },
+  footerChapter: { fontSize: 13, fontFamily: fonts.sansMedium, fontWeight: '500' as const, textAlign: 'center' },
+  footerMeta: { flexDirection: 'row', alignItems: 'center', gap: 12, marginTop: 2 },
+  footerCounter: { fontSize: 11, fontFamily: fonts.sans, fontVariant: ['tabular-nums'] },
+  footerPercent: { fontSize: 11, fontFamily: fonts.sans, fontVariant: ['tabular-nums'] },
   progressBar: { height: 4, borderRadius: 0 },
   progressFill: { height: 4, borderRadius: 0 },
   // Exit summary

--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
-import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Animated } from 'react-native'
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Animated, AppState } from 'react-native'
 import { WebView } from 'react-native-webview'
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router'
 import { createBooksApi, readingProgressApi, bookmarksApi, vocabularyApi, highlightsApi, translationApi, t } from '@textstack/shared'
@@ -344,6 +344,17 @@ export default function ReaderScreen() {
   // Save progress when leaving reader
   useEffect(() => {
     return () => { saveProgress() }
+  }, [saveProgress])
+
+  // Save progress when the app backgrounds. On Android, Home-button +
+  // OS-kill path skips useEffect cleanup, so the final scroll position
+  // would be lost. AppState fires on home/background; we flush now so
+  // the next launch resumes at the right place.
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', state => {
+      if (state === 'background' || state === 'inactive') saveProgress()
+    })
+    return () => sub.remove()
   }, [saveProgress])
 
   const handleMessage = useCallback((event: any) => {

--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -950,7 +950,7 @@ export default function ReaderScreen() {
   return (
     <>
       <Stack.Screen options={{ headerShown: false }} />
-      <StatusBar hidden={!barsVisible} />
+      <StatusBar hidden={!barsVisible} style={settings.theme === 'dark' ? 'light' : 'dark'} />
       <View style={[styles.container, { backgroundColor: barBg }]}>
         {/* Reader WebView — rendered first so overlay bars sit on top */}
         <WebView
@@ -978,6 +978,17 @@ export default function ReaderScreen() {
           androidLayerType="hardware"
           overScrollMode="never"
           bounces={false}
+          // Suppress the native Copy/Share/Web-Search callout that
+          // pops up on long-press. We already render our own
+          // SelectionToolbar above the selection (Translate / Define /
+          // TTS / Highlight / Save word); the native menu is just
+          // visual duplication on both iOS and Android.
+          menuItems={[]}
+          // We build a fresh inline HTML string each chapter mount
+          // and bake the overlay script into it — there is no shared
+          // cached document to reuse across mounts. Skip the WebView
+          // cache to sidestep Android's stale-injection risk.
+          cacheEnabled={false}
           // Block navigation. The WebView loads an inline HTML string;
           // tapping a link inside the book (footnote anchor, external
           // URL, img src) would navigate the WebView, wiping our

--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -651,12 +651,13 @@ export default function ReaderScreen() {
 
   const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Auto-dismiss timer on unmount: user taps Exit → sees 5s summary →
-  // backgrounds the app or screen unmounts → timer fires router.back()
-  // on a stale navigation context.
+  // Clear pending timers on unmount.
+  // - exitTimerRef: 5s summary auto-dismiss → router.back() on stale nav.
+  // - hideTimerRef: 3s chrome auto-hide → setState on unmounted tree.
   useEffect(() => {
     return () => {
       if (exitTimerRef.current) clearTimeout(exitTimerRef.current)
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current)
     }
   }, [])
 

--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -476,7 +476,7 @@ export default function ReaderScreen() {
     } catch (err) {
       if (__DEV__) console.warn('[reader] postMessage handler threw', err, event?.nativeEvent?.data)
     }
-  }, [chapter, settings.autoLookup, isAuthenticated, toggleBars, showBars, hideBars, notifyWordSaved])
+  }, [chapter, isAuthenticated, language, nativeLanguage, settings.ttsSpeed, toggleTts, toggleBars, showBars, hideBars, notifyWordSaved, showToast])
 
   const navigateChapter = (slug: string) => {
     saveProgress()
@@ -650,6 +650,15 @@ export default function ReaderScreen() {
   }
 
   const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Auto-dismiss timer on unmount: user taps Exit → sees 5s summary →
+  // backgrounds the app or screen unmounts → timer fires router.back()
+  // on a stale navigation context.
+  useEffect(() => {
+    return () => {
+      if (exitTimerRef.current) clearTimeout(exitTimerRef.current)
+    }
+  }, [])
 
   const handleExit = () => {
     saveProgress()

--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
-import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Animated, AppState } from 'react-native'
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Animated, AppState, Linking } from 'react-native'
 import { WebView } from 'react-native-webview'
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router'
 import { createBooksApi, readingProgressApi, bookmarksApi, vocabularyApi, highlightsApi, translationApi, t } from '@textstack/shared'
@@ -977,6 +977,21 @@ export default function ReaderScreen() {
           // hardware layer so Chromium composites the page on the GPU.
           androidLayerType="hardware"
           overScrollMode="never"
+          bounces={false}
+          // Block navigation. The WebView loads an inline HTML string;
+          // tapping a link inside the book (footnote anchor, external
+          // URL, img src) would navigate the WebView, wiping our
+          // injected overlay script + rendered chapter. Allow only the
+          // initial document load + in-page anchors (#id).
+          onShouldStartLoadWithRequest={(req) => {
+            const { url, navigationType } = req
+            if (url === 'about:blank' || url.startsWith('data:') || url.startsWith('file:')) return true
+            if (navigationType === 'click' && (url.startsWith('http://') || url.startsWith('https://'))) {
+              Linking.openURL(url).catch(() => {})
+              return false
+            }
+            return false
+          }}
         />
 
         {/* Top bar — rendered after WebView so it's on top of native layer */}

--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -972,6 +972,11 @@ export default function ReaderScreen() {
           originWhitelist={['*']}
           scrollEnabled
           showsVerticalScrollIndicator={false}
+          // Android WebView defaults to a software-rendered view layer —
+          // visible jank on the reader's long scrolling content. Force a
+          // hardware layer so Chromium composites the page on the GPU.
+          androidLayerType="hardware"
+          overScrollMode="never"
         />
 
         {/* Top bar — rendered after WebView so it's on top of native layer */}

--- a/apps/mobile/src/components/WordCard.tsx
+++ b/apps/mobile/src/components/WordCard.tsx
@@ -361,12 +361,12 @@ export function WordCard({
           {isAuthenticated && !wordSaved && !stage && !lookupState && (
             <Animated.View style={{ transform: [{ scale: saveAnim }] }}>
               <TouchableOpacity
-                style={[styles.saveBtn, { backgroundColor: '#10B981' }]}
+                style={[styles.saveBtn, { backgroundColor: colors.primary }]}
                 onPress={() => { cancelAutoDismiss(); onSave() }}
                 accessibilityRole="button"
                 accessibilityLabel="Save word to vocabulary"
               >
-                <Ionicons name="add" size={18} color="#fff" />
+                <Ionicons name="add" size={16} color="#fff" />
                 <Text style={styles.saveBtnText}>Save</Text>
               </TouchableOpacity>
             </Animated.View>
@@ -465,7 +465,7 @@ const styles = StyleSheet.create({
     fontSize: 18,
   },
   phonetic: {
-    fontFamily: fonts.sans,
+    fontFamily: 'Courier',
     fontSize: 13,
   },
   stageBadge: {
@@ -543,13 +543,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-    borderRadius: 20,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 6,
   },
   saveBtnText: {
     fontFamily: fonts.sansMedium,
-    fontSize: 14,
+    fontSize: 13,
     color: '#fff',
   },
   sessionCount: {

--- a/apps/mobile/src/lib/readerHtml.ts
+++ b/apps/mobile/src/lib/readerHtml.ts
@@ -64,6 +64,9 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
       word-wrap: break-word;
       overflow-wrap: break-word;
       -webkit-text-size-adjust: none;
+      -webkit-user-select: text;
+      user-select: text;
+      -webkit-touch-callout: default;
     }
     /* Aged book edge shadows — matches PWA */
     body::before {
@@ -524,11 +527,16 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
       var target = e.target;
       if (target.tagName === 'A' || target.closest('a')) return;
 
-      // Short tap with an active selection in the DOM — that's a prior
-      // long-press selection or a leftover single-word range. Collapse
-      // it so the next tap-to-select can fire cleanly.
+      // Short tap with an active selection in the DOM. selectWordAtPoint
+      // never touches the Selection API, so any non-collapsed selection
+      // here came from a native long-press drag. Preserve multi-word /
+      // long selections (the user just spent effort building them);
+      // only collapse short single-word leftovers so the next tap can
+      // fire word-select cleanly.
       var sel = window.getSelection();
       if (sel && !sel.isCollapsed) {
+        var selText = sel.toString().trim();
+        if (selText.indexOf(' ') !== -1 || selText.length > 30) return;
         sel.removeAllRanges();
         return;
       }
@@ -919,11 +927,28 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
     }
     function vhlUseNew() { return vhlIsSupported() && !vhlKillswitchSet(); }
 
+    // Word-boundary check using a unicode letter/number class.
+    var VHL_WORDCHAR_RE = /[\\p{L}\\p{N}]/u;
+
     // Pure: TreeWalker → Range objects. No DOM mutation. Rejects SCRIPT/STYLE
-    // and the translation overlay subtree (data-vocab-overlay).
+    // and the translation overlay subtree (data-vocab-overlay). Matches both
+    // single-word and multi-word phrase keys (longest-first to avoid overlap).
     function vhlCompute(vocabMap) {
       var out = [];
       if (!vocabMap) return out;
+
+      // Split keys by whitespace presence: single tokens hit the regex pass,
+      // phrases hit the substring-scan pass first (longest first).
+      var singleKeys = {};
+      var phraseKeys = [];
+      for (var k in vocabMap) {
+        if (!Object.prototype.hasOwnProperty.call(vocabMap, k)) continue;
+        var lk = k.toLowerCase();
+        if (lk.indexOf(' ') === -1) singleKeys[lk] = vocabMap[k];
+        else phraseKeys.push({ key: lk, entry: vocabMap[k] });
+      }
+      phraseKeys.sort(function(a, b) { return b.key.length - a.key.length; });
+
       var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
         acceptNode: function(n) {
           var p = n.parentElement;
@@ -938,16 +963,51 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
       while (node = walker.nextNode()) {
         var text = node.textContent;
         if (!text || !text.trim()) continue;
+        var lower = text.toLowerCase();
+        var occupied = phraseKeys.length > 0 ? new Uint8Array(text.length) : null;
+
+        // Phrase pass — longest first; word-boundary on both ends; skip
+        // if the span overlaps an already-claimed phrase region.
+        for (var p = 0; p < phraseKeys.length; p++) {
+          var phr = phraseKeys[p];
+          var search = 0;
+          while (true) {
+            var idx = lower.indexOf(phr.key, search);
+            if (idx === -1) break;
+            var endIdx = idx + phr.key.length;
+            var beforeOk = idx === 0 || !VHL_WORDCHAR_RE.test(text.charAt(idx - 1));
+            var afterOk = endIdx >= text.length || !VHL_WORDCHAR_RE.test(text.charAt(endIdx));
+            if (beforeOk && afterOk) {
+              var collide = false;
+              for (var oi = idx; oi < endIdx; oi++) {
+                if (occupied[oi]) { collide = true; break; }
+              }
+              if (!collide) {
+                try {
+                  var rng = document.createRange();
+                  rng.setStart(node, idx);
+                  rng.setEnd(node, endIdx);
+                  out.push({ range: rng, stage: phr.entry.stage, key: phr.key, translation: phr.entry.translation || null });
+                  for (var oj = idx; oj < endIdx; oj++) occupied[oj] = 1;
+                } catch (e) {}
+              }
+            }
+            search = idx + 1;
+          }
+        }
+
+        // Single-word pass — skip indices already claimed by a phrase match.
         VHL_WORD_RE.lastIndex = 0;
         var m;
         while (m = VHL_WORD_RE.exec(text)) {
-          var lower = m[0].toLowerCase();
-          var entry = vocabMap[lower];
-          if (!entry) continue;
+          if (occupied && occupied[m.index]) continue;
+          var sLower = m[0].toLowerCase();
+          var sEntry = singleKeys[sLower];
+          if (!sEntry) continue;
           var range = document.createRange();
           try { range.setStart(node, m.index); range.setEnd(node, m.index + m[0].length); }
           catch (e) { continue; }
-          out.push({ range: range, stage: entry.stage, key: lower, translation: entry.translation || null });
+          out.push({ range: range, stage: sEntry.stage, key: sLower, translation: sEntry.translation || null });
         }
       }
       return out;
@@ -1243,8 +1303,12 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
       // Drop duplicates — if the user re-selected the exact same text (e.g.
       // iOS magnifier re-firing), don't re-render the popup.
       if (text === _lastDispatchedText) return;
-      // Single word pulse
-      if (!text.includes(' ') && text.length <= 50) applyTapPulse(sel);
+      // No tap-pulse here. range.surroundContents() mutates the DOM under
+      // the live Selection — Android aborts the long-press extension when
+      // the selection's text node gets split mid-drag, so the user only
+      // ever gets one word. selectWordAtPoint paints its own pulse via
+      // applyTapPulseRange (which doesn't touch Selection); long-press
+      // already has the native handles for visual feedback.
       var sentence = '';
       try { sentence = extractSentence(sel.anchorNode); } catch(e) {}
       var anchor = null;

--- a/apps/mobile/src/lib/readerHtml.ts
+++ b/apps/mobile/src/lib/readerHtml.ts
@@ -500,28 +500,37 @@ export function buildReaderHtml(chapterHtml: string, theme: ReaderTheme = defaul
     var lastTapTime = 0;
     var tapTimeout = null;
     var touchStartX = 0, touchStartY = 0;
+    var touchStartTime = 0;
     document.addEventListener('touchstart', function(e) {
       touchStartX = e.changedTouches[0].clientX;
       touchStartY = e.changedTouches[0].clientY;
+      touchStartTime = Date.now();
     }, { passive: true });
     document.addEventListener('touchend', function(e) {
       var tx = e.changedTouches[0].clientX;
       var ty = e.changedTouches[0].clientY;
       var dx = tx - touchStartX;
       var dy = ty - touchStartY;
+      var dur = Date.now() - touchStartTime;
       if (Math.abs(dx) > 10 || Math.abs(dy) > 10) return; // scroll, not tap
+      // Long-press: Android/iOS create a multi-word selection during the
+      // hold, then fire touchend on release. If we treat that touchend as
+      // a tap and call removeAllRanges() we destroy the selection the
+      // user just made. selectionchange already dispatched it to RN, so
+      // bail out here and let the native handles + RN SelectionActionBar
+      // own the lifecycle. 350ms is below Android's 500ms long-press
+      // threshold but above any plausible normal tap.
+      if (dur > 350) return;
       var target = e.target;
       if (target.tagName === 'A' || target.closest('a')) return;
 
-      // Dismiss any native multi-word selection first. Single-word
-      // selections (ours from a prior tap) should NOT block re-tapping
-      // a different word — we'll just re-select below.
+      // Short tap with an active selection in the DOM — that's a prior
+      // long-press selection or a leftover single-word range. Collapse
+      // it so the next tap-to-select can fire cleanly.
       var sel = window.getSelection();
       if (sel && !sel.isCollapsed) {
-        var txt = sel.toString().trim();
-        var isMulti = txt.indexOf(' ') !== -1 || txt.length > 40;
         sel.removeAllRanges();
-        if (isMulti) return; // user dismissing a long-press selection
+        return;
       }
 
       // Highlight tap just fired — skip word-select so a single tap doesn't


### PR DESCRIPTION
## Summary
Polish pass on the mobile reader before this week's Android Play Store submission. 10 commits accumulated.

| Commit | What |
|---|---|
| `b1ff96f` | fix multi-word selection (drop tap-pulse from selectionchange) + phrase-key vocab underlines (longest-first match) |
| `a1a7de2` | WordCard cosmetic parity w/ web WordPopup |
| `efa2e15` | footer parity w/ PWA — chevrons + chapter title + counter + percent |
| `a791a78` | preserve long-press selection on touchend (don't collapse multi-word) |
| `6902eea` | kill native selection callout + theme-aware status bar + disable cache |
| `656e41c` | intercept in-book navigation + disable iOS bounce |
| `13be861` | hardware-composited WebView on Android + no overscroll glow |
| `edc4cd3` | flush progress on AppState background |
| `a670d90` | clear hideBars timer on unmount |
| `a7a8764` | exit-timer cleanup + message handler deps |

Both library reader and user-book reader updated where applicable.

## Why now
Audit pass + tonight's CELPIP vocab import surfaced two real bugs:
- multi-word selection killed by `range.surroundContents()` in selectionchange (DOM mutation aborted Android long-press extension)
- imported CELPIP phrases never underlined — single-token regex couldn't match "From my perspective"-style entries

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] CI green
- [ ] On real Android device after EAS quota resets (May 1):
  - [ ] long-press a sentence → drag handles → multi-word selection survives → SelectionToolbar shows
  - [ ] reader vocabulary contains CELPIP phrases → phrases underlined + Russian translation visible above (when inline-translations on)
  - [ ] tap a single word → WordCard opens, native menu suppressed
  - [ ] background → kill from recents → reopen: progress + highlights restored