### PR TITLE
web header: drop Home nav link (dup of Library)

### DIFF
--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -22,14 +22,11 @@ export function Header() {
   const { t } = useTranslation()
   const quickStats = useQuickStats()
 
-  // /home doesn't exist yet — fall back to /library for authenticated users.
-  const homeTarget = '/library'
-
   return (
     <header className={`site-header ${isScrolled ? 'site-header--scrolled' : ''}`}>
       <div className="site-header__left">
         <LocalizedLink
-          to={isAuthenticated ? homeTarget : '/'}
+          to={isAuthenticated ? '/library' : '/'}
           className="site-header__brand"
           title={t('nav.brandTitle')}
           onClick={() => emit('header.click', { item: 'logo', auth: isAuthenticated })}
@@ -37,16 +34,6 @@ export function Header() {
           <span className="site-header__wordmark">TextStack</span>
         </LocalizedLink>
         <nav className="site-header__nav-links">
-          {isAuthenticated && (
-            <LocalizedLink
-              to={homeTarget}
-              className="site-header__nav-link"
-              title={t('nav.home')}
-              onClick={() => emit('header.click', { item: 'home' })}
-            >
-              {t('nav.home')}
-            </LocalizedLink>
-          )}
           {isAuthenticated && (
             <LocalizedLink
               to="/library"

--- a/apps/web/src/components/__tests__/Header.test.tsx
+++ b/apps/web/src/components/__tests__/Header.test.tsx
@@ -55,17 +55,17 @@ describe('Header', () => {
     authState.isLoading = false
   })
 
-  it('authenticated: shows Home / Library / Discover / Vocabulary, hides About', () => {
+  it('authenticated: shows Library / Discover / Vocabulary, hides Home + About', () => {
     authState.isAuthenticated = true
     renderHeader()
-    expect(screen.getByTitle('Home')).toBeInTheDocument()
+    expect(screen.queryByTitle('Home')).not.toBeInTheDocument()
     expect(screen.getByTitle('Library')).toBeInTheDocument()
     expect(screen.getByTestId('discover-menu')).toBeInTheDocument()
     expect(screen.getByTitle('Vocabulary')).toBeInTheDocument()
     expect(screen.queryByTitle('About TextStack')).not.toBeInTheDocument()
   })
 
-  it('unauthenticated: hides Home/Library/Vocabulary, keeps Discover + About', () => {
+  it('unauthenticated: hides Library/Vocabulary, keeps Discover + About', () => {
     authState.isAuthenticated = false
     renderHeader()
     expect(screen.queryByTitle('Home')).not.toBeInTheDocument()

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -271,7 +271,6 @@
   "nav": {
     "catalog": "Catalog",
     "books": "Books",
-    "home": "Home",
     "library": "Library",
     "discover": "Discover",
     "vocabulary": "Vocabulary",


### PR DESCRIPTION
## Summary
- Removes Home link from web header — `homeTarget` was hardcoded to `/library`, identical to the Library button next to it. Logo also goes to `/library` for authenticated users.
- Cleans `nav.home` from `apps/web/src/locales/en.json` (web no longer references it).
- Mobile bottom-tab Home **stays** — it's a real screen (greeting + continue reading + quick action grid + shelves), not a duplicate.

## Test plan
- [x] tsc clean
- [x] 405/405 vitest pass
- [x] web build succeeds
- [ ] CI green
- [ ] Browser smoke: header shows Library / Discover / Vocabulary only; logo + Library both go to /library

🤖 Generated with [Claude Code](https://claude.com/claude-code)