### PR TITLE
ops: fix backup-verify (pre-create textstack_prod role)

### DIFF
--- a/infra/scripts/backup-verify.sh
+++ b/infra/scripts/backup-verify.sh
@@ -46,6 +46,10 @@ if ! docker exec "$CONTAINER" pg_isready -U "$PG_USER" -d "$PG_DB" >/dev/null 2>
   exit 1
 fi
 
+echo "[verify] pre-creating roles referenced by dump ..."
+docker exec "$CONTAINER" psql -U "$PG_USER" -d "$PG_DB" -c \
+  "CREATE ROLE textstack_prod;" >/dev/null 2>&1 || true
+
 echo "[verify] restoring $BACKUP_FILE ..."
 # Redirect stderr to catch restore errors; NOTICE/WARNING on reload are normal.
 if ! gunzip -c "$BACKUP_FILE" | docker exec -i "$CONTAINER" psql -U "$PG_USER" -d "$PG_DB" --set=ON_ERROR_STOP=on >/dev/null; then


### PR DESCRIPTION
## Summary
- Scheduled backup workflow has been failing 5 days running on the verify step.
- Dump references owner role `textstack_prod`; throwaway verify container only had `verify` user → restore aborted on first GRANT/ALTER OWNER (`ON_ERROR_STOP=on`).
- Backups themselves are fine — 5 daily files (~2.3 GB each) on the server.

## Fix
- Pre-create `textstack_prod` role in the verify container before piping the dump.

## Test plan
- [ ] CI green
- [ ] Next scheduled backup (04:00 UTC) succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)