### PR TITLE
v3 slice 04: status tabs as primary library filter (flag, prod=OFF)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,7 @@ jobs:
             VITE_FEATURE_MYBOOKSV3_HEADER_REFRAME=false \
             VITE_FEATURE_MYBOOKSV3_LIBRARY_SHELVES=false \
             VITE_FEATURE_MYBOOKSV3_LIBRARY_SIDEBAR=false \
+            VITE_FEATURE_MYBOOKSV3_STATUS_TABS_PRIMARY=false \
             pnpm build
 
       - name: Deploy containers

--- a/apps/mobile/app/(tabs)/library.tsx
+++ b/apps/mobile/app/(tabs)/library.tsx
@@ -28,6 +28,8 @@ import {
   useLibraryFilter, filterLibraryItems, filterUserBooks, countsForLibrary, countsForUploads,
 } from '../../src/hooks/useLibraryFilter'
 import { LibraryFilters } from '../../src/components/library/LibraryFilters'
+import { LibraryStatusTabs } from '../../src/components/library/LibraryStatusTabs'
+import { useLibraryStatus } from '../../src/hooks/useLibraryStatus'
 import { useLibrarySearch } from '../../src/hooks/useLibrarySearch'
 import { matchesQuery } from '../../src/lib/searchUtils'
 import { LibrarySearch } from '../../src/components/library/LibrarySearch'
@@ -257,7 +259,11 @@ function SavedList({ library, setLibrary, progressMap, setProgressMap, refreshin
   const { t } = useLanguage()
   const { width } = useWindowDimensions()
   const { sort, setSort } = useLibrarySort('saved')
-  const { filter, setFilter } = useLibraryFilter('saved')
+  const { filter: filterRaw, setFilter: setFilterRaw } = useLibraryFilter('saved')
+  const statusTabsV3 = FEATURES.myBooksV3StatusTabsPrimary
+  const v3Status = useLibraryStatus()
+  const filter = statusTabsV3 ? v3Status.status : filterRaw
+  const setFilter = statusTabsV3 ? v3Status.setStatus : setFilterRaw
   const { query, debouncedQuery, setQuery, clear: clearQuery } = useLibrarySearch('saved')
   const counts = countsForLibrary(library, progressMap)
   const numColumns = viewMode === 'grid' ? Math.floor(width / 130) : 1
@@ -293,7 +299,11 @@ function SavedList({ library, setLibrary, progressMap, setProgressMap, refreshin
         ListHeaderComponent={
           <View>
             <LibrarySearch value={query} onChange={setQuery} onClear={clearQuery} />
-            <LibraryFilters value={filter} onChange={setFilter} counts={counts} />
+            {statusTabsV3 ? (
+              <LibraryStatusTabs value={filter} onChange={setFilter} counts={counts} />
+            ) : (
+              <LibraryFilters value={filter} onChange={setFilter} counts={counts} />
+            )}
             <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.savedSortRow}>
               {SORT_KEYS.map(key => (
                 <TouchableOpacity
@@ -454,7 +464,11 @@ function UploadsList({ books, refreshing, onRefresh, viewMode }: {
   const { show: showToast } = useToast()
   const { width } = useWindowDimensions()
   const { sort, setSort } = useLibrarySort('uploads')
-  const { filter, setFilter } = useLibraryFilter('uploads')
+  const { filter: filterRaw, setFilter: setFilterRaw } = useLibraryFilter('uploads')
+  const statusTabsV3 = FEATURES.myBooksV3StatusTabsPrimary
+  const v3Status = useLibraryStatus()
+  const filter = statusTabsV3 ? v3Status.status : filterRaw
+  const setFilter = statusTabsV3 ? v3Status.setStatus : setFilterRaw
   const { query, debouncedQuery, setQuery, clear: clearQuery } = useLibrarySearch('uploads')
   const counts = countsForUploads(books)
   const [quota, setQuota] = useState<{ usedBytes: number; limitBytes: number } | null>(null)
@@ -514,7 +528,11 @@ function UploadsList({ books, refreshing, onRefresh, viewMode }: {
       {books.length > 0 && (
         <>
           <LibrarySearch value={query} onChange={setQuery} onClear={clearQuery} />
-          <LibraryFilters value={filter} onChange={setFilter} counts={counts} />
+          {statusTabsV3 ? (
+            <LibraryStatusTabs value={filter} onChange={setFilter} counts={counts} />
+          ) : (
+            <LibraryFilters value={filter} onChange={setFilter} counts={counts} />
+          )}
         </>
       )}
 

--- a/apps/mobile/src/components/library/LibraryStatusTabs.tsx
+++ b/apps/mobile/src/components/library/LibraryStatusTabs.tsx
@@ -1,0 +1,110 @@
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native'
+import { useTheme } from '../../context/ThemeContext'
+import { useLanguage } from '../../context/LanguageContext'
+import { fonts } from '../../theme/typography'
+import type { LibraryStatus } from '../../hooks/useLibraryStatus'
+
+const PRIMARY: LibraryStatus[] = ['reading', 'finished', 'notStarted']
+
+interface Props {
+  value: LibraryStatus
+  onChange: (next: LibraryStatus) => void
+  counts: Record<LibraryStatus, number>
+}
+
+export function LibraryStatusTabs({ value, onChange, counts }: Props) {
+  const { colors } = useTheme()
+  const { t } = useLanguage()
+  const showFailed = counts.failed > 0
+
+  const renderTab = (key: LibraryStatus, secondary = false) => {
+    const active = value === key
+    return (
+      <TouchableOpacity
+        key={key}
+        onPress={() => onChange(key)}
+        style={[
+          styles.tab,
+          { borderBottomColor: active ? colors.text : 'transparent' },
+          secondary && styles.tabSecondary,
+        ]}
+        hitSlop={6}
+        accessibilityRole="tab"
+        accessibilityState={{ selected: active }}
+      >
+        <Text
+          style={{
+            fontFamily: fonts.sansMedium,
+            fontSize: secondary ? 12 : 13,
+            color: active ? colors.text : colors.textSecondary,
+            opacity: secondary && !active ? 0.75 : 1,
+          }}
+        >
+          {t(`library.status.${key}`)}
+        </Text>
+        <Text
+          style={[
+            styles.count,
+            {
+              color: active ? colors.text : colors.textSecondary,
+              backgroundColor: colors.surface,
+            },
+          ]}
+        >
+          {counts[key]}
+        </Text>
+      </TouchableOpacity>
+    )
+  }
+
+  return (
+    <View style={[styles.row, { borderBottomColor: colors.border }]}>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.primary}
+      >
+        {PRIMARY.map((k) => renderTab(k, false))}
+        {showFailed && renderTab('failed', false)}
+      </ScrollView>
+      <View style={styles.secondary}>{renderTab('all', true)}</View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 14,
+    borderBottomWidth: 1,
+  },
+  primary: {
+    flexDirection: 'row',
+    gap: 4,
+    alignItems: 'center',
+  },
+  secondary: {
+    marginLeft: 'auto',
+    paddingLeft: 8,
+  },
+  tab: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 12,
+    borderBottomWidth: 2,
+  },
+  tabSecondary: {
+    paddingHorizontal: 8,
+  },
+  count: {
+    fontFamily: fonts.sansBold,
+    fontSize: 11,
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+})

--- a/apps/mobile/src/hooks/useLibraryStatus.ts
+++ b/apps/mobile/src/hooks/useLibraryStatus.ts
@@ -1,0 +1,16 @@
+import { useCallback, useState } from 'react'
+import type { LibraryFilterKey } from './useLibraryFilter'
+
+export type LibraryStatus = LibraryFilterKey
+export const DEFAULT_STATUS: LibraryStatus = 'reading'
+
+export interface LibraryStatusState {
+  status: LibraryStatus
+  setStatus: (next: LibraryStatus) => void
+}
+
+export function useLibraryStatus(): LibraryStatusState {
+  const [status, setStatusState] = useState<LibraryStatus>(DEFAULT_STATUS)
+  const setStatus = useCallback((next: LibraryStatus) => setStatusState(next), [])
+  return { status, setStatus }
+}

--- a/apps/mobile/src/lib/features.ts
+++ b/apps/mobile/src/lib/features.ts
@@ -25,6 +25,8 @@ export const FEATURES = {
   myBooksV3LibraryShelves: readBool(process.env.EXPO_PUBLIC_MYBOOKSV3_LIBRARY_SHELVES, false),
   // My Books v3 slice 03 — Library sidebar drawer (source/tags/collections filters replace Saved/Uploads tabs).
   myBooksV3LibrarySidebar: readBool(process.env.EXPO_PUBLIC_MYBOOKSV3_LIBRARY_SIDEBAR, false),
+  // My Books v3 slice 04 — Status as primary horizontal tabs (Reading/Finished/Not started/Failed/All).
+  myBooksV3StatusTabsPrimary: readBool(process.env.EXPO_PUBLIC_MYBOOKSV3_STATUS_TABS_PRIMARY, false),
 } as const
 
 export type FeatureKey = keyof typeof FEATURES

--- a/apps/web/src/components/library/LibraryStatusTabs.tsx
+++ b/apps/web/src/components/library/LibraryStatusTabs.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from '../../hooks/useTranslation'
+import type { LibraryStatus } from '../../hooks/useLibraryStatus'
+
+const PRIMARY: LibraryStatus[] = ['reading', 'finished', 'notStarted']
+
+interface Props {
+  value: LibraryStatus
+  onChange: (next: LibraryStatus) => void
+  counts: Record<LibraryStatus, number>
+}
+
+export function LibraryStatusTabs({ value, onChange, counts }: Props) {
+  const { t } = useTranslation()
+  const showFailed = counts.failed > 0
+
+  const renderTab = (key: LibraryStatus, variant: 'primary' | 'secondary' = 'primary') => {
+    const active = value === key
+    return (
+      <button
+        key={key}
+        type="button"
+        role="tab"
+        aria-selected={active}
+        className={`library-status-tabs__tab library-status-tabs__tab--${variant} ${active ? 'library-status-tabs__tab--active' : ''}`}
+        onClick={() => onChange(key)}
+      >
+        <span className="library-status-tabs__label">{t(`library.status.${key}`)}</span>
+        <span className="library-status-tabs__count">{counts[key]}</span>
+      </button>
+    )
+  }
+
+  return (
+    <div className="library-status-tabs" role="tablist" aria-label={t('library.status.ariaLabel')}>
+      <div className="library-status-tabs__primary">
+        {PRIMARY.map((k) => renderTab(k, 'primary'))}
+        {showFailed && renderTab('failed', 'primary')}
+      </div>
+      <div className="library-status-tabs__secondary">
+        {renderTab('all', 'secondary')}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/library/__tests__/LibraryStatusTabs.test.tsx
+++ b/apps/web/src/components/library/__tests__/LibraryStatusTabs.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+
+vi.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}))
+
+import { LibraryStatusTabs } from '../LibraryStatusTabs'
+import type { LibraryStatus } from '../../../hooks/useLibraryStatus'
+
+afterEach(() => cleanup())
+
+const baseCounts: Record<LibraryStatus, number> = {
+  all: 12, reading: 3, finished: 4, notStarted: 5, failed: 0,
+}
+
+describe('LibraryStatusTabs', () => {
+  it('renders Reading / Finished / Not started / All; hides Failed when count=0', () => {
+    render(<LibraryStatusTabs value="reading" onChange={() => {}} counts={baseCounts} />)
+    expect(screen.getByText('library.status.reading')).toBeInTheDocument()
+    expect(screen.getByText('library.status.finished')).toBeInTheDocument()
+    expect(screen.getByText('library.status.notStarted')).toBeInTheDocument()
+    expect(screen.getByText('library.status.all')).toBeInTheDocument()
+    expect(screen.queryByText('library.status.failed')).toBeNull()
+  })
+
+  it('shows Failed tab when count > 0', () => {
+    render(<LibraryStatusTabs value="reading" onChange={() => {}} counts={{ ...baseCounts, failed: 2 }} />)
+    expect(screen.getByText('library.status.failed')).toBeInTheDocument()
+  })
+
+  it('marks active tab via aria-selected', () => {
+    render(<LibraryStatusTabs value="finished" onChange={() => {}} counts={baseCounts} />)
+    const tabs = screen.getAllByRole('tab')
+    const finishedTab = tabs.find(t => t.textContent?.includes('finished'))!
+    const readingTab = tabs.find(t => t.textContent?.includes('reading'))!
+    expect(finishedTab).toHaveAttribute('aria-selected', 'true')
+    expect(readingTab).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('calls onChange with selected status', () => {
+    const onChange = vi.fn()
+    render(<LibraryStatusTabs value="reading" onChange={onChange} counts={baseCounts} />)
+    fireEvent.click(screen.getByText('library.status.finished'))
+    expect(onChange).toHaveBeenCalledWith('finished')
+  })
+
+  it('renders counts beside labels', () => {
+    render(<LibraryStatusTabs value="reading" onChange={() => {}} counts={baseCounts} />)
+    expect(screen.getByText('3')).toBeInTheDocument() // reading
+    expect(screen.getByText('4')).toBeInTheDocument() // finished
+    expect(screen.getByText('5')).toBeInTheDocument() // notStarted
+    expect(screen.getByText('12')).toBeInTheDocument() // all
+  })
+})

--- a/apps/web/src/hooks/__tests__/useLibraryStatus.test.tsx
+++ b/apps/web/src/hooks/__tests__/useLibraryStatus.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { useLibraryStatus, DEFAULT_STATUS } from '../useLibraryStatus'
+
+const wrapper = (initial = '/library') => ({ children }: { children: ReactNode }) => (
+  <MemoryRouter initialEntries={[initial]}>{children}</MemoryRouter>
+)
+
+describe('useLibraryStatus', () => {
+  it('defaults to reading when no status param', () => {
+    const { result } = renderHook(() => useLibraryStatus(), { wrapper: wrapper() })
+    expect(result.current.status).toBe('reading')
+    expect(DEFAULT_STATUS).toBe('reading')
+  })
+
+  it('reads valid status values from URL', () => {
+    for (const v of ['all', 'reading', 'finished', 'notStarted', 'failed'] as const) {
+      const { result } = renderHook(() => useLibraryStatus(), {
+        wrapper: wrapper(`/library?status=${v}`),
+      })
+      expect(result.current.status).toBe(v)
+    }
+  })
+
+  it('falls back to reading for unknown status value', () => {
+    const { result } = renderHook(() => useLibraryStatus(), {
+      wrapper: wrapper('/library?status=garbage'),
+    })
+    expect(result.current.status).toBe('reading')
+  })
+
+  it('setStatus(non-default) writes status param', () => {
+    let location: { search: string } = { search: '' }
+    const Capture = () => { location = useLocation(); return null }
+    const w = ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={['/library']}>
+        <Capture />
+        {children}
+      </MemoryRouter>
+    )
+    const { result } = renderHook(() => useLibraryStatus(), { wrapper: w })
+    act(() => result.current.setStatus('finished'))
+    expect(location.search).toBe('?status=finished')
+  })
+
+  it('setStatus(reading) deletes status param (default cleanup)', () => {
+    let location: { search: string } = { search: '' }
+    const Capture = () => { location = useLocation(); return null }
+    const w = ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={['/library?status=finished']}>
+        <Capture />
+        {children}
+      </MemoryRouter>
+    )
+    const { result } = renderHook(() => useLibraryStatus(), { wrapper: w })
+    act(() => result.current.setStatus('reading'))
+    expect(location.search).toBe('')
+  })
+
+  it('preserves other URL params on setStatus', () => {
+    let location: { search: string } = { search: '' }
+    const Capture = () => { location = useLocation(); return null }
+    const w = ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={['/library?source=uploads&tag=fantasy']}>
+        <Capture />
+        {children}
+      </MemoryRouter>
+    )
+    const { result } = renderHook(() => useLibraryStatus(), { wrapper: w })
+    act(() => result.current.setStatus('failed'))
+    expect(location.search).toContain('source=uploads')
+    expect(location.search).toContain('tag=fantasy')
+    expect(location.search).toContain('status=failed')
+  })
+})

--- a/apps/web/src/hooks/useLibraryStatus.ts
+++ b/apps/web/src/hooks/useLibraryStatus.ts
@@ -1,0 +1,40 @@
+import { useCallback, useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import type { LibraryFilterKey } from './useLibraryFilter'
+
+export type LibraryStatus = LibraryFilterKey
+export const DEFAULT_STATUS: LibraryStatus = 'reading'
+
+const VALID: LibraryStatus[] = ['all', 'reading', 'finished', 'notStarted', 'failed']
+
+function readStatus(value: string | null): LibraryStatus {
+  if (!value) return DEFAULT_STATUS
+  return (VALID as string[]).includes(value) ? (value as LibraryStatus) : DEFAULT_STATUS
+}
+
+export interface LibraryStatusState {
+  status: LibraryStatus
+  setStatus: (next: LibraryStatus) => void
+}
+
+export function useLibraryStatus(): LibraryStatusState {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const status = readStatus(searchParams.get('status'))
+
+  const setStatus = useCallback(
+    (next: LibraryStatus) => {
+      setSearchParams(
+        (prev) => {
+          const sp = new URLSearchParams(prev)
+          if (next === DEFAULT_STATUS) sp.delete('status')
+          else sp.set('status', next)
+          return sp
+        },
+        { replace: true },
+      )
+    },
+    [setSearchParams],
+  )
+
+  return useMemo(() => ({ status, setStatus }), [status, setStatus])
+}

--- a/apps/web/src/lib/features.ts
+++ b/apps/web/src/lib/features.ts
@@ -10,5 +10,6 @@ export const features = {
     headerReframe: env('VITE_FEATURE_MYBOOKSV3_HEADER_REFRAME') ?? isDev,
     libraryShelves: env('VITE_FEATURE_MYBOOKSV3_LIBRARY_SHELVES') ?? isDev,
     librarySidebar: env('VITE_FEATURE_MYBOOKSV3_LIBRARY_SIDEBAR') ?? isDev,
+    statusTabsPrimary: env('VITE_FEATURE_MYBOOKSV3_STATUS_TABS_PRIMARY') ?? isDev,
   },
 } as const

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -443,6 +443,21 @@
       "empty": "No books match this filter",
       "clear": "Clear filter"
     },
+    "status": {
+      "reading": "Reading",
+      "finished": "Finished",
+      "notStarted": "Not started",
+      "failed": "Failed",
+      "all": "All",
+      "empty": {
+        "reading": "Open a book to start reading",
+        "finished": "Finish your first book this month",
+        "notStarted": "Looking good — you're on top of your library",
+        "failed": "These uploads need attention",
+        "all": "No books match this filter"
+      },
+      "ariaLabel": "Filter by status"
+    },
     "search": {
       "placeholder": "Search your library…",
       "empty": "No books match \"{query}\"",

--- a/apps/web/src/pages/LibraryPage.tsx
+++ b/apps/web/src/pages/LibraryPage.tsx
@@ -19,11 +19,13 @@ import { features } from '../lib/features'
 import { LibraryStatsHeader } from '../components/library/LibraryStatsHeader'
 import { LibrarySortMenu } from '../components/library/LibrarySortMenu'
 import { LibraryFilters } from '../components/library/LibraryFilters'
+import { LibraryStatusTabs } from '../components/library/LibraryStatusTabs'
 import { LibrarySearch } from '../components/library/LibrarySearch'
 import { useLibrarySort, sortLibraryItems, sortUserBooks } from '../hooks/useLibrarySort'
 import {
   useLibraryFilter, filterLibraryItems, filterUserBooks, countsForLibrary, countsForUploads,
 } from '../hooks/useLibraryFilter'
+import { useLibraryStatus } from '../hooks/useLibraryStatus'
 import { useLibrarySearch } from '../hooks/useLibrarySearch'
 import { matchesQuery, parseQuery } from '../lib/searchUtils'
 import { useUserTags } from '../hooks/useUserTags'
@@ -73,8 +75,14 @@ export function LibraryPage() {
   })
   const { sort: savedSort, setSort: setSavedSort } = useLibrarySort('saved')
   const { sort: uploadsSort, setSort: setUploadsSort } = useLibrarySort('uploads')
-  const { filter: savedFilter, setFilter: setSavedFilter } = useLibraryFilter('saved')
-  const { filter: uploadsFilter, setFilter: setUploadsFilter } = useLibraryFilter('uploads')
+  const { filter: savedFilterRaw, setFilter: setSavedFilterRaw } = useLibraryFilter('saved')
+  const { filter: uploadsFilterRaw, setFilter: setUploadsFilterRaw } = useLibraryFilter('uploads')
+  const statusTabsV3 = features.myBooksV3.statusTabsPrimary
+  const v3Status = useLibraryStatus()
+  const savedFilter = statusTabsV3 ? v3Status.status : savedFilterRaw
+  const setSavedFilter = statusTabsV3 ? v3Status.setStatus : setSavedFilterRaw
+  const uploadsFilter = statusTabsV3 ? v3Status.status : uploadsFilterRaw
+  const setUploadsFilter = statusTabsV3 ? v3Status.setStatus : setUploadsFilterRaw
   const { query: savedQuery, debouncedQuery: savedQueryD, setQuery: setSavedQuery, clear: clearSavedQuery } = useLibrarySearch('saved')
   const {
     query: uploadsQuery, debouncedQuery: uploadsQueryD, setQuery: setUploadsQuery, clear: clearUploadsQuery,
@@ -429,7 +437,11 @@ export function LibraryPage() {
             {items.length > 0 && (
               <>
                 <LibrarySearch value={savedQuery} onChange={setSavedQuery} />
-                <LibraryFilters value={savedFilter} onChange={setSavedFilter} counts={savedCounts} />
+                {statusTabsV3 ? (
+                  <LibraryStatusTabs value={savedFilter} onChange={setSavedFilter} counts={savedCounts} />
+                ) : (
+                  <LibraryFilters value={savedFilter} onChange={setSavedFilter} counts={savedCounts} />
+                )}
               </>
             )}
 
@@ -632,14 +644,22 @@ export function LibraryPage() {
                   contentSearch={uploadsContentSearch}
                   onToggleContentSearch={setUploadsContentSearch}
                 />
-                <LibraryFilters
-                  value={uploadsFilter}
-                  onChange={setUploadsFilter}
-                  counts={uploadsCounts}
-                  tags={userTags}
-                  activeTag={activeUploadTag}
-                  onTagClick={onUploadTagSelect}
-                />
+                {statusTabsV3 ? (
+                  <LibraryStatusTabs
+                    value={uploadsFilter}
+                    onChange={setUploadsFilter}
+                    counts={uploadsCounts}
+                  />
+                ) : (
+                  <LibraryFilters
+                    value={uploadsFilter}
+                    onChange={setUploadsFilter}
+                    counts={uploadsCounts}
+                    tags={userTags}
+                    activeTag={activeUploadTag}
+                    onTagClick={onUploadTagSelect}
+                  />
+                )}
               </>
             )}
 

--- a/apps/web/src/styles/books.css
+++ b/apps/web/src/styles/books.css
@@ -5018,6 +5018,89 @@ html.dark .user-book-detail__spinner {
   .library-filters__chip { flex-shrink: 0; }
 }
 
+/* My Books v3 — status tabs (slice 04) */
+.library-status-tabs {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.library-status-tabs__primary {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.library-status-tabs__secondary {
+  display: flex;
+  flex-shrink: 0;
+}
+
+.library-status-tabs__tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.15s ease, border-color 0.15s ease;
+  white-space: nowrap;
+}
+
+.library-status-tabs__tab:hover {
+  color: var(--color-text);
+}
+
+.library-status-tabs__tab--active {
+  color: var(--color-text);
+  border-bottom-color: var(--color-text);
+}
+
+.library-status-tabs__tab--secondary {
+  font-size: 13px;
+  padding: 10px 10px;
+  opacity: 0.75;
+}
+
+.library-status-tabs__tab--secondary.library-status-tabs__tab--active {
+  opacity: 1;
+}
+
+.library-status-tabs__count {
+  font-size: 12px;
+  font-weight: 600;
+  opacity: 0.7;
+  padding: 1px 6px;
+  border-radius: 10px;
+  background: var(--color-bg-secondary);
+}
+
+.library-status-tabs__tab--active .library-status-tabs__count {
+  opacity: 1;
+}
+
+@media (max-width: 768px) {
+  .library-status-tabs {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+  .library-status-tabs::-webkit-scrollbar { display: none; }
+  .library-status-tabs__primary { gap: 2px; }
+  .library-status-tabs__tab { padding: 10px 10px; font-size: 13px; flex-shrink: 0; }
+  .library-status-tabs__tab--secondary { padding: 10px 8px; }
+}
+
 /* View toggle */
 .library-view-btn {
   display: flex;

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -245,6 +245,21 @@
       "empty": "No books match this filter",
       "clear": "Clear filter"
     },
+    "status": {
+      "reading": "Reading",
+      "finished": "Finished",
+      "notStarted": "Not started",
+      "failed": "Failed",
+      "all": "All",
+      "empty": {
+        "reading": "Open a book to start reading",
+        "finished": "Finish your first book this month",
+        "notStarted": "Looking good — you're on top of your library",
+        "failed": "These uploads need attention",
+        "all": "No books match this filter"
+      },
+      "ariaLabel": "Filter by status"
+    },
     "search": {
       "placeholder": "Search your library…",
       "empty": "No books match \"{query}\"",


### PR DESCRIPTION
## Summary
- New `LibraryStatusTabs` component (web + mobile) — Reading / Finished / Not started / [Failed] / All as primary horizontal tabs.
- `useLibraryStatus` hook — URL-synced (`?status=…`) on web, local state on mobile. Default = `reading`.
- Wired into `LibraryPage` (web) and `library.tsx` (mobile) behind feature flags; falls back to legacy `LibraryFilters` chips when flags off.

## Behaviour
- Failed tab hidden when `count === 0`.
- `All` rendered as smaller secondary tab on the right (matches v3 IA spec).
- Web URL: `?status=reading` is the default and gets stripped from the query (clean URL); other values persist.
- Other URL params (source/tag/collection) preserved on status change.

## Flags
- web: `VITE_FEATURE_MYBOOKSV3_STATUS_TABS_PRIMARY` (default `isDev`, prod = `false` via `deploy.yml`)
- mobile: `EXPO_PUBLIC_MYBOOKSV3_STATUS_TABS_PRIMARY` (default `false`)

## Test plan
- [x] vitest: `useLibraryStatus.test.tsx` (6) + `LibraryStatusTabs.test.tsx` (5) — all green.
- [x] Full vitest suite: 413/414 (1 pre-existing `NativeLanguageContext` flake, not introduced here).
- [x] `pnpm -C apps/web build` clean.
- [x] `tsc --noEmit` clean for web + mobile.
- [ ] Smoke: dev server with flag ON → tabs render, click switches active tab + writes URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)