### PR TITLE
mobile reader: openSelection method on useReaderSelection

### DIFF
--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -126,8 +126,8 @@ export default function ReaderScreen() {
     setWordSaved,
     lookupState,
     setLookupState,
-    selectionIdRef,
     autoSavedRef,
+    openSelection,
   } = useReaderSelection({ flushVocabMap })
 
   // Single source of truth for "word added" feedback — keeps toast copy + haptic
@@ -256,34 +256,20 @@ export default function ReaderScreen() {
         const hl = highlightsRef.current.find(h => h.id === data.highlightId)
         if (hl) setEditingHighlight(hl)
       } else if (data.type === 'selection') {
-        if (data.text) {
-          if (__DEV__) console.log('[diag] setSelection OPEN', data.text)
-          const nextId = ++selectionIdRef.current
-          setSelection({
-            text: data.text,
-            sentence: data.sentence || '',
-            anchor: data.anchor || null,
-            selectionId: nextId,
-          })
-          setWordSaved(false)
-          setLookupState(null)
-          // Single word: auto-TTS + auto-save to vocabulary (matches web behavior)
-          if (!data.text.includes(' ')) {
-            toggleTts(data.text, { rate: settings.ttsSpeed, lang: language })
-            vocabActions.autoSaveWord(
-              { text: data.text, sentence: data.sentence || '', anchor: data.anchor || null, selectionId: nextId },
-              autoSavedRef,
-            )
-          }
-        } else {
-          if (__DEV__) console.log('[diag] setSelection NULL (empty-data branch)')
-          setSelection(null)
+        const nextId = openSelection(data.text ? data : null)
+        // Single word: auto-TTS + auto-save to vocabulary (matches web behavior)
+        if (nextId !== null && !data.text.includes(' ')) {
+          toggleTts(data.text, { rate: settings.ttsSpeed, lang: language })
+          vocabActions.autoSaveWord(
+            { text: data.text, sentence: data.sentence || '', anchor: data.anchor || null, selectionId: nextId },
+            autoSavedRef,
+          )
         }
       }
     } catch (err) {
       if (__DEV__) console.warn('[reader] postMessage handler threw', err, event?.nativeEvent?.data)
     }
-  }, [chapter, language, settings.ttsSpeed, toggleTts, toggleBars, showBars, hideBars, vocabActions, setEditingHighlight, highlightsRef, updateSessionProgress, enableInfiniteScrollFor, loadNextChapter])
+  }, [chapter, language, settings.ttsSpeed, toggleTts, toggleBars, showBars, hideBars, vocabActions, setEditingHighlight, highlightsRef, updateSessionProgress, enableInfiniteScrollFor, loadNextChapter, openSelection, autoSavedRef])
 
   const navigateChapter = (slug: string) => {
     saveProgress()

--- a/apps/mobile/src/hooks/useReaderSelection.ts
+++ b/apps/mobile/src/hooks/useReaderSelection.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 export type Selection = {
   text: string
@@ -54,6 +54,34 @@ export function useReaderSelection({ flushVocabMap }: Options) {
     }
   }, [selection, flushVocabMap])
 
+  /**
+   * Opens or closes the selection in response to a WebView postMessage.
+   * Returns the freshly minted `selectionId` for single-word callers that
+   * still need to wire up auto-TTS / auto-save (the hook stays out of those
+   * concerns to avoid coupling to vocab/TTS internals).
+   */
+  const openSelection = useCallback(
+    (payload: { text: string; sentence?: string; anchor?: any } | null): number | null => {
+      if (!payload || !payload.text) {
+        if (__DEV__) console.log('[diag] setSelection NULL (empty-data branch)')
+        setSelection(null)
+        return null
+      }
+      if (__DEV__) console.log('[diag] setSelection OPEN', payload.text)
+      const nextId = ++selectionIdRef.current
+      setSelection({
+        text: payload.text,
+        sentence: payload.sentence || '',
+        anchor: payload.anchor || null,
+        selectionId: nextId,
+      })
+      setWordSaved(false)
+      setLookupState(null)
+      return nextId
+    },
+    [],
+  )
+
   return {
     selection,
     setSelection,
@@ -63,5 +91,6 @@ export function useReaderSelection({ flushVocabMap }: Options) {
     setLookupState,
     selectionIdRef,
     autoSavedRef,
+    openSelection,
   }
 }


### PR DESCRIPTION
## Summary
- New `openSelection(payload | null)` on `useReaderSelection` does the open/close + state-reset (`setSelection` + `setWordSaved(false)` + `setLookupState(null)`) in one call. Returns the freshly minted `selectionId`.
- Hook stays out of TTS/vocab concerns — the screen still wires single-word auto-TTS + auto-save inline using the returned id.
- handleMessage's `selection` branch shrinks ~24 → ~10 lines.

Continues mobile reader hook extraction (#179–#188).

## Test plan
- [ ] Single-word tap: WordCard opens, auto-TTS speaks once, auto-save fires once
- [ ] Multi-word selection: SelectionToolbar shows, no auto-TTS, no auto-save
- [ ] Re-tap same word: `selectionId` increments, auto-dismiss timer resets
- [ ] Empty selection (dismiss): closes WordCard cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)