### PR TITLE
mobile reader: extract useReaderExitSummary hook

### DIFF
--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -12,6 +12,7 @@ import { useAuth } from '../../../src/context/AuthContext'
 import { useReaderSettings } from '../../../src/hooks/useReaderSettings'
 import { useReaderBars } from '../../../src/hooks/useReaderBars'
 import { useReaderBookmarks, getSlugFromLocator } from '../../../src/hooks/useReaderBookmarks'
+import { useReaderExitSummary } from '../../../src/hooks/useReaderExitSummary'
 import { ReaderSettingsDrawer } from '../../../src/components/ReaderSettingsDrawer'
 import { BookmarksSheet } from '../../../src/components/BookmarksSheet'
 import { SelectionActionBar } from '../../../src/components/SelectionActionBar'
@@ -87,8 +88,6 @@ export default function ReaderScreen() {
   // current selection (cleared on dismiss below) so a stale vocabMapRef never
   // blocks retry across fresh taps.
   const autoSavedRef = useRef<Set<string>>(new Set())
-  const [sessionWordCount, setSessionWordCount] = useState(0)
-  const [exitSummary, setExitSummary] = useState(false)
   const [dictOpen, setDictOpen] = useState(false)
   const [translateOpen, setTranslateOpen] = useState(false)
   const [explainOpen, setExplainOpen] = useState(false)
@@ -319,6 +318,15 @@ export default function ReaderScreen() {
     })
     return () => sub.remove()
   }, [saveProgress])
+
+  const {
+    sessionWordCount,
+    setSessionWordCount,
+    exitSummary,
+    exit: handleExit,
+    exitToReview: handleExitReview,
+    exitLater: handleExitLater,
+  } = useReaderExitSummary({ router, saveProgress })
 
   const handleMessage = useCallback((event: any) => {
     try {
@@ -597,35 +605,6 @@ export default function ReaderScreen() {
       setWordSaved(true)
       showToast({ message: 'Could not remove word. Try again.', variant: 'error' })
     }
-  }
-
-  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  // exitTimerRef: 5s summary auto-dismiss → router.back() on stale nav.
-  useEffect(() => {
-    return () => {
-      if (exitTimerRef.current) clearTimeout(exitTimerRef.current)
-    }
-  }, [])
-
-  const handleExit = () => {
-    saveProgress()
-    if (sessionWordCount > 0) {
-      setExitSummary(true)
-      exitTimerRef.current = setTimeout(() => router.back(), 5000)
-    } else {
-      router.back()
-    }
-  }
-
-  const handleExitReview = () => {
-    if (exitTimerRef.current) clearTimeout(exitTimerRef.current)
-    router.replace('/vocabulary/review')
-  }
-
-  const handleExitLater = () => {
-    if (exitTimerRef.current) clearTimeout(exitTimerRef.current)
-    router.back()
   }
 
   const handleHighlight = async (color: string) => {

--- a/apps/mobile/src/hooks/useReaderExitSummary.ts
+++ b/apps/mobile/src/hooks/useReaderExitSummary.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+type Router = { back: () => void; replace: (href: string) => void }
+
+type Options = {
+  router: Router
+  saveProgress: () => void
+  /** ms before the summary auto-dismisses and pops the screen. */
+  autoDismissMs?: number
+}
+
+/**
+ * Owns the post-reading "{N} words saved → Review now / Later" overlay.
+ * Caller increments sessionWordCount on each saved word; on exit, if any
+ * were saved we show the summary, else we pop immediately.
+ */
+export function useReaderExitSummary({ router, saveProgress, autoDismissMs = 5000 }: Options) {
+  const [sessionWordCount, setSessionWordCount] = useState(0)
+  const [exitSummary, setExitSummary] = useState(false)
+  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (exitTimerRef.current) clearTimeout(exitTimerRef.current)
+    }
+  }, [])
+
+  const exit = useCallback(() => {
+    saveProgress()
+    if (sessionWordCount > 0) {
+      setExitSummary(true)
+      exitTimerRef.current = setTimeout(() => router.back(), autoDismissMs)
+    } else {
+      router.back()
+    }
+  }, [saveProgress, sessionWordCount, router, autoDismissMs])
+
+  const exitToReview = useCallback(() => {
+    if (exitTimerRef.current) clearTimeout(exitTimerRef.current)
+    router.replace('/vocabulary/review')
+  }, [router])
+
+  const exitLater = useCallback(() => {
+    if (exitTimerRef.current) clearTimeout(exitTimerRef.current)
+    router.back()
+  }, [router])
+
+  return { sessionWordCount, setSessionWordCount, exitSummary, exit, exitToReview, exitLater }
+}


### PR DESCRIPTION
## Summary
- 3rd slice of mobile reader decomposition (after #175 bars, #176 bookmarks).
- Post-reading "{N} words saved → Review now / Later" overlay → \`apps/mobile/src/hooks/useReaderExitSummary.ts\`.
- Hook owns: \`sessionWordCount\` + \`exitSummary\` state, 3 nav handlers, auto-dismiss timer + cleanup.
- Caller still owns the increment side (via \`setSessionWordCount\`) — vocab handlers stay where they are.
- Net -21 lines in the reader screen, behavior identical.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] CI green
- [ ] Smoke: save ≥1 word, tap back → overlay appears with correct count, "Review Now" goes to vocab review, "Later" pops the screen, 5s auto-dismiss pops the screen, navigating away during the 5s window doesn't double-pop

🤖 Generated with [Claude Code](https://claude.com/claude-code)