### PR TITLE
vocab: fix dup vocabulary.practice i18n key (Practice CTA)

### DIFF
--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1000,19 +1000,17 @@
     "practice": {
       "title": "Practice",
       "cta": "Practice anyway",
-      "subtitle": "Doesn't affect your SRS schedule"
-    },
-    "retired": {
-      "title": "Mastered — retired",
-      "subtitle": "Graduated from review. Tap to bring back.",
-      "unretire": "Bring back to review"
-    },
-    "practice": {
+      "subtitle": "Doesn't affect your SRS schedule",
       "mode": "Mode",
       "length": "Length",
       "flashcards": "Flashcards",
       "blitz": "Blitz",
       "wordsUnit": "words"
+    },
+    "retired": {
+      "title": "Mastered — retired",
+      "subtitle": "Graduated from review. Tap to bring back.",
+      "unretire": "Bring back to review"
     },
     "chart": {
       "title": "Practice every day",


### PR DESCRIPTION
## Summary
- PR #191 added `vocabulary.practice.{title,cta,subtitle}` but a prior block at the same level had `{mode,length,flashcards,blitz,wordsUnit}` — JSON keeps last dup → `cta` lost
- "Practice anyway" button rendered raw key `vocabulary.practice.cta`
- Merge both into one block

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [x] `j.vocabulary.practice.cta === "Practice anyway"` and old keys still resolve
- [ ] After deploy: budget-reached empty state shows "Practice anyway" button → routes to `?practice=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)