### PR TITLE
v3-03: library sidebar (source/tags/collections) behind myBooksV3.librarySidebar

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,7 @@ jobs:
           VITE_API_URL=/api VITE_STORAGE_URL=https://textstack.app VITE_CANONICAL_URL=https://textstack.app \
             VITE_FEATURE_MYBOOKSV3_HEADER_REFRAME=false \
             VITE_FEATURE_MYBOOKSV3_LIBRARY_SHELVES=false \
+            VITE_FEATURE_MYBOOKSV3_LIBRARY_SIDEBAR=false \
             pnpm build
 
       - name: Deploy containers

--- a/apps/mobile/app/(tabs)/library.tsx
+++ b/apps/mobile/app/(tabs)/library.tsx
@@ -19,6 +19,7 @@ import { SkeletonLoader } from '../../src/components/ui/SkeletonLoader'
 import { EmptyState } from '../../src/components/ui/EmptyState'
 import { ContinueReadingShelf } from '../../src/components/library/ContinueReadingShelf'
 import { LibraryShelves } from '../../src/components/library/LibraryShelves'
+import { LibrarySidebarDrawer, type LibrarySource } from '../../src/components/library/LibrarySidebarDrawer'
 import { BookStatusBadge } from '../../src/components/library/BookStatusBadge'
 import { GeneratedCover } from '../../src/components/library/GeneratedCover'
 import { FEATURES } from '../../src/lib/features'
@@ -54,6 +55,9 @@ export default function LibraryScreen() {
   const router = useRouter()
   const [tab, setTab] = useState<Tab>('saved')
   const [viewMode, setViewMode] = useState<ViewMode>('list')
+  const sidebarV3 = FEATURES.myBooksV3LibrarySidebar
+  const [source, setSource] = useState<LibrarySource>('all')
+  const [drawerOpen, setDrawerOpen] = useState(false)
   const [library, setLibrary] = useState<UserLibraryItem[]>([])
   const [userBooks, setUserBooks] = useState<UserBookDto[]>([])
   const [progressMap, setProgressMap] = useState<Record<string, ReadingProgressDto>>({})
@@ -161,8 +165,21 @@ export default function LibraryScreen() {
     )
   }
 
+  const effectiveTab: Tab = sidebarV3 && source === 'uploads' ? 'uploads'
+    : sidebarV3 && source === 'catalog' ? 'saved'
+    : tab
+  const showTabs = !sidebarV3 || source === 'all'
+
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
+      {sidebarV3 && (
+        <View style={styles.sidebarHeader}>
+          <TouchableOpacity onPress={() => setDrawerOpen(true)} hitSlop={10} style={styles.menuBtn}>
+            <Ionicons name="menu" size={20} color={colors.text} />
+            <Text style={[styles.menuBtnText, { color: colors.text }]}>{t('library.sidebar.open')}</Text>
+          </TouchableOpacity>
+        </View>
+      )}
       {user && (
         <Text style={[styles.emailText, { color: colors.textSecondary }]}>
           {user.isGuest ? getAnonymousReaderName(user.id) : user.email}
@@ -174,17 +191,20 @@ export default function LibraryScreen() {
         FEATURES.myBooksV2ContinueReading && <ContinueReadingShelf />
       )}
       <View style={{ flexDirection: 'row', alignItems: 'center', borderBottomWidth: 1, borderBottomColor: colors.border }}>
-        <View style={[styles.tabs, { flex: 1, borderBottomWidth: 0 }]}>
-          {([['saved', `Saved (${library.length})`], ['uploads', `Uploads (${userBooks.length})`]] as [Tab, string][]).map(([t, label]) => (
-            <TouchableOpacity
-              key={t}
-              style={[styles.tab, tab === t && { borderBottomColor: colors.primary, borderBottomWidth: 2 }]}
-              onPress={() => setTab(t)}
-            >
-              <Text style={[styles.tabText, { color: tab === t ? colors.primary : colors.textSecondary }]}>{label}</Text>
-            </TouchableOpacity>
-          ))}
-        </View>
+        {showTabs && (
+          <View style={[styles.tabs, { flex: 1, borderBottomWidth: 0 }]}>
+            {([['saved', `Saved (${library.length})`], ['uploads', `Uploads (${userBooks.length})`]] as [Tab, string][]).map(([t, label]) => (
+              <TouchableOpacity
+                key={t}
+                style={[styles.tab, tab === t && { borderBottomColor: colors.primary, borderBottomWidth: 2 }]}
+                onPress={() => setTab(t)}
+              >
+                <Text style={[styles.tabText, { color: tab === t ? colors.primary : colors.textSecondary }]}>{label}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        )}
+        {!showTabs && <View style={{ flex: 1 }} />}
         <View style={{ flexDirection: 'row', paddingRight: 10, gap: 2 }}>
           <TouchableOpacity onPress={() => toggleView('grid')} hitSlop={6} style={{ padding: 4 }}>
             <Ionicons name="grid-outline" size={18} color={viewMode === 'grid' ? colors.primary : colors.textSecondary} />
@@ -195,10 +215,23 @@ export default function LibraryScreen() {
         </View>
       </View>
 
-      {tab === 'saved' ? (
+      {effectiveTab === 'saved' ? (
         <SavedList library={library} setLibrary={setLibrary} progressMap={progressMap} setProgressMap={setProgressMap} refreshing={refreshing} onRefresh={onRefresh} viewMode={viewMode} />
       ) : (
         <UploadsList books={userBooks} refreshing={refreshing} onRefresh={onRefresh} viewMode={viewMode} />
+      )}
+      {sidebarV3 && (
+        <LibrarySidebarDrawer
+          visible={drawerOpen}
+          source={source}
+          counts={{ all: library.length + userBooks.length, uploads: userBooks.length, catalog: library.length }}
+          onSelect={(next) => {
+            setSource(next)
+            if (next === 'uploads') setTab('uploads')
+            else if (next === 'catalog') setTab('saved')
+          }}
+          onClose={() => setDrawerOpen(false)}
+        />
       )}
     </View>
   )
@@ -837,4 +870,13 @@ const styles = StyleSheet.create({
   rowDotsBtn: {
     paddingHorizontal: 10, alignSelf: 'center', justifyContent: 'center',
   },
+  sidebarHeader: {
+    flexDirection: 'row', alignItems: 'center',
+    paddingHorizontal: 14, paddingTop: 8,
+  },
+  menuBtn: {
+    flexDirection: 'row', alignItems: 'center', gap: 6,
+    paddingVertical: 6, paddingHorizontal: 10,
+  },
+  menuBtnText: { fontFamily: fonts.sansMedium, fontSize: 13 },
 })

--- a/apps/mobile/src/components/library/LibrarySidebarDrawer.tsx
+++ b/apps/mobile/src/components/library/LibrarySidebarDrawer.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef } from 'react'
+import { Animated, Modal, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { useTheme } from '../../context/ThemeContext'
+import { useLanguage } from '../../context/LanguageContext'
+import { fonts } from '../../theme/typography'
+
+export type LibrarySource = 'all' | 'uploads' | 'catalog'
+
+interface Props {
+  visible: boolean
+  source: LibrarySource
+  counts: { all: number; uploads: number; catalog: number }
+  onSelect: (next: LibrarySource) => void
+  onClose: () => void
+}
+
+const DRAWER_WIDTH = 280
+
+export function LibrarySidebarDrawer({ visible, source, counts, onSelect, onClose }: Props) {
+  const { colors } = useTheme()
+  const { t } = useLanguage()
+  const slide = useRef(new Animated.Value(-DRAWER_WIDTH)).current
+
+  useEffect(() => {
+    Animated.timing(slide, {
+      toValue: visible ? 0 : -DRAWER_WIDTH,
+      duration: 200,
+      useNativeDriver: true,
+    }).start()
+  }, [visible, slide])
+
+  const items: Array<{ key: LibrarySource; icon: keyof typeof Ionicons.glyphMap; label: string; count: number }> = [
+    { key: 'all', icon: 'book-outline', label: t('library.sidebar.all'), count: counts.all },
+    { key: 'uploads', icon: 'cloud-upload-outline', label: t('library.sidebar.uploads'), count: counts.uploads },
+    { key: 'catalog', icon: 'bookmark-outline', label: t('library.sidebar.catalog'), count: counts.catalog },
+  ]
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.backdrop} onPress={onClose} />
+      <Animated.View
+        style={[
+          styles.drawer,
+          { backgroundColor: colors.background, transform: [{ translateX: slide }] },
+        ]}
+      >
+        <View style={styles.header}>
+          <Text style={[styles.title, { color: colors.text }]}>{t('library.title')}</Text>
+          <TouchableOpacity onPress={onClose} hitSlop={10}>
+            <Ionicons name="close" size={22} color={colors.textSecondary} />
+          </TouchableOpacity>
+        </View>
+        {items.map((item) => {
+          const active = source === item.key
+          return (
+            <TouchableOpacity
+              key={item.key}
+              style={[
+                styles.item,
+                active && { backgroundColor: colors.primaryLight },
+              ]}
+              onPress={() => { onSelect(item.key); onClose() }}
+            >
+              <Ionicons name={item.icon} size={18} color={active ? colors.primary : colors.textSecondary} />
+              <Text style={[styles.label, { color: active ? colors.primary : colors.text }]} numberOfLines={1}>
+                {item.label}
+              </Text>
+              <Text style={[styles.count, { color: colors.textSecondary }]}>{item.count}</Text>
+            </TouchableOpacity>
+          )
+        })}
+      </Animated.View>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  backdrop: { ...StyleSheet.absoluteFillObject, backgroundColor: 'rgba(0,0,0,0.4)' },
+  drawer: {
+    position: 'absolute', top: 0, left: 0, bottom: 0, width: DRAWER_WIDTH,
+    paddingTop: 50, paddingHorizontal: 12,
+    shadowColor: '#000', shadowOffset: { width: 2, height: 0 }, shadowOpacity: 0.15, shadowRadius: 8, elevation: 6,
+  },
+  header: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    paddingHorizontal: 8, paddingBottom: 16,
+  },
+  title: { fontFamily: fonts.serifBold, fontSize: 20 },
+  item: {
+    flexDirection: 'row', alignItems: 'center', gap: 12,
+    paddingVertical: 10, paddingHorizontal: 12, borderRadius: 8, marginBottom: 4,
+  },
+  label: { flex: 1, fontFamily: fonts.sansMedium, fontSize: 15 },
+  count: { fontFamily: fonts.sans, fontSize: 13 },
+})

--- a/apps/mobile/src/lib/features.ts
+++ b/apps/mobile/src/lib/features.ts
@@ -23,6 +23,8 @@ export const FEATURES = {
   myBooksV3HeaderReframe: readBool(process.env.EXPO_PUBLIC_MYBOOKSV3_HEADER_REFRAME, false),
   // My Books v3 slice 02 — smart shelves at top of Library (4 shelves: Continue / Recently added / Quick reads / Finished this month).
   myBooksV3LibraryShelves: readBool(process.env.EXPO_PUBLIC_MYBOOKSV3_LIBRARY_SHELVES, false),
+  // My Books v3 slice 03 — Library sidebar drawer (source/tags/collections filters replace Saved/Uploads tabs).
+  myBooksV3LibrarySidebar: readBool(process.env.EXPO_PUBLIC_MYBOOKSV3_LIBRARY_SIDEBAR, false),
 } as const
 
 export type FeatureKey = keyof typeof FEATURES

--- a/apps/web/src/components/library/LibrarySidebar.tsx
+++ b/apps/web/src/components/library/LibrarySidebar.tsx
@@ -1,0 +1,163 @@
+import { useState } from 'react'
+import { useTranslation } from '../../hooks/useTranslation'
+import { useUserTags } from '../../hooks/useUserTags'
+import { useCollections } from '../../hooks/useCollections'
+import type { LibrarySource } from '../../hooks/useLibrarySource'
+
+const TAG_LIMIT = 10
+
+interface Counts {
+  all: number
+  uploads: number
+  catalog: number
+}
+
+interface Props {
+  source: LibrarySource
+  tag: string | null
+  collection: string | null
+  counts: Counts
+  onSourceChange: (next: LibrarySource) => void
+  onTagChange: (next: string | null) => void
+  onCollectionChange: (next: string | null) => void
+}
+
+export function LibrarySidebar({
+  source, tag, collection, counts,
+  onSourceChange, onTagChange, onCollectionChange,
+}: Props) {
+  const { t } = useTranslation()
+  const { tags } = useUserTags()
+  const { collections, create } = useCollections()
+  const [creatingCollection, setCreatingCollection] = useState(false)
+  const [newCollectionName, setNewCollectionName] = useState('')
+  const [busyCreate, setBusyCreate] = useState(false)
+
+  const visibleTags = tags.slice(0, TAG_LIMIT)
+  const moreTags = tags.length > TAG_LIMIT
+
+  const handleCreateCollection = async () => {
+    const trimmed = newCollectionName.trim()
+    if (!trimmed || busyCreate) return
+    setBusyCreate(true)
+    try {
+      const c = await create(trimmed)
+      onCollectionChange(c.id)
+      setNewCollectionName('')
+      setCreatingCollection(false)
+    } finally {
+      setBusyCreate(false)
+    }
+  }
+
+  const isSourceActive = (s: LibrarySource) => source === s && !tag && !collection
+
+  return (
+    <nav className="library-sidebar-v3" aria-label={t('library.title')}>
+      <div className="library-sidebar-v3__section">
+        <button
+          type="button"
+          className={`library-sidebar-v3__item ${isSourceActive('all') ? 'library-sidebar-v3__item--active' : ''}`}
+          onClick={() => onSourceChange('all')}
+        >
+          <span className="material-icons-outlined">book</span>
+          <span className="library-sidebar-v3__label">{t('library.sidebar.all')}</span>
+          <span className="library-sidebar-v3__count">{counts.all}</span>
+        </button>
+        <button
+          type="button"
+          className={`library-sidebar-v3__item ${isSourceActive('uploads') ? 'library-sidebar-v3__item--active' : ''}`}
+          onClick={() => onSourceChange('uploads')}
+        >
+          <span className="material-icons-outlined">file_upload</span>
+          <span className="library-sidebar-v3__label">{t('library.sidebar.uploads')}</span>
+          <span className="library-sidebar-v3__count">{counts.uploads}</span>
+        </button>
+        <button
+          type="button"
+          className={`library-sidebar-v3__item ${isSourceActive('catalog') ? 'library-sidebar-v3__item--active' : ''}`}
+          onClick={() => onSourceChange('catalog')}
+        >
+          <span className="material-icons-outlined">bookmark</span>
+          <span className="library-sidebar-v3__label">{t('library.sidebar.catalog')}</span>
+          <span className="library-sidebar-v3__count">{counts.catalog}</span>
+        </button>
+      </div>
+
+      {visibleTags.length > 0 && (
+        <div className="library-sidebar-v3__section">
+          <h3 className="library-sidebar-v3__heading">{t('library.sidebar.tags')}</h3>
+          {visibleTags.map((entry) => (
+            <button
+              key={entry.tag}
+              type="button"
+              className={`library-sidebar-v3__item library-sidebar-v3__item--tag ${tag === entry.tag ? 'library-sidebar-v3__item--active' : ''}`}
+              onClick={() => onTagChange(tag === entry.tag ? null : entry.tag)}
+            >
+              <span className="library-sidebar-v3__tag-dot" />
+              <span className="library-sidebar-v3__label">#{entry.tag}</span>
+              <span className="library-sidebar-v3__count">{entry.count}</span>
+            </button>
+          ))}
+          {moreTags && (
+            <button
+              type="button"
+              className="library-sidebar-v3__more"
+              onClick={() => onSourceChange('uploads')}
+            >
+              {t('library.sidebar.allTags')}
+            </button>
+          )}
+        </div>
+      )}
+
+      <div className="library-sidebar-v3__section">
+        <h3 className="library-sidebar-v3__heading">{t('library.sidebar.collections')}</h3>
+        {collections.map((c) => (
+          <button
+            key={c.id}
+            type="button"
+            className={`library-sidebar-v3__item library-sidebar-v3__item--collection ${collection === c.id ? 'library-sidebar-v3__item--active' : ''}`}
+            onClick={() => onCollectionChange(collection === c.id ? null : c.id)}
+          >
+            <span className={`library-sidebar-v3__collection-swatch library-sidebar-v3__collection-swatch--${c.color}`} />
+            <span className="library-sidebar-v3__label">{c.name}</span>
+            <span className="library-sidebar-v3__count">{c.count}</span>
+          </button>
+        ))}
+        {creatingCollection ? (
+          <form
+            className="library-sidebar-v3__new-form"
+            onSubmit={(e) => { e.preventDefault(); handleCreateCollection() }}
+          >
+            <input
+              type="text"
+              value={newCollectionName}
+              onChange={(e) => setNewCollectionName(e.target.value)}
+              placeholder={t('library.collections.newPlaceholder')}
+              maxLength={100}
+              autoFocus
+              disabled={busyCreate}
+            />
+            <div className="library-sidebar-v3__new-actions">
+              <button type="submit" disabled={busyCreate || !newCollectionName.trim()}>
+                {t('library.collections.add')}
+              </button>
+              <button type="button" onClick={() => { setCreatingCollection(false); setNewCollectionName('') }}>
+                ×
+              </button>
+            </div>
+          </form>
+        ) : (
+          <button
+            type="button"
+            className="library-sidebar-v3__more"
+            onClick={() => setCreatingCollection(true)}
+          >
+            {t('library.sidebar.newCollection')}
+          </button>
+        )}
+      </div>
+    </nav>
+  )
+}

--- a/apps/web/src/hooks/__tests__/useLibrarySource.test.tsx
+++ b/apps/web/src/hooks/__tests__/useLibrarySource.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { useLibrarySource } from '../useLibrarySource'
+
+const wrapper = (initial = '/library') => ({ children }: { children: ReactNode }) => (
+  <MemoryRouter initialEntries={[initial]}>{children}</MemoryRouter>
+)
+
+describe('useLibrarySource', () => {
+  it('defaults to all when no params', () => {
+    const { result } = renderHook(() => useLibrarySource(), { wrapper: wrapper() })
+    expect(result.current.source).toBe('all')
+    expect(result.current.tag).toBeNull()
+    expect(result.current.collection).toBeNull()
+  })
+
+  it('reads source from URL', () => {
+    const { result } = renderHook(() => useLibrarySource(), {
+      wrapper: wrapper('/library?source=uploads'),
+    })
+    expect(result.current.source).toBe('uploads')
+  })
+
+  it('reads catalog source', () => {
+    const { result } = renderHook(() => useLibrarySource(), {
+      wrapper: wrapper('/library?source=catalog'),
+    })
+    expect(result.current.source).toBe('catalog')
+  })
+
+  it('falls back to all for unknown source value', () => {
+    const { result } = renderHook(() => useLibrarySource(), {
+      wrapper: wrapper('/library?source=garbage'),
+    })
+    expect(result.current.source).toBe('all')
+  })
+
+  it('reads tag and collection from URL', () => {
+    const { result } = renderHook(() => useLibrarySource(), {
+      wrapper: wrapper('/library?tag=fantasy&collection=summer'),
+    })
+    expect(result.current.tag).toBe('fantasy')
+    expect(result.current.collection).toBe('summer')
+  })
+
+  it('setSource clears tag and collection', () => {
+    let location: { search: string } = { search: '' }
+    const Capture = () => { location = useLocation(); return null }
+    const w = ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={['/library?tag=foo&collection=bar']}>
+        <Capture />
+        {children}
+      </MemoryRouter>
+    )
+    const { result } = renderHook(() => useLibrarySource(), { wrapper: w })
+    act(() => result.current.setSource('uploads'))
+    expect(location.search).toBe('?source=uploads')
+  })
+
+  it('setSource(all) deletes source param', () => {
+    let location: { search: string } = { search: '' }
+    const Capture = () => { location = useLocation(); return null }
+    const w = ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={['/library?source=uploads']}>
+        <Capture />
+        {children}
+      </MemoryRouter>
+    )
+    const { result } = renderHook(() => useLibrarySource(), { wrapper: w })
+    act(() => result.current.setSource('all'))
+    expect(location.search).toBe('')
+  })
+
+  it('setTag clears collection but keeps source', () => {
+    let location: { search: string } = { search: '' }
+    const Capture = () => { location = useLocation(); return null }
+    const w = ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={['/library?source=uploads&collection=bar']}>
+        <Capture />
+        {children}
+      </MemoryRouter>
+    )
+    const { result } = renderHook(() => useLibrarySource(), { wrapper: w })
+    act(() => result.current.setTag('fantasy'))
+    expect(location.search).toContain('source=uploads')
+    expect(location.search).toContain('tag=fantasy')
+    expect(location.search).not.toContain('collection=')
+  })
+
+  it('setCollection clears tag', () => {
+    let location: { search: string } = { search: '' }
+    const Capture = () => { location = useLocation(); return null }
+    const w = ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={['/library?tag=foo']}>
+        <Capture />
+        {children}
+      </MemoryRouter>
+    )
+    const { result } = renderHook(() => useLibrarySource(), { wrapper: w })
+    act(() => result.current.setCollection('summer'))
+    expect(location.search).toContain('collection=summer')
+    expect(location.search).not.toContain('tag=foo')
+  })
+})

--- a/apps/web/src/hooks/useLibrarySource.ts
+++ b/apps/web/src/hooks/useLibrarySource.ts
@@ -1,0 +1,79 @@
+import { useCallback, useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
+
+export type LibrarySource = 'all' | 'uploads' | 'catalog'
+
+export interface LibrarySourceState {
+  source: LibrarySource
+  tag: string | null
+  collection: string | null
+  setSource: (next: LibrarySource) => void
+  setTag: (next: string | null) => void
+  setCollection: (next: string | null) => void
+}
+
+function readSource(value: string | null): LibrarySource {
+  if (value === 'uploads' || value === 'catalog') return value
+  return 'all'
+}
+
+export function useLibrarySource(): LibrarySourceState {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const source = readSource(searchParams.get('source'))
+  const tag = searchParams.get('tag') || null
+  const collection = searchParams.get('collection') || null
+
+  const update = useCallback(
+    (mutate: (sp: URLSearchParams) => void) => {
+      setSearchParams(
+        (prev) => {
+          const sp = new URLSearchParams(prev)
+          mutate(sp)
+          return sp
+        },
+        { replace: true },
+      )
+    },
+    [setSearchParams],
+  )
+
+  const setSource = useCallback(
+    (next: LibrarySource) => {
+      update((sp) => {
+        if (next === 'all') sp.delete('source')
+        else sp.set('source', next)
+        sp.delete('tag')
+        sp.delete('collection')
+      })
+    },
+    [update],
+  )
+
+  const setTag = useCallback(
+    (next: string | null) => {
+      update((sp) => {
+        if (next) sp.set('tag', next)
+        else sp.delete('tag')
+        sp.delete('collection')
+      })
+    },
+    [update],
+  )
+
+  const setCollection = useCallback(
+    (next: string | null) => {
+      update((sp) => {
+        if (next) sp.set('collection', next)
+        else sp.delete('collection')
+        sp.delete('tag')
+      })
+    },
+    [update],
+  )
+
+  return useMemo(
+    () => ({ source, tag, collection, setSource, setTag, setCollection }),
+    [source, tag, collection, setSource, setTag, setCollection],
+  )
+}

--- a/apps/web/src/lib/features.ts
+++ b/apps/web/src/lib/features.ts
@@ -9,5 +9,6 @@ export const features = {
   myBooksV3: {
     headerReframe: env('VITE_FEATURE_MYBOOKSV3_HEADER_REFRAME') ?? isDev,
     libraryShelves: env('VITE_FEATURE_MYBOOKSV3_LIBRARY_SHELVES') ?? isDev,
+    librarySidebar: env('VITE_FEATURE_MYBOOKSV3_LIBRARY_SIDEBAR') ?? isDev,
   },
 } as const

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -382,6 +382,20 @@
       "scrollLeft": "Scroll left",
       "scrollRight": "Scroll right"
     },
+    "sidebar": {
+      "all": "All books",
+      "uploads": "My uploads",
+      "catalog": "Bookmarked from catalog",
+      "tags": "Tags",
+      "collections": "Collections",
+      "allTags": "All tags →",
+      "newCollection": "+ New collection",
+      "open": "Open filters",
+      "close": "Close filters"
+    },
+    "tab": {
+      "bookmarked": "Bookmarked"
+    },
     "shelves": {
       "viewAll": "View all",
       "continueReading": {

--- a/apps/web/src/pages/LibraryPage.tsx
+++ b/apps/web/src/pages/LibraryPage.tsx
@@ -13,6 +13,8 @@ import { UploadSection } from '../components/library/UploadSection'
 import { UploadDropZone } from '../components/library/UploadDropZone'
 import { ContinueReadingShelf } from '../components/library/ContinueReadingShelf'
 import { LibraryShelves } from '../components/library/LibraryShelves'
+import { LibrarySidebar } from '../components/library/LibrarySidebar'
+import { useLibrarySource } from '../hooks/useLibrarySource'
 import { features } from '../lib/features'
 import { LibraryStatsHeader } from '../components/library/LibraryStatsHeader'
 import { LibrarySortMenu } from '../components/library/LibrarySortMenu'
@@ -54,6 +56,15 @@ export function LibraryPage() {
   const tabFromUrl = searchParams.get('tab')
   const initialTab: SidebarTab = tabFromUrl === 'uploads' ? 'uploads' : (isGuest ? 'uploads' : 'saved')
   const [activeTab, setActiveTab] = useState<SidebarTab>(initialTab)
+  const sidebarV3 = features.myBooksV3.librarySidebar
+  const librarySource = useLibrarySource()
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const showSavedBlock = sidebarV3
+    ? (librarySource.source === 'all' || librarySource.source === 'catalog')
+    : activeTab === 'saved'
+  const showUploadsBlock = sidebarV3
+    ? (librarySource.source === 'all' || librarySource.source === 'uploads')
+    : activeTab === 'uploads'
   const highlightedBookId = useHighlightedBook()
   const [userBooks, setUserBooks] = useState<UserBook[]>([])
   const [userBooksLoading, setUserBooksLoading] = useState(false)
@@ -113,7 +124,7 @@ export function LibraryPage() {
 
   // Content search (server-side FTS) — runs only when toggle is on and we have a query
   useEffect(() => {
-    if (activeTab !== 'uploads') return
+    if (!showUploadsBlock) return
     if (!uploadsContentSearch) { setContentHits(null); return }
     const parsed = parseQuery(uploadsQueryD)
     if (!parsed.text) { setContentHits(null); return }
@@ -124,7 +135,7 @@ export function LibraryPage() {
       .catch(err => { if (err?.name !== 'AbortError') setContentHits([]) })
       .finally(() => setContentLoading(false))
     return () => ctrl.abort()
-  }, [uploadsContentSearch, uploadsQueryD, activeTab])
+  }, [uploadsContentSearch, uploadsQueryD, showUploadsBlock])
 
   // Fetch user books
   const fetchUserBooks = useCallback(async () => {
@@ -300,30 +311,82 @@ export function LibraryPage() {
       <SeoHead title={t('library.title')} noindex />
 
       {/* Sidebar */}
-      <aside className="library-sidebar">
-        <div className="library-sidebar__inner">
-          <button
-            className={`library-sidebar__btn ${activeTab === 'saved' ? 'library-sidebar__btn--active' : ''}`}
-            onClick={() => setActiveTab('saved')}
-          >
-            <span className="material-icons-outlined">book</span>
-            <span>{t('library.saved')}</span>
-            {items.length > 0 && <span className="library-sidebar__count">{items.length}</span>}
-          </button>
-          <button
-            className={`library-sidebar__btn ${activeTab === 'uploads' ? 'library-sidebar__btn--active' : ''}`}
-            onClick={() => setActiveTab('uploads')}
-          >
-            <span className="material-icons-outlined">file_upload</span>
-            <span>{t('library.uploads')}</span>
-            {userBooks.length > 0 && <span className="library-sidebar__count">{userBooks.length}</span>}
-          </button>
-        </div>
-      </aside>
+      {sidebarV3 ? (
+        <>
+          {sidebarOpen && (
+            <div
+              className="library-sidebar-v3__backdrop"
+              onClick={() => setSidebarOpen(false)}
+              aria-hidden="true"
+            />
+          )}
+          <aside className={`library-sidebar-v3 ${sidebarOpen ? 'library-sidebar-v3--open' : ''}`}>
+            <LibrarySidebar
+              source={librarySource.source}
+              tag={librarySource.tag}
+              collection={librarySource.collection}
+              counts={{
+                all: items.length + userBooks.length,
+                uploads: userBooks.length,
+                catalog: items.length,
+              }}
+              onSourceChange={(s) => {
+                librarySource.setSource(s)
+                setSidebarOpen(false)
+                if (s === 'uploads') setActiveTab('uploads')
+                else if (s === 'catalog') setActiveTab('saved')
+              }}
+              onTagChange={(next) => {
+                librarySource.setTag(next)
+                setSidebarOpen(false)
+                onUploadTagSelect(next)
+                setActiveTab('uploads')
+              }}
+              onCollectionChange={(id) => {
+                librarySource.setCollection(id)
+                setSidebarOpen(false)
+                onCollectionChange(id)
+              }}
+            />
+          </aside>
+        </>
+      ) : (
+        <aside className="library-sidebar">
+          <div className="library-sidebar__inner">
+            <button
+              className={`library-sidebar__btn ${activeTab === 'saved' ? 'library-sidebar__btn--active' : ''}`}
+              onClick={() => setActiveTab('saved')}
+            >
+              <span className="material-icons-outlined">book</span>
+              <span>{t('library.saved')}</span>
+              {items.length > 0 && <span className="library-sidebar__count">{items.length}</span>}
+            </button>
+            <button
+              className={`library-sidebar__btn ${activeTab === 'uploads' ? 'library-sidebar__btn--active' : ''}`}
+              onClick={() => setActiveTab('uploads')}
+            >
+              <span className="material-icons-outlined">file_upload</span>
+              <span>{t('library.uploads')}</span>
+              {userBooks.length > 0 && <span className="library-sidebar__count">{userBooks.length}</span>}
+            </button>
+          </div>
+        </aside>
+      )}
 
       {/* Main Content */}
       <main className="library-main">
         <header className="library-header">
+          {sidebarV3 && (
+            <button
+              type="button"
+              className="library-sidebar-toggle"
+              onClick={() => setSidebarOpen(true)}
+              aria-label={t('library.sidebar.open')}
+            >
+              <span className="material-icons-outlined">menu</span>
+              {t('library.sidebar.open')}
+            </button>
+          )}
           <h1 className="library-header__title">{t('library.title')}</h1>
           {user && <p className="library-header__email">{user.email}</p>}
         </header>
@@ -338,7 +401,7 @@ export function LibraryPage() {
 
         <CollectionChips activeId={activeCollectionId} onSelect={onCollectionChange} />
 
-        {activeTab === 'saved' && (
+        {showSavedBlock && (
           <>
             {/* Toolbar */}
             <div className="library-toolbar">
@@ -523,7 +586,7 @@ export function LibraryPage() {
           </>
         )}
 
-        {activeTab === 'uploads' && (
+        {showUploadsBlock && (
           <>
             {showUploadModal && (
               <UploadSection onUploadComplete={() => { fetchUserBooks(); setShowUploadModal(false) }} />
@@ -738,7 +801,7 @@ export function LibraryPage() {
       </main>
 
       {/* FAB */}
-      {activeTab === 'uploads' && !selection.active && (
+      {showUploadsBlock && !selection.active && (
         <button
           className="library-fab"
           onClick={() => setShowUploadModal(true)}
@@ -748,7 +811,7 @@ export function LibraryPage() {
         </button>
       )}
 
-      {selection.active && activeTab === 'uploads' && (
+      {selection.active && showUploadsBlock && (
         <BulkActionBar
           count={selection.count}
           onCancel={selection.exit}

--- a/apps/web/src/styles/books.css
+++ b/apps/web/src/styles/books.css
@@ -4519,6 +4519,224 @@ html.dark .user-book-detail__spinner {
   background: var(--color-bg-card);
 }
 
+/* Sidebar v3 (slice 03 — source/tags/collections) */
+.library-sidebar-v3 {
+  position: sticky;
+  top: 112px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 220px;
+}
+
+.library-sidebar-v3__section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.library-sidebar-v3__heading {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  margin: 0 0 4px;
+  padding: 0 12px;
+}
+
+.library-sidebar-v3__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  background: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.library-sidebar-v3__item:hover {
+  background: var(--color-bg-secondary);
+  color: var(--color-text);
+}
+
+.library-sidebar-v3__item--active {
+  background: var(--color-bg-secondary);
+  color: var(--color-text);
+}
+
+.library-sidebar-v3__item .material-icons-outlined {
+  font-size: 18px;
+}
+
+.library-sidebar-v3__label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.library-sidebar-v3__count {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  background: transparent;
+  padding: 0 6px;
+  min-width: 24px;
+  text-align: right;
+}
+
+.library-sidebar-v3__item--active .library-sidebar-v3__count {
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.library-sidebar-v3__tag-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-accent, #5b8def);
+  flex-shrink: 0;
+  margin-left: 4px;
+}
+
+.library-sidebar-v3__collection-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  background: var(--color-border);
+  flex-shrink: 0;
+  margin-left: 4px;
+}
+
+.library-sidebar-v3__collection-swatch--blue { background: #5b8def; }
+.library-sidebar-v3__collection-swatch--green { background: #2bb673; }
+.library-sidebar-v3__collection-swatch--purple { background: #8b5cf6; }
+.library-sidebar-v3__collection-swatch--red { background: #ef4444; }
+.library-sidebar-v3__collection-swatch--orange { background: #f59e0b; }
+.library-sidebar-v3__collection-swatch--yellow { background: #eab308; }
+.library-sidebar-v3__collection-swatch--pink { background: #ec4899; }
+.library-sidebar-v3__collection-swatch--gray { background: var(--color-text-secondary); }
+
+.library-sidebar-v3__more {
+  display: block;
+  width: 100%;
+  padding: 6px 12px;
+  border: none;
+  background: none;
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--color-accent, #5b8def);
+  cursor: pointer;
+  text-align: left;
+}
+
+.library-sidebar-v3__more:hover {
+  background: var(--color-bg-secondary);
+}
+
+.library-sidebar-v3__new-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px 12px;
+}
+
+.library-sidebar-v3__new-form input {
+  padding: 6px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  font-size: 13px;
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+.library-sidebar-v3__new-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.library-sidebar-v3__new-actions button {
+  flex: 1;
+  padding: 4px 8px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  border-radius: 6px;
+  font-size: 12px;
+  cursor: pointer;
+  color: var(--color-text);
+}
+
+.library-sidebar-v3__new-actions button[type="submit"] {
+  background: var(--color-accent, #5b8def);
+  color: #fff;
+  border-color: var(--color-accent, #5b8def);
+}
+
+.library-sidebar-v3__new-actions button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Mobile drawer behavior — open via hamburger, slide from left */
+.library-sidebar-v3__backdrop {
+  display: none;
+}
+
+@media (max-width: 1024px) {
+  .library-sidebar-v3 {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 280px;
+    max-width: 85vw;
+    background: var(--color-bg);
+    z-index: 50;
+    padding: 24px 16px;
+    overflow-y: auto;
+    box-shadow: 2px 0 12px rgba(0, 0, 0, 0.15);
+    transform: translateX(-100%);
+    transition: transform 0.2s ease;
+  }
+  .library-sidebar-v3--open {
+    transform: translateX(0);
+  }
+  .library-sidebar-v3__backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 49;
+  }
+}
+
+.library-sidebar-toggle {
+  display: none;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  border-radius: 8px;
+  font-size: 13px;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+@media (max-width: 1024px) {
+  .library-sidebar-toggle {
+    display: inline-flex;
+  }
+}
+
 /* Main content */
 .library-main {
   flex: 1;

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -197,6 +197,20 @@
       "title": "Continue reading",
       "badge": "Continue"
     },
+    "sidebar": {
+      "all": "All books",
+      "uploads": "My uploads",
+      "catalog": "Bookmarked from catalog",
+      "tags": "Tags",
+      "collections": "Collections",
+      "allTags": "All tags →",
+      "newCollection": "+ New collection",
+      "open": "Open filters",
+      "close": "Close filters"
+    },
+    "tab": {
+      "bookmarked": "Bookmarked"
+    },
     "shelves": {
       "continueReading": { "title": "Continue reading", "subtitle": "Pick up where you left off" },
       "recentlyAdded": { "title": "Recently added", "subtitle": "New in your library" },


### PR DESCRIPTION
## Summary
- Web: LibrarySidebar replaces Saved/Uploads tabs with source filters (All / My uploads / Bookmarked from catalog) + tag list (top 10) + collections section with inline create. `useLibrarySource` syncs `?source/?tag/?collection`. Hamburger drawer on <1024px.
- Mobile: LibrarySidebarDrawer (Modal + Animated slide) with source filters. Tags/collections deferred (mobile lacks tag/collection UI today).
- Old tabs preserved when flag OFF; default OFF in prod (deploy.yml), ON in dev.

## Locked-in copy decision
- Sidebar entry says "Bookmarked from catalog" (`library.sidebar.catalog`).
- New tab key `library.tab.bookmarked` added; old `library.tab.saved` still in use until tabs disappear.
- DB column `saved_books`, API field names, analytics — unchanged.

## Test plan
- [x] `pnpm vitest run` — 402/403 pass (1 pre-existing NativeLanguageContext flake from slice 02; passes in isolation)
- [x] `pnpm vitest run useLibrarySource` — 9/9 pass (URL roundtrip, source/tag/collection clear semantics)
- [x] `pnpm build` (web) — clean
- [x] `npx tsc --noEmit` (mobile) — clean
- [x] Browser smoke `/en/library` — page loads, no console errors. Sidebar visual confirm requires sign-in (auth-gated, same constraint as slice 02).

## Out of scope (per slice doc)
- Status tabs (slice 04)
- "+" button menu (slice 05)
- Tag/collection management UIs (already in v2)
- Mobile tag/collection sidebar entries (follow-up — needs mobile tag UI first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)