### PR TITLE
web reader: phrase-key vocab underlines (parity w/ mobile)

### DIFF
--- a/apps/web/src/lib/vocabHighlightEngine.test.ts
+++ b/apps/web/src/lib/vocabHighlightEngine.test.ts
@@ -162,6 +162,92 @@ describe('computeVocabMatches', () => {
     })
     expect(matches[0].translation).toBeNull()
   })
+
+  describe('multi-word phrase keys', () => {
+    it('matches a phrase across word boundaries', () => {
+      root.textContent = 'From my perspective, this is fine.'
+      const map = mkMap([['from my perspective', { stage: 0, translation: 'с моей точки зрения' }]])
+      const matches = computeVocabMatches(root, { vocabMap: map })
+      expect(matches).toHaveLength(1)
+      expect(matches[0].key).toBe('from my perspective')
+      expect(matches[0].range.toString()).toBe('From my perspective')
+      expect(matches[0].translation).toBe('с моей точки зрения')
+    })
+
+    it('matches case-insensitively', () => {
+      root.textContent = 'FROM MY PERSPECTIVE this works'
+      const map = mkMap([['from my perspective', { stage: 1 }]])
+      const matches = computeVocabMatches(root, { vocabMap: map })
+      expect(matches).toHaveLength(1)
+      expect(matches[0].range.toString()).toBe('FROM MY PERSPECTIVE')
+    })
+
+    it('respects word boundaries (rejects partial matches)', () => {
+      root.textContent = 'unfortunate make sense ofthese ideas'
+      const map = mkMap([['make sense of', { stage: 0 }]])
+      const matches = computeVocabMatches(root, { vocabMap: map })
+      // "make sense of" is followed by "t" → no afterOk → reject
+      expect(matches).toHaveLength(0)
+    })
+
+    it('prefers the longer phrase when phrases overlap', () => {
+      root.textContent = 'I want to make sense of this'
+      const map = mkMap([
+        ['make sense', { stage: 0 }],
+        ['make sense of', { stage: 1 }],
+      ])
+      const matches = computeVocabMatches(root, { vocabMap: map })
+      expect(matches).toHaveLength(1)
+      expect(matches[0].key).toBe('make sense of')
+      expect(matches[0].range.toString()).toBe('make sense of')
+    })
+
+    it('matches multiple occurrences of the same phrase', () => {
+      root.textContent = 'on the other hand foo on the other hand bar'
+      const map = mkMap([['on the other hand', { stage: 0 }]])
+      const matches = computeVocabMatches(root, { vocabMap: map })
+      expect(matches).toHaveLength(2)
+      expect(matches.every((m) => m.range.toString() === 'on the other hand')).toBe(true)
+    })
+
+    it('still matches single-token entries that fall outside the phrase span', () => {
+      root.textContent = 'A case in point is the fox'
+      const map = mkMap([
+        ['a case in point is', { stage: 0 }],
+        ['fox', { stage: 2 }],
+      ])
+      const matches = computeVocabMatches(root, { vocabMap: map })
+      expect(matches).toHaveLength(2)
+      expect(matches.find((m) => m.key === 'a case in point is')).toBeTruthy()
+      expect(matches.find((m) => m.key === 'fox')).toBeTruthy()
+    })
+
+    it('does not double-match tokens inside a claimed phrase span', () => {
+      root.textContent = 'I want to make sense of this'
+      const map = mkMap([
+        ['make sense of', { stage: 0 }],
+        ['sense', { stage: 0 }],
+        ['of', { stage: 0 }],
+      ])
+      const matches = computeVocabMatches(root, { vocabMap: map })
+      // "sense" and "of" are claimed by the phrase; "make" was never in the map
+      expect(matches).toHaveLength(1)
+      expect(matches[0].key).toBe('make sense of')
+    })
+
+    it('mixes phrases and single tokens in one document', () => {
+      root.innerHTML = '<p>Conversely, this stems from a different premise.</p>'
+      const map = mkMap([
+        ['this stems from', { stage: 0, translation: 'это происходит из-за' }],
+        ['conversely', { stage: 1, translation: 'напротив' }],
+      ])
+      const matches = computeVocabMatches(root, { vocabMap: map })
+      expect(matches).toHaveLength(2)
+      expect(new Set(matches.map((m) => m.key))).toEqual(
+        new Set(['this stems from', 'conversely']),
+      )
+    })
+  })
 })
 
 describe('groupByHighlight', () => {

--- a/apps/web/src/lib/vocabHighlightEngine.ts
+++ b/apps/web/src/lib/vocabHighlightEngine.ts
@@ -76,8 +76,16 @@ export interface ComputeOptions {
   activeBubble?: ActiveBubbleSnapshot | null
 }
 
+// Word-boundary char class — matches the unicode set tokenizeVocabWords uses,
+// so phrase boundaries align with single-token boundaries (no overlap surprises).
+const WORDCHAR_RE = /[\p{L}\p{M}\p{N}]/u
+
 // Walk text nodes → for each tokenized word that's in vocabMap (or is the
-// active bubble), create a Range covering just that word.
+// active bubble), create a Range covering just that word. Multi-word phrase
+// keys (those containing whitespace) match first via case-insensitive
+// substring scan, longest-first; the single-token pass skips any indices
+// already claimed by a phrase so "make sense" never double-matches as
+// "make" + "sense".
 export function computeVocabMatches(
   container: Node | null | undefined,
   { vocabMap, activeBubble }: ComputeOptions,
@@ -91,14 +99,66 @@ export function computeVocabMatches(
   const matches: WordMatch[] = []
   const textNodes = collectTextNodes(container)
 
+  // Split keys into single-token vs phrase. Phrases sorted longest-first so
+  // "in spite of" claims its span before "spite" can short-match.
+  const phraseKeys: { key: string; entry: { stage: number; translation?: string | null } }[] = []
+  for (const [k, v] of vocabMap.entries()) {
+    if (k.indexOf(' ') !== -1) phraseKeys.push({ key: k, entry: v })
+  }
+  phraseKeys.sort((a, b) => b.key.length - a.key.length)
+
   for (const textNode of textNodes) {
     const text = textNode.data
     if (!text || !text.trim()) continue
+
+    const lower = text.normalize('NFC').toLowerCase()
+    const occupied: Uint8Array | null =
+      phraseKeys.length > 0 ? new Uint8Array(text.length) : null
+
+    if (occupied) {
+      for (const phr of phraseKeys) {
+        let search = 0
+        while (search <= lower.length - phr.key.length) {
+          const idx = lower.indexOf(phr.key, search)
+          if (idx === -1) break
+          const endIdx = idx + phr.key.length
+          const beforeOk = idx === 0 || !WORDCHAR_RE.test(text.charAt(idx - 1))
+          const afterOk = endIdx >= text.length || !WORDCHAR_RE.test(text.charAt(endIdx))
+          if (beforeOk && afterOk) {
+            let collide = false
+            for (let i = idx; i < endIdx; i++) {
+              if (occupied[i]) { collide = true; break }
+            }
+            if (!collide) {
+              const range = doc.createRange()
+              try {
+                range.setStart(textNode, idx)
+                range.setEnd(textNode, endIdx)
+                matches.push({
+                  key: phr.key,
+                  word: text.slice(idx, endIdx),
+                  stage: phr.entry.stage,
+                  translation: phr.entry.translation ?? null,
+                  range,
+                  isActive: false,
+                })
+                for (let i = idx; i < endIdx; i++) occupied[i] = 1
+              } catch {
+                // setStart/setEnd may throw if the text node was mutated mid-walk.
+                // Skip this match and continue — the next call will retry.
+              }
+            }
+          }
+          search = idx + 1
+        }
+      }
+    }
 
     const tokens = tokenizeVocabWords(text)
     if (tokens.length === 0) continue
 
     for (const tok of tokens) {
+      if (occupied && occupied[tok.start]) continue
       const key = normalizeVocabKey(tok.word)
       const entry = vocabMap.get(key)
       const isActive = !entry && activeKey !== null && key === activeKey


### PR DESCRIPTION
## Summary
Mirror of mobile fix `b1ff96f` (PR #158). `computeVocabMatches` now matches multi-word phrase keys before single tokens, so imported CELPIP-style phrases ("from my perspective", "make sense of", "this stems from") underline + show inline translation in the web reader.

## Why
Tonight's CELPIP Band 9 import added 154 mostly-multi-word entries. Mobile shipped the phrase matcher; web was still single-token-only, so the same vocab paint silent-dropped them.

## Algorithm
1. Split keys: phrases (have whitespace) vs single tokens.
2. Phrase pass per text node: longest-first; case-insensitive `indexOf`; word-boundary check (unicode letter/number class) on both ends; `Uint8Array` occupied-bitset prevents shorter phrases / single tokens from claiming a span the longer match already owns.
3. Single-token pass unchanged, except it skips `tok.start` when occupied.

## Test plan
- [x] `pnpm -C apps/web test -- vocabHighlightEngine.test` — 26/26 (8 new)
- [x] `npx tsc --noEmit` clean
- [ ] Manual: open a public book in PWA logged in as user with CELPIP vocab → phrases visibly underlined + Russian translation shows above (when inline-translations on)

## Tests added
- matches a phrase across word boundaries
- case-insensitive match
- rejects partial / mid-word matches
- prefers longer phrase when overlapping
- multiple occurrences of same phrase
- mixed phrase + single-token in one document
- no double-match of tokens inside a claimed phrase span