### PR TITLE
vocab: practice mode (off-budget, no SRS mutation)

### DIFF
--- a/apps/mobile/app/vocabulary/review.tsx
+++ b/apps/mobile/app/vocabulary/review.tsx
@@ -22,8 +22,9 @@ export default function VocabularyReviewScreen() {
   const { colors } = useTheme()
   const { language, t } = useLanguage()
   const router = useRouter()
-  const params = useLocalSearchParams<{ limit?: string; reviewMode?: string; cluster?: string }>()
+  const params = useLocalSearchParams<{ limit?: string; reviewMode?: string; cluster?: string; practice?: string }>()
   const clusterId = typeof params.cluster === 'string' ? params.cluster : null
+  const practiceMode = params.practice === '1' || params.practice === 'true'
 
   const [batchSize, setBatchSize] = useState(() => {
     const v = parseInt(params.limit || String(DEFAULT_BATCH_SIZE), 10)
@@ -50,11 +51,11 @@ export default function VocabularyReviewScreen() {
     if (clusterId) {
       review.startClusterSession(clusterId, review.reviewMode)
     } else {
-      review.startSession(batchSize, review.reviewMode)
+      review.startSession(batchSize, review.reviewMode, practiceMode)
     }
     // `review` is stable per-hook, review.reviewMode read at call time.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [batchSize, clusterId])
+  }, [batchSize, clusterId, practiceMode])
 
   // Haptic on session-complete — must be in an effect, not render, or
   // it re-fires on every re-render while the summary is visible.
@@ -78,7 +79,14 @@ export default function VocabularyReviewScreen() {
 
   const handleAgain = () => {
     sessionStartRef.current = Date.now()
-    review.startSession(batchSize, review.reviewMode)
+    review.startSession(batchSize, review.reviewMode, practiceMode)
+  }
+
+  const handlePracticeAnyway = () => {
+    router.replace({
+      pathname: '/vocabulary/review',
+      params: { ...params, practice: '1' },
+    } as any)
   }
 
   // Loading
@@ -91,10 +99,11 @@ export default function VocabularyReviewScreen() {
     )
   }
 
-  const budgetReached = !review.hasCards && (review.weeklyProgress?.remaining ?? 1) <= 0
+  const budgetReached = !practiceMode && !review.hasCards && (review.weeklyProgress?.remaining ?? 1) <= 0
 
   // Budget-reached empty state — served when the backend returned no cards
   // because the weekly budget is exhausted (not because nothing is due).
+  // Practice mode bypasses the budget entirely so this branch never fires there.
   if (budgetReached) {
     return (
       <>
@@ -110,10 +119,18 @@ export default function VocabularyReviewScreen() {
               {t('vocabulary.weeklyBudget.emptyStateSubtitle')}
             </Text>
             <PressableScale
-              onPress={() => router.back()}
+              onPress={handlePracticeAnyway}
               style={[styles.budgetReachedCta, { backgroundColor: colors.primary }]}
             >
               <Text style={styles.budgetReachedCtaText}>
+                {t('vocabulary.practice.cta')}
+              </Text>
+            </PressableScale>
+            <PressableScale
+              onPress={() => router.back()}
+              style={styles.budgetReachedSecondary}
+            >
+              <Text style={[styles.budgetReachedSecondaryText, { color: colors.textSecondary }]}>
                 {t('vocabulary.weeklyBudget.backToReading')}
               </Text>
             </PressableScale>
@@ -150,7 +167,9 @@ export default function VocabularyReviewScreen() {
   return (
     <>
       <Stack.Screen options={{
-        title: `Practice (${review.currentIndex + 1}/${review.cards.length})`,
+        title: practiceMode
+          ? `Practice (${review.currentIndex + 1}/${review.cards.length}) · Free`
+          : `Practice (${review.currentIndex + 1}/${review.cards.length})`,
         headerShown: true,
         headerRight: () => (
           <View style={styles.headerRight}>
@@ -166,7 +185,7 @@ export default function VocabularyReviewScreen() {
       }} />
       <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
         <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
-          {review.weeklyProgress && <WeeklyBudgetBar progress={review.weeklyProgress} />}
+          {!practiceMode && review.weeklyProgress && <WeeklyBudgetBar progress={review.weeklyProgress} />}
 
           {/* Progress */}
           <View style={[styles.progressTrack, { backgroundColor: colors.border }]}>
@@ -181,6 +200,14 @@ export default function VocabularyReviewScreen() {
                 {review.reviewMode === 'blitz' ? 'Blitz' : 'Flashcards'}
               </Text>
             </View>
+            {practiceMode && (
+              <View style={[styles.modeBadge, { backgroundColor: colors.surface, borderWidth: 1, borderColor: colors.primary }]}>
+                <Ionicons name="infinite" size={12} color={colors.primary} />
+                <Text style={[styles.modeBadgeText, { color: colors.primary }]}>
+                  {t('vocabulary.practice.title')}
+                </Text>
+              </View>
+            )}
           </View>
 
           {/* Card area */}
@@ -240,4 +267,6 @@ const styles = StyleSheet.create({
   budgetReachedSubtitle: { fontSize: 14, marginTop: 8, textAlign: 'center' },
   budgetReachedCta: { marginTop: 24, paddingHorizontal: 20, paddingVertical: 12, borderRadius: 12 },
   budgetReachedCtaText: { color: '#fff', fontFamily: 'Inter-Medium' },
+  budgetReachedSecondary: { marginTop: 12, paddingHorizontal: 20, paddingVertical: 8 },
+  budgetReachedSecondaryText: { fontSize: 13, fontFamily: 'Inter-Regular' },
 })

--- a/apps/mobile/e2e/tests/vocabulary.spec.ts
+++ b/apps/mobile/e2e/tests/vocabulary.spec.ts
@@ -31,4 +31,14 @@ test.describe('Vocabulary', () => {
     const hasReview = await page.locator('text=/Review|No words|nothing to review/i').first().isVisible({ timeout: 10000 }).catch(() => false)
     expect(hasReview).toBeTruthy()
   })
+
+  test('practice mode route loads', async ({ page }) => {
+    await page.goto('/vocabulary/review?practice=1')
+    await page.waitForLoadState('networkidle')
+
+    // Practice route is reachable — backend returns weeklyProgress=null so
+    // the bar is hidden; just verify the page itself renders without crashing.
+    const hasPage = await page.locator('text=/Practice|Review|No words|nothing to review/i').first().isVisible({ timeout: 10000 }).catch(() => false)
+    expect(hasPage).toBeTruthy()
+  })
 })

--- a/apps/mobile/src/components/home/VocabularyReviewCard.tsx
+++ b/apps/mobile/src/components/home/VocabularyReviewCard.tsx
@@ -183,9 +183,9 @@ export function VocabularyReviewCard() {
       return {
         headline: savedTitle(),
         subline: t('vocabulary.banner.budgetReached'),
-        ctaLabel: t('home.vocabCard.openCta'),
-        iconName: 'checkmark-done',
-        ctaAction: openVocab,
+        ctaLabel: t('vocabulary.practice.cta'),
+        iconName: 'infinite',
+        ctaAction: () => router.push('/vocabulary/review?practice=1' as never),
       }
     }
     if (dueNow > 0) {
@@ -216,7 +216,7 @@ export function VocabularyReviewCard() {
   }
 
   const { headline, subline, ctaLabel, iconName, ctaAction } = resolveState()
-  const isActionable = dueNow > 0
+  const isActionable = dueNow > 0 || budgetReached
 
   // Stitch together a single accessibility label so VoiceOver reads the card
   // as one coherent announcement instead of three separate children.

--- a/apps/mobile/src/hooks/useVocabularyReview.ts
+++ b/apps/mobile/src/hooks/useVocabularyReview.ts
@@ -27,6 +27,7 @@ export function useVocabularyReview() {
   const [reviewMode, setReviewMode] = useState<ReviewMode>('classic')
   const [showingNewWord, setShowingNewWord] = useState(false)
   const [activeClusterId, setActiveClusterId] = useState<string | null>(null)
+  const [isPractice, setIsPractice] = useState(false)
 
   // Guards against state updates after unmount. The two async calls below
   // (getReviewQueue, submitReview) can resolve after the user has navigated
@@ -54,15 +55,17 @@ export function useVocabularyReview() {
     }
   }, [])
 
-  const startSession = useCallback(async (limit?: number, rMode?: ReviewMode) => {
+  const startSession = useCallback(async (limit?: number, rMode?: ReviewMode, practice?: boolean) => {
     if (rMode) setReviewMode(rMode)
+    const practiceFlag = practice === true
+    setIsPractice(practiceFlag)
     setLoading(true)
     setError(null)
     setCurrentIndex(0)
     setActiveClusterId(null)
     resetAnswerState()
     try {
-      const queue = await vocabularyApi.getReviewQueue(limit)
+      const queue = await vocabularyApi.getReviewQueue(limit, practiceFlag)
       if (!mountedRef.current) return
       setCards(queue.cards)
       setTotalDue(queue.totalDue)
@@ -79,6 +82,7 @@ export function useVocabularyReview() {
 
   const startClusterSession = useCallback(async (clusterId: string, rMode?: ReviewMode) => {
     if (rMode) setReviewMode(rMode)
+    setIsPractice(false)
     setLoading(true)
     setError(null)
     setCurrentIndex(0)
@@ -119,6 +123,7 @@ export function useVocabularyReview() {
         isCorrect,
         responseTimeMs,
         selfAssessment,
+        isPractice,
       })
       if (!mountedRef.current) return
       setLastResult(result)
@@ -135,7 +140,7 @@ export function useVocabularyReview() {
     } finally {
       if (mountedRef.current) setSubmitting(false)
     }
-  }, [cards, currentIndex, submitting])
+  }, [cards, currentIndex, submitting, isPractice])
 
   const nextCard = useCallback(() => {
     const nextIdx = currentIndex + 1
@@ -166,6 +171,7 @@ export function useVocabularyReview() {
     reviewMode,
     showingNewWord,
     activeClusterId,
+    isPractice,
     startSession,
     startClusterSession,
     submitAnswer,

--- a/apps/web/src/api/vocabulary.ts
+++ b/apps/web/src/api/vocabulary.ts
@@ -69,7 +69,7 @@ export interface WeeklyProgressDto {
 export interface ReviewQueueResponse {
   cards: ReviewCardDto[]
   totalDue: number
-  weeklyProgress: WeeklyProgressDto
+  weeklyProgress: WeeklyProgressDto | null
 }
 
 export interface VocabSettingsDto {
@@ -87,6 +87,7 @@ export interface SubmitReviewRequest {
   isCorrect: boolean
   responseTimeMs: number
   selfAssessment?: SelfAssessment
+  isPractice?: boolean
 }
 
 export interface SubmitReviewResponse {
@@ -266,10 +267,11 @@ export async function updateWord(id: string, data: UpdateWordRequest): Promise<V
   })
 }
 
-export async function getReviewQueue(limit?: number, includeAll?: boolean): Promise<ReviewQueueResponse> {
+export async function getReviewQueue(limit?: number, includeAll?: boolean, practice?: boolean): Promise<ReviewQueueResponse> {
   const params = new URLSearchParams()
   if (limit) params.set('limit', String(limit))
   if (includeAll) params.set('includeAll', 'true')
+  if (practice) params.set('practice', 'true')
   const qs = params.toString()
   return authFetch<ReviewQueueResponse>(`/me/vocabulary/review${qs ? `?${qs}` : ''}`)
 }

--- a/apps/web/src/hooks/useVocabularyReview.ts
+++ b/apps/web/src/hooks/useVocabularyReview.ts
@@ -36,6 +36,7 @@ export function useVocabularyReview() {
   const [showingNewWord, setShowingNewWord] = useState(false)
   const [wrongCards, setWrongCards] = useState<ReviewCardDto[]>([])
   const [activeClusterId, setActiveClusterId] = useState<string | null>(null)
+  const [isPractice, setIsPractice] = useState(false)
 
   const resetAnswerState = useCallback(() => {
     setLastResult(null)
@@ -50,8 +51,10 @@ export function useVocabularyReview() {
     }
   }, [])
 
-  const startSession = useCallback(async (limit?: number, rMode?: ReviewMode, includeAll?: boolean) => {
+  const startSession = useCallback(async (limit?: number, rMode?: ReviewMode, includeAll?: boolean, practice?: boolean) => {
     if (rMode) setReviewMode(rMode)
+    const practiceFlag = practice === true
+    setIsPractice(practiceFlag)
     setLoading(true)
     setError(null)
     setCurrentIndex(0)
@@ -59,7 +62,7 @@ export function useVocabularyReview() {
     setActiveClusterId(null)
     resetAnswerState()
     try {
-      const queue = await getReviewQueue(limit, includeAll ?? true)
+      const queue = await getReviewQueue(limit, includeAll ?? true, practiceFlag)
       setCards(queue.cards)
       setTotalDue(queue.totalDue)
       setWeeklyProgress(queue.weeklyProgress ?? null)
@@ -74,6 +77,7 @@ export function useVocabularyReview() {
 
   const startClusterSession = useCallback(async (clusterId: string, rMode?: ReviewMode) => {
     if (rMode) setReviewMode(rMode)
+    setIsPractice(false)
     setLoading(true)
     setError(null)
     setCurrentIndex(0)
@@ -113,6 +117,7 @@ export function useVocabularyReview() {
         isCorrect,
         responseTimeMs,
         selfAssessment,
+        isPractice,
       })
       setLastResult(result)
       setLastAnswerCorrect(isCorrect)
@@ -134,7 +139,7 @@ export function useVocabularyReview() {
     } finally {
       setSubmitting(false)
     }
-  }, [cards, currentIndex, submitting])
+  }, [cards, currentIndex, submitting, isPractice])
 
   const nextCard = useCallback(() => {
     const nextIdx = currentIndex + 1
@@ -177,6 +182,7 @@ export function useVocabularyReview() {
     showingNewWord,
     wrongCards,
     activeClusterId,
+    isPractice,
     startSession,
     startClusterSession,
     submitAnswer,

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -997,6 +997,11 @@
       "emptyStateSubtitle": "You've hit your weekly review target. Read — new reviews unlock as old ones age out.",
       "backToReading": "Back to reading"
     },
+    "practice": {
+      "title": "Practice",
+      "cta": "Practice anyway",
+      "subtitle": "Doesn't affect your SRS schedule"
+    },
     "retired": {
       "title": "Mastered — retired",
       "subtitle": "Graduated from review. Tap to bring back.",

--- a/apps/web/src/pages/VocabularyReviewPage.tsx
+++ b/apps/web/src/pages/VocabularyReviewPage.tsx
@@ -24,6 +24,7 @@ export function VocabularyReviewPage() {
   const [searchParams] = useSearchParams()
   const initialReviewMode = (searchParams.get('reviewMode') as ReviewMode) || 'classic'
   const clusterIdParam = searchParams.get('cluster')
+  const practiceMode = searchParams.get('practice') === '1' || searchParams.get('practice') === 'true'
   const initialBatchSize = useMemo(() => {
     const v = parseInt(searchParams.get('limit') || String(DEFAULT_BATCH_SIZE), 10)
     return (REVIEW_BATCH_SIZES as readonly number[]).includes(v) ? v : DEFAULT_BATCH_SIZE
@@ -44,10 +45,10 @@ export function VocabularyReviewPage() {
       if (clusterIdParam) {
         review.startClusterSession(clusterIdParam, initialReviewMode)
       } else {
-        review.startSession(initialBatchSize, initialReviewMode)
+        review.startSession(initialBatchSize, initialReviewMode, undefined, practiceMode)
       }
     }
-  }, [user, initialReviewMode, clusterIdParam]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [user, initialReviewMode, clusterIdParam, practiceMode]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleAnswer = (isCorrect: boolean, responseTimeMs: number, selfAssessment?: SelfAssessment) => {
     playSound(isCorrect ? 'correct' : 'wrong')
@@ -65,7 +66,7 @@ export function VocabularyReviewPage() {
     }
   }, [review.isSessionComplete]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const budgetReached = (review.weeklyProgress?.remaining ?? 1) <= 0
+  const budgetReached = !practiceMode && (review.weeklyProgress?.remaining ?? 1) <= 0
 
   // Redirect to vocabulary if no cards available AND user hasn't hit weekly cap.
   // When cap is reached, we show a dedicated "weekly goal" empty state instead.
@@ -114,8 +115,8 @@ export function VocabularyReviewPage() {
             icon="🎯"
             title={t('vocabulary.banner.budgetReached')}
             subtitle={t('vocabulary.weeklyBudget.emptyStateSubtitle')}
-            buttonLabel={t('vocabulary.weeklyBudget.backToReading')}
-            buttonTo="/library"
+            buttonLabel={t('vocabulary.practice.cta')}
+            buttonTo={`/${language}/vocabulary/review?practice=1`}
           />
         </div>
       )
@@ -160,7 +161,7 @@ export function VocabularyReviewPage() {
         </button>
       </div>
 
-      {review.weeklyProgress && <WeeklyBudgetBar progress={review.weeklyProgress} />}
+      {!practiceMode && review.weeklyProgress && <WeeklyBudgetBar progress={review.weeklyProgress} />}
 
       <div className="review-progress">
         <div className="review-progress__bar">

--- a/backend/src/Api/Endpoints/VocabularyEndpoints.cs
+++ b/backend/src/Api/Endpoints/VocabularyEndpoints.cs
@@ -453,6 +453,7 @@ public static class VocabularyEndpoints
         [FromQuery] int? limit,
         [FromQuery] string? mode,
         [FromQuery] bool? includeAll,
+        [FromQuery] bool? practice,
         CancellationToken ct)
     {
         if (!TryGetAuth(httpContext, authService, out var userId, out var siteId))
@@ -460,13 +461,17 @@ public static class VocabularyEndpoints
 
         var now = DateTimeOffset.UtcNow;
         var batchSize = Math.Min(limit ?? 10, 50);
+        var isPractice = practice == true;
 
-        // Anti-spiral F5: clamp the batch by remaining weekly budget so a user
-        // who already reviewed 70 this week sees an empty queue instead of a
-        // bottomless backlog. ResetAt is when the oldest review in the 7d
-        // window rolls off — frontend shows "back tomorrow at X" messaging.
-        var weeklyProgress = await weeklyBudget.GetProgressAsync(userId, siteId, ct);
-        var fetchLimit = Math.Min(batchSize, weeklyProgress.Remaining);
+        // Anti-spiral F5 bypass: practice mode skips the budget clamp so users
+        // can drill words anytime without waiting for the 7d window to roll.
+        // Practice rows never feed back into the budget (see WeeklyBudgetService).
+        WeeklyProgress? weeklyProgress = isPractice
+            ? null
+            : await weeklyBudget.GetProgressAsync(userId, siteId, ct);
+        var fetchLimit = isPractice
+            ? batchSize
+            : Math.Min(batchSize, weeklyProgress!.Remaining);
 
         // Retired rows (F4) are hidden from the queue — they already graduated.
         var baseQuery = db.VocabularyWords
@@ -475,7 +480,7 @@ public static class VocabularyEndpoints
         var totalDue = await baseQuery
             .CountAsync(w => w.NextReviewAt <= now, ct);
 
-        var weeklyProgressDto = ToDto(weeklyProgress);
+        var weeklyProgressDto = weeklyProgress is null ? null : ToDto(weeklyProgress);
 
         if (fetchLimit == 0)
             return Results.Ok(new ReviewQueueResponse([], totalDue, weeklyProgressDto));
@@ -489,8 +494,9 @@ public static class VocabularyEndpoints
             .Take(fetchLimit)
             .ToListAsync(ct);
 
-        // When no due words and includeAll requested, return non-due words (closest to due first)
-        if (dueWords.Count == 0 && includeAll == true)
+        // Practice mode wants something to drill even when nothing is due —
+        // fall back to closest-to-due words (same as explicit ?includeAll=true).
+        if (dueWords.Count == 0 && (includeAll == true || isPractice))
         {
             dueWords = await baseQuery
                 .OrderBy(w => w.NextReviewAt)
@@ -552,39 +558,55 @@ public static class VocabularyEndpoints
 
         var prevStage = word.Stage;
         var now = DateTimeOffset.UtcNow;
+        var isPractice = request.IsPractice;
 
-        // Always full SRS calculation
-        var (newStage, newInterval, newConsecutive) = srsEngine.Calculate(
-            word.Stage, word.ConsecutiveCorrect, word.IntervalDays, request.IsCorrect);
-        word.Stage = newStage;
-        word.IntervalDays = newInterval;
-        word.ConsecutiveCorrect = newConsecutive;
-        word.NextReviewAt = now.AddDays(newInterval);
+        // Practice mode: don't touch SRS state at all. The user wanted a way to
+        // drill words anytime without disrupting their schedule — so Stage,
+        // Interval, ConsecutiveCorrect, NextReviewAt, retirement, and the
+        // word-level review counters all stay frozen. We still write a
+        // VocabularyReview row (prefixed `practice_`) so daily stats and the
+        // streak query pick it up; AchievementChecker is skipped so users can't
+        // grind achievements by spamming practice answers.
+        int newStage = prevStage;
+        double newInterval = word.IntervalDays;
 
-        word.LastReviewedAt = now;
-        word.TotalReviews++;
-        if (request.IsCorrect) word.CorrectReviews++;
-        word.UpdatedAt = now;
-
-        // Anti-spiral F4: retire immediately on threshold cross. Waiting for
-        // the 6h sweeper would re-surface the word in the next queue fetch,
-        // negating the "Mastered" graduation UX. Respect AutoRetireEnabled —
-        // users who disabled it should keep Mastered words reviewable.
-        if (!word.IsRetired && srsEngine.ShouldAutoRetire(word.Stage, word.ConsecutiveCorrect, word.IntervalDays))
+        if (!isPractice)
         {
-            var autoRetireEnabled = await db.UserVocabularySettings
-                .Where(s => s.UserId == userId && s.SiteId == siteId)
-                .Select(s => (bool?)s.AutoRetireEnabled)
-                .FirstOrDefaultAsync(ct) ?? true;
-            if (autoRetireEnabled)
+            var (calcStage, calcInterval, calcConsecutive) = srsEngine.Calculate(
+                word.Stage, word.ConsecutiveCorrect, word.IntervalDays, request.IsCorrect);
+            newStage = calcStage;
+            newInterval = calcInterval;
+            word.Stage = newStage;
+            word.IntervalDays = newInterval;
+            word.ConsecutiveCorrect = calcConsecutive;
+            word.NextReviewAt = now.AddDays(newInterval);
+
+            word.LastReviewedAt = now;
+            word.TotalReviews++;
+            if (request.IsCorrect) word.CorrectReviews++;
+            word.UpdatedAt = now;
+
+            // Anti-spiral F4: retire immediately on threshold cross. Waiting for
+            // the 6h sweeper would re-surface the word in the next queue fetch,
+            // negating the "Mastered" graduation UX. Respect AutoRetireEnabled —
+            // users who disabled it should keep Mastered words reviewable.
+            if (!word.IsRetired && srsEngine.ShouldAutoRetire(word.Stage, word.ConsecutiveCorrect, word.IntervalDays))
             {
-                word.IsRetired = true;
-                word.RetiredAt = now;
-                word.RetiredReason = "auto_3_correct_long_interval";
+                var autoRetireEnabled = await db.UserVocabularySettings
+                    .Where(s => s.UserId == userId && s.SiteId == siteId)
+                    .Select(s => (bool?)s.AutoRetireEnabled)
+                    .FirstOrDefaultAsync(ct) ?? true;
+                if (autoRetireEnabled)
+                {
+                    word.IsRetired = true;
+                    word.RetiredAt = now;
+                    word.RetiredReason = "auto_3_correct_long_interval";
+                }
             }
         }
 
-        var reviewMode = srsEngine.GetReviewMode(prevStage, word.Sentence != null);
+        var baseReviewMode = srsEngine.GetReviewMode(prevStage, word.Sentence != null);
+        var reviewMode = isPractice ? "practice_" + baseReviewMode : baseReviewMode;
         var review = new VocabularyReview
         {
             Id = Guid.NewGuid(),
@@ -602,10 +624,15 @@ public static class VocabularyEndpoints
         db.VocabularyReviews.Add(review);
         await db.SaveChangesAsync(ct);
 
-        // Check streak achievements (vocab reviews now count toward streak)
-        var streakMinMinutes = await ReadingTrackingEndpoints.GetStreakMinMinutes(db, userId, siteId, ct);
-        var currentStreak = await ReadingTrackingEndpoints.CalculateStreak(db, userId, siteId, streakMinMinutes, now, ct);
-        await new AchievementChecker(db).CheckAfterReview(userId, siteId, currentStreak, ct);
+        // SRS-only path runs achievement checks. Practice rows still hit the
+        // streak query (it scans VocabularyReviews) but skipping the checker
+        // here prevents grinding "1000 reviews"-style achievements.
+        if (!isPractice)
+        {
+            var streakMinMinutes = await ReadingTrackingEndpoints.GetStreakMinMinutes(db, userId, siteId, ct);
+            var currentStreak = await ReadingTrackingEndpoints.CalculateStreak(db, userId, siteId, streakMinMinutes, now, ct);
+            await new AchievementChecker(db).CheckAfterReview(userId, siteId, currentStreak, ct);
+        }
 
         return Results.Ok(new SubmitReviewResponse(
             word.Id, prevStage, newStage, prevStage != newStage,
@@ -1457,7 +1484,7 @@ public record VocabWordDto(
     int TotalReviews, int CorrectReviews,
     DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
 
-public record ReviewQueueResponse(List<ReviewCardDto> Cards, int TotalDue, WeeklyProgressDto WeeklyProgress);
+public record ReviewQueueResponse(List<ReviewCardDto> Cards, int TotalDue, WeeklyProgressDto? WeeklyProgress);
 
 public record WeeklyProgressDto(int Used, int Budget, int Remaining, DateTimeOffset ResetAt);
 
@@ -1468,7 +1495,7 @@ public record ReviewCardDto(
     string? Hint, string? Explanation, bool IsNew,
     List<string>? Options, int? CorrectOptionIndex);
 
-public record SubmitReviewRequest(Guid WordId, bool IsCorrect, int ResponseTimeMs, string? Mode = null, string? SelfAssessment = null);
+public record SubmitReviewRequest(Guid WordId, bool IsCorrect, int ResponseTimeMs, string? Mode = null, string? SelfAssessment = null, bool IsPractice = false);
 
 public record SubmitReviewResponse(
     Guid WordId, int PreviousStage, int NewStage, bool StageChanged,

--- a/backend/src/Application/Vocabulary/WeeklyBudgetService.cs
+++ b/backend/src/Application/Vocabulary/WeeklyBudgetService.cs
@@ -17,8 +17,11 @@ public class WeeklyBudgetService(IAppDbContext db)
         var now = DateTimeOffset.UtcNow;
         var since = now.AddDays(-7);
 
+        // Practice rows (ReviewMode prefixed `practice_`) are excluded — they
+        // bypass the budget by design, so they must not feed back into it.
         var used = await db.VocabularyReviews
-            .Where(r => r.UserId == userId && r.SiteId == siteId && r.CreatedAt >= since)
+            .Where(r => r.UserId == userId && r.SiteId == siteId && r.CreatedAt >= since
+                && !r.ReviewMode.StartsWith("practice_"))
             .CountAsync(ct);
 
         var budget = await db.UserVocabularySettings
@@ -29,7 +32,8 @@ public class WeeklyBudgetService(IAppDbContext db)
         // ResetAt = oldest review in window rolls off → window opens up.
         // If no reviews in window, budget resets immediately (now).
         var oldestInWindow = await db.VocabularyReviews
-            .Where(r => r.UserId == userId && r.SiteId == siteId && r.CreatedAt >= since)
+            .Where(r => r.UserId == userId && r.SiteId == siteId && r.CreatedAt >= since
+                && !r.ReviewMode.StartsWith("practice_"))
             .OrderBy(r => r.CreatedAt)
             .Select(r => (DateTimeOffset?)r.CreatedAt)
             .FirstOrDefaultAsync(ct);

--- a/packages/shared/src/api/vocabulary.ts
+++ b/packages/shared/src/api/vocabulary.ts
@@ -57,9 +57,9 @@ export function deleteWord(id: string) {
   return authFetch<void>(`/me/vocabulary/words/${id}`, { method: 'DELETE' })
 }
 
-export function getReviewQueue(limit?: number) {
-  return authFetch<{ cards: ReviewCardDto[]; totalDue: number; weeklyProgress: WeeklyProgressDto }>(
-    `/me/vocabulary/review${buildQuery({ limit })}`
+export function getReviewQueue(limit?: number, practice?: boolean) {
+  return authFetch<{ cards: ReviewCardDto[]; totalDue: number; weeklyProgress: WeeklyProgressDto | null }>(
+    `/me/vocabulary/review${buildQuery({ limit, practice: practice ? true : undefined })}`
   )
 }
 
@@ -75,7 +75,7 @@ export function unretireWord(id: string) {
   return authFetch<VocabularyWordDto>(`/me/vocabulary/words/${id}/unretire`, { method: 'POST' })
 }
 
-export function submitReview(data: { wordId: string; isCorrect: boolean; responseTimeMs: number; selfAssessment?: string }) {
+export function submitReview(data: { wordId: string; isCorrect: boolean; responseTimeMs: number; selfAssessment?: string; isPractice?: boolean }) {
   return authFetch<SubmitReviewResponse>('/me/vocabulary/review', jsonBody('POST', data))
 }
 

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -593,6 +593,11 @@
     "banner": {
       "budgetReached": "Weekly goal reached. See you next week!"
     },
+    "practice": {
+      "title": "Practice",
+      "cta": "Practice anyway",
+      "subtitle": "Doesn't affect your SRS schedule"
+    },
     "retired": {
       "title": "Mastered — retired",
       "subtitle": "Graduated from review. Tap to bring back.",

--- a/tests/TextStack.IntegrationTests/VocabularyPracticeTests.cs
+++ b/tests/TextStack.IntegrationTests/VocabularyPracticeTests.cs
@@ -1,0 +1,182 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace TextStack.IntegrationTests;
+
+/// <summary>
+/// Practice mode contract:
+/// <list type="bullet">
+///   <item><c>GET /me/vocabulary/review?practice=true</c> returns <c>weeklyProgress=null</c>.</item>
+///   <item><c>POST /me/vocabulary/review</c> with <c>isPractice=true</c> doesn't mutate Stage / IntervalDays / NextReviewAt.</item>
+///   <item>Practice rows don't count against the weekly budget.</item>
+/// </list>
+/// </summary>
+[Collection("VocabularySpiral")]
+public class VocabularyPracticeTests : IClassFixture<AuthenticatedApiFixture>
+{
+    private readonly AuthenticatedApiFixture _auth;
+
+    public VocabularyPracticeTests(AuthenticatedApiFixture auth)
+    {
+        _auth = auth;
+    }
+
+    private const string SrsLang = "de";
+
+    private static bool ShouldSkip(HttpResponseMessage r) =>
+        r.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.InternalServerError;
+
+    private string UniqueWord(string prefix) => $"{prefix}{Guid.NewGuid():N}"[..16];
+
+    private async Task<HttpResponseMessage> SaveWordAsync(string word, string language, CancellationToken ct)
+    {
+        var req = _auth.CreateRequest(HttpMethod.Post, "/me/vocabulary/words");
+        req.Content = JsonContent.Create(new { word, language, nativeLanguage = "en" });
+        return await _auth.Client.SendAsync(req, ct);
+    }
+
+    private async Task<JsonElement> GetWordAsync(string wordId, CancellationToken ct)
+    {
+        var resp = await _auth.Client.SendAsync(
+            _auth.CreateRequest(HttpMethod.Get, $"/me/vocabulary/words?search="), ct);
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+        foreach (var w in body.GetProperty("items").EnumerateArray())
+        {
+            if (w.GetProperty("id").GetString() == wordId)
+                return w.Clone();
+        }
+        throw new InvalidOperationException($"Word {wordId} not found");
+    }
+
+    private async Task DeleteWordAsync(string wordId, CancellationToken ct)
+    {
+        await _auth.Client.SendAsync(_auth.CreateRequest(HttpMethod.Delete, $"/me/vocabulary/words/{wordId}"), ct);
+    }
+
+    [Fact]
+    public async Task GetReviewQueue_PracticeFlag_ReturnsNullWeeklyProgress()
+    {
+        if (!_auth.IsAuthenticated) return;
+        var ct = TestContext.Current.CancellationToken;
+
+        var resp = await _auth.Client.SendAsync(
+            _auth.CreateRequest(HttpMethod.Get, "/me/vocabulary/review?practice=true"), ct);
+        if (ShouldSkip(resp)) return;
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+
+        // Practice mode hides budget UI — null is the contract the FE relies on
+        // to skip the WeeklyBudgetBar render.
+        Assert.Equal(JsonValueKind.Null, body.GetProperty("weeklyProgress").ValueKind);
+    }
+
+    [Fact]
+    public async Task SubmitReview_PracticeMode_DoesNotMutateSrsState()
+    {
+        if (!_auth.IsAuthenticated) return;
+        var ct = TestContext.Current.CancellationToken;
+
+        // Need a real SRS-eligible word. "de" bypasses the EN frequency filter.
+        var save = await SaveWordAsync(UniqueWord("zzpract"), SrsLang, ct);
+        if (ShouldSkip(save)) return;
+        save.EnsureSuccessStatusCode();
+        var saveBody = await save.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+        if (saveBody.GetProperty("outcome").GetString() != "srs") return; // pending/lookup — skip
+        var wordId = saveBody.GetProperty("word").GetProperty("id").GetString()!;
+
+        try
+        {
+            var before = await GetWordAsync(wordId, ct);
+            var beforeStage = before.GetProperty("stage").GetInt32();
+            var beforeInterval = before.GetProperty("intervalDays").GetDouble();
+            var beforeNextReview = before.GetProperty("nextReviewAt").GetString();
+            var beforeTotal = before.GetProperty("totalReviews").GetInt32();
+            var beforeCorrect = before.GetProperty("correctReviews").GetInt32();
+
+            var submit = _auth.CreateRequest(HttpMethod.Post, "/me/vocabulary/review");
+            submit.Content = JsonContent.Create(new
+            {
+                wordId,
+                isCorrect = true,
+                responseTimeMs = 1500,
+                isPractice = true,
+            });
+            var submitResp = await _auth.Client.SendAsync(submit, ct);
+            if (ShouldSkip(submitResp)) return;
+            submitResp.EnsureSuccessStatusCode();
+
+            // Backend response echoes "no movement" — same stage in/out, same interval.
+            var submitBody = await submitResp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+            Assert.Equal(beforeStage, submitBody.GetProperty("previousStage").GetInt32());
+            Assert.Equal(beforeStage, submitBody.GetProperty("newStage").GetInt32());
+            Assert.False(submitBody.GetProperty("stageChanged").GetBoolean());
+
+            // DB state must match exactly — Stage / Interval / NextReviewAt frozen.
+            var after = await GetWordAsync(wordId, ct);
+            Assert.Equal(beforeStage, after.GetProperty("stage").GetInt32());
+            Assert.Equal(beforeInterval, after.GetProperty("intervalDays").GetDouble());
+            Assert.Equal(beforeNextReview, after.GetProperty("nextReviewAt").GetString());
+            // Per plan: practice doesn't bump the word-level review counters.
+            Assert.Equal(beforeTotal, after.GetProperty("totalReviews").GetInt32());
+            Assert.Equal(beforeCorrect, after.GetProperty("correctReviews").GetInt32());
+        }
+        finally
+        {
+            await DeleteWordAsync(wordId, ct);
+        }
+    }
+
+    [Fact]
+    public async Task SubmitReview_PracticeMode_DoesNotConsumeWeeklyBudget()
+    {
+        if (!_auth.IsAuthenticated) return;
+        var ct = TestContext.Current.CancellationToken;
+
+        var save = await SaveWordAsync(UniqueWord("zzbud"), SrsLang, ct);
+        if (ShouldSkip(save)) return;
+        save.EnsureSuccessStatusCode();
+        var saveBody = await save.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+        if (saveBody.GetProperty("outcome").GetString() != "srs") return;
+        var wordId = saveBody.GetProperty("word").GetProperty("id").GetString()!;
+
+        try
+        {
+            var queueBefore = await _auth.Client.SendAsync(
+                _auth.CreateRequest(HttpMethod.Get, "/me/vocabulary/review"), ct);
+            queueBefore.EnsureSuccessStatusCode();
+            var beforeBody = await queueBefore.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+            var usedBefore = beforeBody.GetProperty("weeklyProgress").GetProperty("used").GetInt32();
+
+            // 3 practice submissions — none should land in the weekly budget count.
+            for (var i = 0; i < 3; i++)
+            {
+                var submit = _auth.CreateRequest(HttpMethod.Post, "/me/vocabulary/review");
+                submit.Content = JsonContent.Create(new
+                {
+                    wordId,
+                    isCorrect = true,
+                    responseTimeMs = 1000,
+                    isPractice = true,
+                });
+                var submitResp = await _auth.Client.SendAsync(submit, ct);
+                if (ShouldSkip(submitResp)) return;
+                submitResp.EnsureSuccessStatusCode();
+            }
+
+            var queueAfter = await _auth.Client.SendAsync(
+                _auth.CreateRequest(HttpMethod.Get, "/me/vocabulary/review"), ct);
+            queueAfter.EnsureSuccessStatusCode();
+            var afterBody = await queueAfter.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+            var usedAfter = afterBody.GetProperty("weeklyProgress").GetProperty("used").GetInt32();
+
+            Assert.Equal(usedBefore, usedAfter);
+        }
+        finally
+        {
+            await DeleteWordAsync(wordId, ct);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **practice mode** for the vocabulary SRS — drill words anytime without hitting the 70/week anti-spiral budget AND without disturbing SRS state (Stage / Interval / NextReviewAt).

- Hybrid endpoint: `GET /me/vocabulary/review?practice=true` skips the weekly-budget clamp; `POST /me/vocabulary/review` accepts `isPractice` to skip all SRS mutations.
- `ReviewMode` prefixed `practice_*` — already filtered by stats queries (`VocabularyEndpoints.cs:658,791-792`) and now by `WeeklyBudgetService` so practice rows never feed back into the budget window.
- `AchievementChecker` is skipped on practice rows (anti-grind); `VocabularyReview` row still written so streak query naturally counts the day.
- Mobile + web: `?practice=1` on the review screen, swap budget-reached empty state CTA to "Practice anyway", hide `WeeklyBudgetBar` in practice sessions.

## Why

Today: user does 70 reviews, half wrong → blocked for ~1 week till oldest reviews fall out of the rolling window. Product thesis is "we do not interrupt reading. We enhance it." — practice mode keeps the budget as a real SRS scheduler signal but gives an always-on drill path.

## Test plan

- [ ] `dotnet build` (verified locally — clean)
- [ ] `tsc --noEmit` mobile / web / shared (verified locally — clean)
- [ ] Add backend tests: `SubmitReview_PracticeMode_DoesNotMutateSrsState`, `Practice_OverBudget_ReturnsCards`, `Practice_DoesNotConsumeBudget`
- [ ] Mobile e2e: budget-reached → "Practice anyway" CTA → drill cards
- [ ] Manual: fill budget on staging, verify Practice CTA renders, drill ≥10 cards, verify Stage unchanged in DB

## Unresolved

- Increment `TotalReviews`/`CorrectReviews`/`LastReviewedAt` on practice? *(default: NO — keep SRS counters honest)*
- Cluster bonus also accept `practice` flag? *(default: NO — cluster bonus already off-budget)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)