### PR TITLE
v3 slice 05: + button becomes add-menu (flag, prod=OFF)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,7 @@ jobs:
             VITE_FEATURE_MYBOOKSV3_LIBRARY_SHELVES=false \
             VITE_FEATURE_MYBOOKSV3_LIBRARY_SIDEBAR=false \
             VITE_FEATURE_MYBOOKSV3_STATUS_TABS_PRIMARY=false \
+            VITE_FEATURE_MYBOOKSV3_ADD_MENU=false \
             pnpm build
 
       - name: Deploy containers

--- a/apps/mobile/src/components/UploadTabButton.tsx
+++ b/apps/mobile/src/components/UploadTabButton.tsx
@@ -1,34 +1,54 @@
+import { useState } from 'react'
 import { TouchableOpacity, View, StyleSheet, Platform } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { useRouter } from 'expo-router'
 import { useTheme } from '../context/ThemeContext'
 import { useAuth } from '../context/AuthContext'
+import { FEATURES } from '../lib/features'
+import { AddMenuBottomSheet } from './library/AddMenuBottomSheet'
 
 export function UploadTabButton() {
   const { colors } = useTheme()
   const { isAuthenticated } = useAuth()
   const router = useRouter()
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const addMenu = FEATURES.myBooksV3AddMenu
+
+  const goUpload = () => router.push('/my-books/upload')
 
   const onPress = () => {
     if (!isAuthenticated) {
       router.push('/auth/login')
       return
     }
-    router.push('/my-books/upload')
+    if (addMenu) {
+      setSheetOpen(true)
+    } else {
+      goUpload()
+    }
   }
 
   return (
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessibilityLabel="Upload"
-      onPress={onPress}
-      activeOpacity={0.85}
-      style={styles.wrapper}
-    >
-      <View style={[styles.button, { backgroundColor: colors.primary, shadowColor: colors.text }]}>
-        <Ionicons name="add" size={28} color="#fff" />
-      </View>
-    </TouchableOpacity>
+    <>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Upload"
+        onPress={onPress}
+        activeOpacity={0.85}
+        style={styles.wrapper}
+      >
+        <View style={[styles.button, { backgroundColor: colors.primary, shadowColor: colors.text }]}>
+          <Ionicons name="add" size={28} color="#fff" />
+        </View>
+      </TouchableOpacity>
+      {addMenu && (
+        <AddMenuBottomSheet
+          visible={sheetOpen}
+          onClose={() => setSheetOpen(false)}
+          onUpload={goUpload}
+        />
+      )}
+    </>
   )
 }
 

--- a/apps/mobile/src/components/library/AddMenuBottomSheet.tsx
+++ b/apps/mobile/src/components/library/AddMenuBottomSheet.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useRef } from 'react'
+import { Animated, Modal, Pressable, StyleSheet, Text, TouchableOpacity, View, Linking } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { useRouter } from 'expo-router'
+import { useTheme } from '../../context/ThemeContext'
+import { useLanguage } from '../../context/LanguageContext'
+import { fonts } from '../../theme/typography'
+
+interface Props {
+  visible: boolean
+  onClose: () => void
+  onUpload: () => void
+}
+
+interface Item {
+  key: string
+  icon: keyof typeof Ionicons.glyphMap
+  labelKey: string
+  comingSoon?: boolean
+  onPress?: () => void
+}
+
+const SHEET_MAX_HEIGHT = 420
+
+export function AddMenuBottomSheet({ visible, onClose, onUpload }: Props) {
+  const { colors } = useTheme()
+  const { t } = useLanguage()
+  const router = useRouter()
+  const slide = useRef(new Animated.Value(SHEET_MAX_HEIGHT)).current
+
+  useEffect(() => {
+    Animated.timing(slide, {
+      toValue: visible ? 0 : SHEET_MAX_HEIGHT,
+      duration: 220,
+      useNativeDriver: true,
+    }).start()
+  }, [visible, slide])
+
+  const handle = (cb?: () => void) => () => {
+    onClose()
+    cb?.()
+  }
+
+  const items: Array<Item | { divider: true; key: string }> = [
+    { key: 'upload', icon: 'cloud-upload-outline', labelKey: 'addMenu.uploadFile', onPress: onUpload },
+    { key: 'url', icon: 'link-outline', labelKey: 'addMenu.pasteUrl', comingSoon: true },
+    { key: 'email', icon: 'mail-outline', labelKey: 'addMenu.emailBook', comingSoon: true },
+    { key: 'd1', divider: true },
+    {
+      key: 'extension',
+      icon: 'extension-puzzle-outline',
+      labelKey: 'addMenu.browserExtension',
+      onPress: () => Linking.openURL('https://chromewebstore.google.com').catch(() => {}),
+    },
+    { key: 'd2', divider: true },
+    {
+      key: 'browse',
+      icon: 'book-outline',
+      labelKey: 'addMenu.browseAll',
+      onPress: () => router.push('/(tabs)/search'),
+    },
+  ]
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.backdrop} onPress={onClose} />
+      <Animated.View
+        style={[
+          styles.sheet,
+          {
+            backgroundColor: colors.background,
+            transform: [{ translateY: slide }],
+            borderTopColor: colors.border,
+          },
+        ]}
+      >
+        <View style={styles.handle} />
+        <View style={styles.headerRow}>
+          <Text style={[styles.title, { color: colors.text }]}>{t('addMenu.title')}</Text>
+          <TouchableOpacity onPress={onClose} hitSlop={10}>
+            <Ionicons name="close" size={22} color={colors.textSecondary} />
+          </TouchableOpacity>
+        </View>
+        {items.map((entry) => {
+          if ('divider' in entry) {
+            return <View key={entry.key} style={[styles.divider, { backgroundColor: colors.border }]} />
+          }
+          const disabled = !!entry.comingSoon
+          return (
+            <TouchableOpacity
+              key={entry.key}
+              style={styles.item}
+              disabled={disabled}
+              onPress={handle(entry.onPress)}
+              activeOpacity={0.7}
+              accessibilityRole="menuitem"
+              accessibilityState={{ disabled }}
+            >
+              <Ionicons
+                name={entry.icon}
+                size={22}
+                color={disabled ? colors.textSecondary : colors.text}
+                style={{ opacity: disabled ? 0.55 : 1 }}
+              />
+              <Text
+                style={[
+                  styles.label,
+                  {
+                    color: disabled ? colors.textSecondary : colors.text,
+                    fontStyle: disabled ? 'italic' : 'normal',
+                  },
+                ]}
+              >
+                {t(entry.labelKey)}
+              </Text>
+              {disabled && (
+                <Text style={[styles.badge, { backgroundColor: colors.surface, color: colors.textSecondary }]}>
+                  {t('addMenu.comingSoon')}
+                </Text>
+              )}
+            </TouchableOpacity>
+          )
+        })}
+      </Animated.View>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  backdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.4)' },
+  sheet: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    borderTopWidth: 1,
+    paddingBottom: 32,
+    paddingTop: 8,
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: 'rgba(0,0,0,0.18)',
+    marginBottom: 8,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 18,
+    paddingVertical: 8,
+  },
+  title: { fontFamily: fonts.sansBold, fontSize: 16 },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+    paddingHorizontal: 18,
+    paddingVertical: 14,
+  },
+  label: { flex: 1, fontFamily: fonts.sansMedium, fontSize: 15 },
+  divider: { height: 1, marginVertical: 4, marginHorizontal: 18 },
+  badge: {
+    fontFamily: fonts.sansMedium,
+    fontSize: 10,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+    overflow: 'hidden',
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  },
+})

--- a/apps/mobile/src/lib/features.ts
+++ b/apps/mobile/src/lib/features.ts
@@ -27,6 +27,8 @@ export const FEATURES = {
   myBooksV3LibrarySidebar: readBool(process.env.EXPO_PUBLIC_MYBOOKSV3_LIBRARY_SIDEBAR, false),
   // My Books v3 slice 04 — Status as primary horizontal tabs (Reading/Finished/Not started/Failed/All).
   myBooksV3StatusTabsPrimary: readBool(process.env.EXPO_PUBLIC_MYBOOKSV3_STATUS_TABS_PRIMARY, false),
+  // My Books v3 slice 05 — `+` button becomes a menu (Upload / coming-soon items / Browse all).
+  myBooksV3AddMenu: readBool(process.env.EXPO_PUBLIC_MYBOOKSV3_ADD_MENU, false),
 } as const
 
 export type FeatureKey = keyof typeof FEATURES

--- a/apps/web/e2e/tests/reader-progress.spec.ts
+++ b/apps/web/e2e/tests/reader-progress.spec.ts
@@ -130,12 +130,12 @@ test.describe('QA-001: Reading Progress', () => {
     // Wait for auto-save
     await page.waitForTimeout(5000)
 
-    // Check library
-    await page.goto('/en/library')
+    // Check library — pin both legacy & v3 filter params to 'all' so the
+    // default 'reading' tab (slice 04) doesn't race with progressMap fetch.
+    await page.goto('/en/library?filter=all&status=all')
     await page.waitForLoadState('networkidle')
 
     const libraryItems = page.locator('.library-list-item, .library-card')
-    const count = await libraryItems.count()
-    expect(count).toBeGreaterThan(0)
+    await expect(libraryItems.first()).toBeVisible({ timeout: 10_000 })
   })
 })

--- a/apps/web/src/components/library/AddMenu.tsx
+++ b/apps/web/src/components/library/AddMenu.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useLanguage } from '../../context/LanguageContext'
+import { useTranslation } from '../../hooks/useTranslation'
+
+interface MenuItem {
+  key: string
+  icon: string
+  label: string
+  shortcut?: string
+  comingSoon?: boolean
+  onSelect?: () => void
+  divider?: false
+}
+
+interface Divider { key: string; divider: true }
+type MenuEntry = MenuItem | Divider
+
+interface Props {
+  onUpload: () => void
+  triggerLabel: string
+  triggerTitle: string
+  triggerClassName?: string
+}
+
+export function AddMenu({ onUpload, triggerLabel, triggerTitle, triggerClassName }: Props) {
+  const { t } = useTranslation()
+  const { getLocalizedPath } = useLanguage()
+  const navigate = useNavigate()
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  const close = useCallback(() => setOpen(false), [])
+
+  useEffect(() => {
+    if (!open) return
+    const onDoc = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) close()
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        close()
+        triggerRef.current?.focus()
+      }
+    }
+    document.addEventListener('mousedown', onDoc)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDoc)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open, close])
+
+  const handle = (cb?: () => void) => () => {
+    close()
+    cb?.()
+  }
+
+  const entries: MenuEntry[] = [
+    {
+      key: 'upload',
+      icon: 'upload_file',
+      label: t('addMenu.uploadFile'),
+      shortcut: t('addMenu.uploadShortcut'),
+      onSelect: onUpload,
+    },
+    { key: 'url', icon: 'link', label: t('addMenu.pasteUrl'), comingSoon: true },
+    { key: 'email', icon: 'mail_outline', label: t('addMenu.emailBook'), comingSoon: true },
+    { key: 'd1', divider: true },
+    {
+      key: 'extension',
+      icon: 'extension',
+      label: t('addMenu.browserExtension'),
+      onSelect: () => window.open('https://chromewebstore.google.com', '_blank', 'noopener,noreferrer'),
+    },
+    {
+      key: 'mobile',
+      icon: 'phone_iphone',
+      label: t('addMenu.mobileApps'),
+      onSelect: () => navigate(getLocalizedPath('/')),
+    },
+    { key: 'd2', divider: true },
+    {
+      key: 'browse',
+      icon: 'menu_book',
+      label: t('addMenu.browseAll'),
+      onSelect: () => navigate(getLocalizedPath('/books')),
+    },
+  ]
+
+  return (
+    <div className="add-menu" ref={wrapRef}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={triggerClassName ?? 'site-header__upload-btn'}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={triggerLabel}
+        title={triggerTitle}
+        onClick={() => setOpen((o) => !o)}
+      >
+        <span className="material-icons-outlined">add</span>
+        <span className="site-header__upload-btn-label">{triggerLabel}</span>
+      </button>
+      {open && (
+        <ul className="add-menu__list" role="menu" aria-label={t('addMenu.ariaLabel')}>
+          {entries.map((e) => {
+            if ('divider' in e) return <li key={e.key} className="add-menu__divider" role="separator" />
+            const disabled = !!e.comingSoon
+            return (
+              <li key={e.key} role="none">
+                <button
+                  type="button"
+                  role="menuitem"
+                  className={`add-menu__item ${disabled ? 'add-menu__item--disabled' : ''}`}
+                  disabled={disabled}
+                  title={disabled ? t('addMenu.comingSoon') : undefined}
+                  onClick={handle(e.onSelect)}
+                >
+                  <span className="material-icons-outlined add-menu__icon">{e.icon}</span>
+                  <span className="add-menu__label">{e.label}</span>
+                  {e.shortcut && <kbd className="add-menu__shortcut">{e.shortcut}</kbd>}
+                  {disabled && <span className="add-menu__badge">{t('addMenu.comingSoon')}</span>}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/library/UploadButton.tsx
+++ b/apps/web/src/components/library/UploadButton.tsx
@@ -6,6 +6,8 @@ import { useTranslation } from '../../hooks/useTranslation'
 import { useGlobalUploadShortcut } from '../../hooks/useGlobalUploadShortcut'
 import { emit } from '../../lib/telemetry/myBooksV2'
 import { UploadModal } from './UploadModal'
+import { AddMenu } from './AddMenu'
+import { features } from '../../lib/features'
 
 export function UploadButton() {
   const { isAuthenticated, isLoading } = useAuth()
@@ -52,6 +54,19 @@ export function UploadButton() {
         <span className="material-icons-outlined">upload</span>
         <span className="site-header__upload-btn-label">{t('upload.modal.signin')}</span>
       </button>
+    )
+  }
+
+  if (features.myBooksV3.addMenu) {
+    return (
+      <>
+        <AddMenu
+          onUpload={openModal}
+          triggerLabel={t('upload.button')}
+          triggerTitle={t('upload.shortcut.hint')}
+        />
+        <UploadModal open={open} onClose={closeModal} />
+      </>
     )
   }
 

--- a/apps/web/src/components/library/__tests__/AddMenu.test.tsx
+++ b/apps/web/src/components/library/__tests__/AddMenu.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}))
+
+vi.mock('../../../context/LanguageContext', () => ({
+  useLanguage: () => ({ getLocalizedPath: (p: string) => p }),
+}))
+
+import { AddMenu } from '../AddMenu'
+
+afterEach(() => cleanup())
+
+const renderMenu = (onUpload = () => {}) =>
+  render(
+    <MemoryRouter>
+      <AddMenu onUpload={onUpload} triggerLabel="Add" triggerTitle="Add" />
+    </MemoryRouter>,
+  )
+
+describe('AddMenu', () => {
+  it('opens menu on trigger click', () => {
+    renderMenu()
+    expect(screen.queryByRole('menu')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+  })
+
+  it('renders all menu entries', () => {
+    renderMenu()
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    for (const k of [
+      'addMenu.uploadFile',
+      'addMenu.pasteUrl',
+      'addMenu.emailBook',
+      'addMenu.browserExtension',
+      'addMenu.mobileApps',
+      'addMenu.browseAll',
+    ]) {
+      expect(screen.getByText(k)).toBeInTheDocument()
+    }
+  })
+
+  it('marks coming-soon items disabled', () => {
+    renderMenu()
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    const url = screen.getByRole('menuitem', { name: /addMenu\.pasteUrl/ })
+    const email = screen.getByRole('menuitem', { name: /addMenu\.emailBook/ })
+    expect(url).toBeDisabled()
+    expect(email).toBeDisabled()
+  })
+
+  it('Upload click triggers onUpload and closes menu', () => {
+    const onUpload = vi.fn()
+    renderMenu(onUpload)
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: /addMenu\.uploadFile/ }))
+    expect(onUpload).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('Esc closes menu', () => {
+    renderMenu()
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('click outside closes menu', () => {
+    render(
+      <MemoryRouter>
+        <div data-testid="outside">outside</div>
+        <AddMenu onUpload={() => {}} triggerLabel="Add" triggerTitle="Add" />
+      </MemoryRouter>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    fireEvent.mouseDown(screen.getByTestId('outside'))
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+})

--- a/apps/web/src/components/library/__tests__/UploadButton.test.tsx
+++ b/apps/web/src/components/library/__tests__/UploadButton.test.tsx
@@ -19,6 +19,9 @@ vi.mock('react-router-dom', () => ({
 vi.mock('../UploadModal', () => ({
   UploadModal: ({ open }: { open: boolean }) => (open ? <div data-testid="modal" /> : null),
 }))
+vi.mock('../../../lib/features', () => ({
+  features: { myBooksV3: { addMenu: false } },
+}))
 
 import { UploadButton } from '../UploadButton'
 

--- a/apps/web/src/lib/features.ts
+++ b/apps/web/src/lib/features.ts
@@ -11,5 +11,6 @@ export const features = {
     libraryShelves: env('VITE_FEATURE_MYBOOKSV3_LIBRARY_SHELVES') ?? isDev,
     librarySidebar: env('VITE_FEATURE_MYBOOKSV3_LIBRARY_SIDEBAR') ?? isDev,
     statusTabsPrimary: env('VITE_FEATURE_MYBOOKSV3_STATUS_TABS_PRIMARY') ?? isDev,
+    addMenu: env('VITE_FEATURE_MYBOOKSV3_ADD_MENU') ?? isDev,
   },
 } as const

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -631,6 +631,17 @@
       "signinAction": "Sign in"
     }
   },
+  "addMenu": {
+    "ariaLabel": "Add content menu",
+    "comingSoon": "Coming in a future update",
+    "uploadFile": "Upload file",
+    "uploadShortcut": "U",
+    "pasteUrl": "Paste URL",
+    "emailBook": "Email a book",
+    "browserExtension": "Browser extension",
+    "mobileApps": "Mobile apps",
+    "browseAll": "Browse all books"
+  },
   "books": {
     "title": "Books",
     "seoDesc": "Read books online for free | TextStack Reader",

--- a/apps/web/src/styles/books.css
+++ b/apps/web/src/styles/books.css
@@ -7543,3 +7543,71 @@ html.dark .book-hero__read-btn--secondary {
   .library-stats-header { grid-template-columns: repeat(2, 1fr); }
   .library-stats-header__tile:nth-child(n+3) { display: none; }
 }
+
+/* My Books v3 — `+` add menu (slice 05) */
+.add-menu { position: relative; display: inline-flex; }
+.add-menu__list {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 30;
+  list-style: none;
+  margin: 0;
+  padding: 6px 0;
+  background: var(--color-bg-card, #fff);
+  border: 1px solid var(--color-border, #e0d8c8);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  min-width: 240px;
+}
+.add-menu__divider {
+  height: 1px;
+  margin: 6px 8px;
+  background: var(--color-border, #e0d8c8);
+  border: 0;
+}
+.add-menu__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 8px 12px;
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  color: var(--color-text, #1f2937);
+  transition: background 120ms;
+}
+.add-menu__item:hover:not(:disabled) {
+  background: var(--color-bg-secondary, #f1ece2);
+}
+.add-menu__item--disabled {
+  cursor: not-allowed;
+  color: var(--color-text-secondary, #6b7280);
+  font-style: italic;
+}
+.add-menu__icon { font-size: 18px; opacity: 0.85; }
+.add-menu__label { flex: 1; min-width: 0; }
+.add-menu__shortcut {
+  font: inherit;
+  font-size: 11px;
+  background: var(--color-bg-secondary, #f1ece2);
+  padding: 1px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border, #e0d8c8);
+  color: var(--color-text-secondary, #6b7280);
+}
+.add-menu__badge {
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--color-bg-secondary, #f1ece2);
+  color: var(--color-text-secondary, #6b7280);
+}

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -287,6 +287,17 @@
       "confirmDeleteCancel": "Keep"
     }
   },
+  "addMenu": {
+    "title": "Add to library",
+    "ariaLabel": "Add content menu",
+    "comingSoon": "Coming in a future update",
+    "uploadFile": "Upload file",
+    "pasteUrl": "Paste URL",
+    "emailBook": "Email a book",
+    "browserExtension": "Browser extension",
+    "mobileApps": "Mobile apps",
+    "browseAll": "Browse all books"
+  },
   "books": {
     "title": "Books",
     "seoDesc": "Read books online for free | TextStack",


### PR DESCRIPTION
## Summary
- New **`AddMenu`** dropdown (web) — Upload file / Paste URL (coming soon) / Email a book (coming soon) / Browser extension / Mobile apps / Browse all books.
- New **`AddMenuBottomSheet`** (mobile) — same options, presented as a bottom sheet (Modal + Animated, no extra deps).
- `UploadButton` (web) and `UploadTabButton` (mobile) refactored to render the menu when their flag is on; legacy direct-upload behaviour preserved when off.

## Behaviour
- Coming-soon items render disabled, italic, with a small \"Coming soon\" badge + tooltip (`addMenu.comingSoon`).
- Web: Esc + click-outside close. Cmd+U keyboard shortcut still opens upload modal directly (skips the menu).
- Mobile: tap-backdrop and `onRequestClose` close the sheet.
- Browser extension item opens Chrome Web Store in a new tab; \"Mobile apps\" → home (placeholder until install page exists); \"Browse all\" → `/books`.

## Flags
- web: `VITE_FEATURE_MYBOOKSV3_ADD_MENU` (default `isDev`, prod = `false` via `deploy.yml`)
- mobile: `EXPO_PUBLIC_MYBOOKSV3_ADD_MENU` (default `false`)

## Test plan
- [x] vitest: `AddMenu.test.tsx` — 6 tests (open, all entries render, coming-soon disabled, Upload click triggers callback + closes menu, Esc closes, click-outside closes).
- [x] `UploadButton.test.tsx` updated to mock `features` so legacy path is covered.
- [x] Full vitest suite: 419/420 (1 pre-existing `NativeLanguageContext` flake — not introduced here).
- [x] `pnpm -C apps/web build` clean.
- [x] `tsc --noEmit` clean for web + mobile.
- [ ] Smoke: dev server with flag ON → click +, menu opens, Upload opens modal, coming-soon items show tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)