### PR TITLE
mobile reader: extract useReaderProgress hook

### DIFF
--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -1,12 +1,11 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
-import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Animated, AppState, Linking } from 'react-native'
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Animated, Linking } from 'react-native'
 import { WebView } from 'react-native-webview'
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router'
-import { createBooksApi, readingProgressApi, bookmarksApi, vocabularyApi, translationApi, t } from '@textstack/shared'
+import { createBooksApi, bookmarksApi, vocabularyApi, translationApi, t } from '@textstack/shared'
 import type { Chapter, ChapterSummary } from '@textstack/shared'
 import { buildReaderHtml } from '../../../src/lib/readerHtml'
 import { getCachedChapter, getAllCachedBooks } from '../../../src/lib/offlineDb'
-import { saveLocalProgress } from '../../../src/lib/progressStorage'
 import { useAuth } from '../../../src/context/AuthContext'
 import { useReaderSettings } from '../../../src/hooks/useReaderSettings'
 import { useReaderBars } from '../../../src/hooks/useReaderBars'
@@ -14,6 +13,7 @@ import { useReaderBookmarks, getSlugFromLocator } from '../../../src/hooks/useRe
 import { useReaderExitSummary } from '../../../src/hooks/useReaderExitSummary'
 import { useReaderHighlights } from '../../../src/hooks/useReaderHighlights'
 import { useReaderVocabMap } from '../../../src/hooks/useReaderVocabMap'
+import { useReaderProgress } from '../../../src/hooks/useReaderProgress'
 import { ReaderSettingsDrawer } from '../../../src/components/ReaderSettingsDrawer'
 import { BookmarksSheet } from '../../../src/components/BookmarksSheet'
 import { SelectionActionBar } from '../../../src/components/SelectionActionBar'
@@ -301,45 +301,14 @@ export default function ReaderScreen() {
     return () => { cancelled = true }
   }, [bookSlug, chapterSlug, language])
 
-  const saveProgress = useCallback(() => {
-    if (!editionIdRef.current || !chapter || !chapterSlug) return
-    const slug = currentChapterSlugRef.current || chapterSlug
-    const percent = progressRef.current
-    const updatedAt = Date.now()
-
-    // Offline-first: always persist locally, even for guests. Survives flaky network,
-    // crashes between PUTs, and gives ContinueReadingCard a fallback when server is
-    // unreachable. LWW merge in consumers uses this `updatedAt`.
-    saveLocalProgress(editionIdRef.current, {
-      chapterId: chapter.id,
-      chapterSlug: slug,
-      percent,
-      updatedAt,
-    }).catch(() => {})
-
-    if (!isAuthenticated) return
-    readingProgressApi.updateProgress(editionIdRef.current, {
-      chapterId: chapter.id,
-      chapterSlug: slug,
-      progress: percent,
-    }).catch(() => {})
-  }, [isAuthenticated, chapter, chapterSlug])
-
-  // Save progress when leaving reader
-  useEffect(() => {
-    return () => { saveProgress() }
-  }, [saveProgress])
-
-  // Save progress when the app backgrounds. On Android, Home-button +
-  // OS-kill path skips useEffect cleanup, so the final scroll position
-  // would be lost. AppState fires on home/background; we flush now so
-  // the next launch resumes at the right place.
-  useEffect(() => {
-    const sub = AppState.addEventListener('change', state => {
-      if (state === 'background' || state === 'inactive') saveProgress()
-    })
-    return () => sub.remove()
-  }, [saveProgress])
+  const { saveProgress } = useReaderProgress({
+    editionIdRef,
+    chapter,
+    chapterSlug,
+    currentChapterSlugRef,
+    progressRef,
+    isAuthenticated,
+  })
 
   const {
     sessionWordCount,

--- a/apps/mobile/src/hooks/useReaderProgress.ts
+++ b/apps/mobile/src/hooks/useReaderProgress.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, MutableRefObject } from 'react'
+import { AppState } from 'react-native'
+import { readingProgressApi } from '@textstack/shared'
+import type { Chapter } from '@textstack/shared'
+import { saveLocalProgress } from '../lib/progressStorage'
+
+type Options = {
+  editionIdRef: MutableRefObject<string | null>
+  chapter: Chapter | null
+  chapterSlug: string | undefined
+  /** Live cursor for the active chapter slug (changes as user scrolls into next chapter). */
+  currentChapterSlugRef: MutableRefObject<string | null>
+  /** Live scroll progress (0..1). */
+  progressRef: MutableRefObject<number>
+  isAuthenticated: boolean
+}
+
+/**
+ * Owns progress save: a stable `saveProgress()` callback plus the two
+ * effects that flush it (unmount cleanup + AppState background/inactive).
+ *
+ * Offline-first: always persists locally, even for guests. LWW via `updatedAt`.
+ * Authenticated users also PUT to the server (fire-and-forget).
+ */
+export function useReaderProgress({
+  editionIdRef,
+  chapter,
+  chapterSlug,
+  currentChapterSlugRef,
+  progressRef,
+  isAuthenticated,
+}: Options) {
+  const saveProgress = useCallback(() => {
+    if (!editionIdRef.current || !chapter || !chapterSlug) return
+    const slug = currentChapterSlugRef.current || chapterSlug
+    const percent = progressRef.current
+    const updatedAt = Date.now()
+
+    saveLocalProgress(editionIdRef.current, {
+      chapterId: chapter.id,
+      chapterSlug: slug,
+      percent,
+      updatedAt,
+    }).catch(() => {})
+
+    if (!isAuthenticated) return
+    readingProgressApi.updateProgress(editionIdRef.current, {
+      chapterId: chapter.id,
+      chapterSlug: slug,
+      progress: percent,
+    }).catch(() => {})
+  }, [isAuthenticated, chapter, chapterSlug, editionIdRef, currentChapterSlugRef, progressRef])
+
+  useEffect(() => {
+    return () => { saveProgress() }
+  }, [saveProgress])
+
+  // On Android, Home-button + OS-kill skips useEffect cleanup, so the final
+  // scroll position would be lost. AppState fires on home/background;
+  // flush now so the next launch resumes at the right place.
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', state => {
+      if (state === 'background' || state === 'inactive') saveProgress()
+    })
+    return () => sub.remove()
+  }, [saveProgress])
+
+  return { saveProgress }
+}


### PR DESCRIPTION
## Summary
- Pull saveProgress callback + unmount + AppState background flush effects out of the reader screen.
- Same offline-first behavior: local persist always (incl. guests), server PUT for authenticated users only.

## Test plan
- [ ] scroll → leave reader → reopen → resumes at last position
- [ ] scroll → background app → reopen → resumes at last position (Android home button)
- [ ] guest user → scroll → leave reader → local progress preserved (no server call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)