### PR TITLE
mobile reader: extract useReaderBook

### DIFF
--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -2,10 +2,8 @@ import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
 import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Animated, Linking } from 'react-native'
 import { WebView } from 'react-native-webview'
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router'
-import { createBooksApi, bookmarksApi, t } from '@textstack/shared'
-import type { ChapterSummary } from '@textstack/shared'
+import { createBooksApi, t } from '@textstack/shared'
 import { buildReaderHtml } from '../../../src/lib/readerHtml'
-import { getAllCachedBooks } from '../../../src/lib/offlineDb'
 import { useAuth } from '../../../src/context/AuthContext'
 import { useReaderSettings } from '../../../src/hooks/useReaderSettings'
 import { useReaderBars } from '../../../src/hooks/useReaderBars'
@@ -17,6 +15,7 @@ import { useReaderProgress } from '../../../src/hooks/useReaderProgress'
 import { useReaderVocabActions } from '../../../src/hooks/useReaderVocabActions'
 import { useReaderSelection } from '../../../src/hooks/useReaderSelection'
 import { useReaderChapter } from '../../../src/hooks/useReaderChapter'
+import { useReaderBook } from '../../../src/hooks/useReaderBook'
 import { ReaderSettingsDrawer } from '../../../src/components/ReaderSettingsDrawer'
 import { BookmarksSheet } from '../../../src/components/BookmarksSheet'
 import { SelectionActionBar } from '../../../src/components/SelectionActionBar'
@@ -41,7 +40,6 @@ import { useNativeLanguage } from '../../../src/context/NativeLanguageContext'
 import { fonts } from '../../../src/theme/typography'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { StatusBar } from 'expo-status-bar'
-import { trackBookOpened } from '../../../src/lib/analytics'
 
 /** Lightweight {key} interpolation — shared `t()` returns raw keys, we fill them in here. */
 function interpolate(template: string, vars: Record<string, string | number>): string {
@@ -60,9 +58,7 @@ export default function ReaderScreen() {
   const [translateOpen, setTranslateOpen] = useState(false)
   const [explainOpen, setExplainOpen] = useState(false)
   const [tocOpen, setTocOpen] = useState(false)
-  const [chapters, setChapters] = useState<ChapterSummary[]>([])
   const [progress, setProgress] = useState(0)
-  const [bookTitle, setBookTitle] = useState('')
   const { toggle: toggleTts, isSpeaking } = useTts()
   const webViewRef = useRef<WebView>(null)
   // Wrap in try/catch so runtime errors in injected JS are forwarded to RN
@@ -174,48 +170,15 @@ export default function ReaderScreen() {
     isAuthenticated,
   })
 
-  // Resolve editionId from bookSlug (needed for progress + bookmarks).
-  // On network failure fall back to the offline book catalog so a fully
-  // downloaded book still picks up its editionId, bookmarks, and progress
-  // events keep working.
-  const bookOpenedFiredRef = useRef(false)
-  useEffect(() => {
-    if (!bookSlug) return
-    let cancelled = false
-    const api = createBooksApi(language)
-    api.getBook(bookSlug)
-      .then(b => {
-        if (cancelled) return
-        editionIdRef.current = b.id
-        bookTitleRef.current = b.title
-        setBookTitle(b.title)
-        if (!bookOpenedFiredRef.current) {
-          bookOpenedFiredRef.current = true
-          trackBookOpened({ source: 'library', editionId: b.id, language })
-        }
-        if (b.chapters) {
-          setChapters(b.chapters)
-          totalWordCountRef.current = b.chapters.reduce((sum, c) => sum + (c.wordCount || 0), 0)
-        }
-        if (isAuthenticated) {
-          bookmarksApi.getBookmarks(b.id)
-            .then(res => { if (!cancelled) setBookmarks(res) })
-            .catch(() => {})
-        }
-      })
-      .catch(() => {
-        getAllCachedBooks().then(books => {
-          if (cancelled) return
-          const match = books.find(b => b.slug === bookSlug)
-          if (match) {
-            editionIdRef.current = match.editionId
-            bookTitleRef.current = match.title
-            setBookTitle(match.title)
-          }
-        }).catch(() => {})
-      })
-    return () => { cancelled = true }
-  }, [bookSlug, isAuthenticated, language])
+  const { bookTitle, chapters } = useReaderBook({
+    bookSlug,
+    language,
+    isAuthenticated,
+    editionIdRef,
+    bookTitleRef,
+    totalWordCountRef,
+    setBookmarks,
+  })
 
   const { saveProgress } = useReaderProgress({
     editionIdRef,

--- a/apps/mobile/src/hooks/useReaderBook.ts
+++ b/apps/mobile/src/hooks/useReaderBook.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState, MutableRefObject } from 'react'
+import { createBooksApi, bookmarksApi } from '@textstack/shared'
+import type { ChapterSummary, Language, BookmarkDto } from '@textstack/shared'
+import { getAllCachedBooks } from '../lib/offlineDb'
+import { trackBookOpened } from '../lib/analytics'
+
+type Options = {
+  bookSlug: string | undefined
+  language: Language
+  isAuthenticated: boolean
+  /** Screen-owned refs the hook mutates from the API response — kept here so
+   * other hooks (progress, highlights, vocab, …) can keep reading them. */
+  editionIdRef: MutableRefObject<string | null>
+  bookTitleRef: MutableRefObject<string | null>
+  totalWordCountRef: MutableRefObject<number>
+  /** Initial bookmarks load on auth users — mirrors the current inline behaviour. */
+  setBookmarks: (b: BookmarkDto[]) => void
+}
+
+/**
+ * Resolves edition id + book metadata from `bookSlug`. On network failure
+ * falls back to the offline book catalog so a fully downloaded book still
+ * picks up its editionId, title, and bookmarks (progress events keep
+ * working downstream).
+ *
+ * Side effects (intentional, mirror the previous inline effect):
+ * - Mutates `editionIdRef`, `bookTitleRef`, `totalWordCountRef`
+ * - Fires the one-shot `book_opened` analytics event
+ * - Loads bookmarks via `setBookmarks` for authed users
+ */
+export function useReaderBook({
+  bookSlug,
+  language,
+  isAuthenticated,
+  editionIdRef,
+  bookTitleRef,
+  totalWordCountRef,
+  setBookmarks,
+}: Options) {
+  const [bookTitle, setBookTitle] = useState('')
+  const [chapters, setChapters] = useState<ChapterSummary[]>([])
+  const bookOpenedFiredRef = useRef(false)
+
+  useEffect(() => {
+    if (!bookSlug) return
+    let cancelled = false
+    const api = createBooksApi(language)
+    api.getBook(bookSlug)
+      .then(b => {
+        if (cancelled) return
+        editionIdRef.current = b.id
+        bookTitleRef.current = b.title
+        setBookTitle(b.title)
+        if (!bookOpenedFiredRef.current) {
+          bookOpenedFiredRef.current = true
+          trackBookOpened({ source: 'library', editionId: b.id, language })
+        }
+        if (b.chapters) {
+          setChapters(b.chapters)
+          totalWordCountRef.current = b.chapters.reduce((sum, c) => sum + (c.wordCount || 0), 0)
+        }
+        if (isAuthenticated) {
+          bookmarksApi.getBookmarks(b.id)
+            .then(res => { if (!cancelled) setBookmarks(res) })
+            .catch(() => {})
+        }
+      })
+      .catch(() => {
+        getAllCachedBooks().then(books => {
+          if (cancelled) return
+          const match = books.find(b => b.slug === bookSlug)
+          if (match) {
+            editionIdRef.current = match.editionId
+            bookTitleRef.current = match.title
+            setBookTitle(match.title)
+          }
+        }).catch(() => {})
+      })
+    return () => { cancelled = true }
+  }, [bookSlug, isAuthenticated, language, editionIdRef, bookTitleRef, totalWordCountRef, setBookmarks])
+
+  return { bookTitle, chapters }
+}


### PR DESCRIPTION
## Summary
- New `useReaderBook` hook owns the book-meta resolve effect: API → editionIdRef/bookTitleRef/totalWordCountRef writes, chapters TOC, one-shot `book_opened` analytics, and the auth-only initial bookmarks fetch. Falls back to offline catalog on network failure.
- Drops the inline effect + 4 unused imports from the screen.

Continues mobile reader hook extraction (#179–#186).

## Test plan
- [ ] Online: book title appears in top bar, chapters list populates TOC
- [ ] Offline (downloaded book): title still resolves from cache
- [ ] Auth user: bookmarks for the book appear after open
- [ ] `book_opened` analytics fires once per session

🤖 Generated with [Claude Code](https://claude.com/claude-code)