### PR TITLE
reader: scroll to top on chapter change without saved offset

### DIFF
--- a/apps/web/src/hooks/useReaderScrollSync.ts
+++ b/apps/web/src/hooks/useReaderScrollSync.ts
@@ -58,31 +58,25 @@ export function useReaderScrollSync({
     scrollRestoredRef.current = false
   }, [chapterIdentifier])
 
-  // Restore scroll: locator must match current chapter, otherwise URL wins.
+  // Restore scroll: locator must match current chapter. Otherwise scroll to
+  // top — React Router preserves scrollY across route changes, so without
+  // this, hitting "Next" at the bottom of ch1 leaves you mid-/end-of ch2.
   useEffect(() => {
     if (scrollRestoredRef.current || effectiveLoading) return
     if (!chapterLoaded) return
 
-    if (!effectiveProgress?.locator?.startsWith('scroll:')) {
-      scrollRestoredRef.current = true
-      return
-    }
-
-    const parts = effectiveProgress.locator.split(':')
-    if (parts.length < 3) {
-      scrollRestoredRef.current = true
-      return
-    }
-
-    const savedSlug = parts[1]
-    const savedOffset = parseInt(parts[2], 10)
-    if (isNaN(savedOffset) || savedSlug !== chapterIdentifier) {
-      scrollRestoredRef.current = true
-      return
-    }
+    const targetOffset = (() => {
+      if (!effectiveProgress?.locator?.startsWith('scroll:')) return 0
+      const parts = effectiveProgress.locator.split(':')
+      if (parts.length < 3) return 0
+      const savedSlug = parts[1]
+      const savedOffset = parseInt(parts[2], 10)
+      if (isNaN(savedOffset) || savedSlug !== chapterIdentifier) return 0
+      return savedOffset
+    })()
 
     requestAnimationFrame(() => {
-      window.scrollTo({ top: savedOffset, behavior: 'instant' })
+      window.scrollTo({ top: targetOffset, behavior: 'instant' })
       scrollRestoredRef.current = true
     })
   }, [chapterLoaded, effectiveLoading, effectiveProgress, chapterIdentifier])


### PR DESCRIPTION
## Summary
- React Router preserves \`scrollY\` across route changes → clicking "Next" at the bottom of ch1 leaves the reader deep inside / past the start of ch2
- \`useReaderScrollSync\` restored scroll only when locator matched the new chapter; the three "no restore" branches just flipped \`scrollRestoredRef\` without resetting \`scrollY\`
- Collapse them: target defaults to 0, chapter-match restore overrides

## Test plan
- [x] \`pnpm tsc --noEmit\` passes
- [x] \`pnpm vitest run src/hooks\` — 99/99 green
- [ ] After deploy: scroll to bottom of ch1, click Next → ch2 starts at top
- [ ] Refresh mid-chapter → still restores to saved scroll position
- [ ] TOC jump (\`?direct=1\`) → starts at top

🤖 Generated with [Claude Code](https://claude.com/claude-code)