### PR TITLE
tests: pin reader scroll + i18n no-dup-keys

### DIFF
--- a/apps/web/src/hooks/__tests__/useReaderScrollSync.test.ts
+++ b/apps/web/src/hooks/__tests__/useReaderScrollSync.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useReaderScrollSync } from '../useReaderScrollSync'
+
+// rAF runs sync in tests so window.scrollTo fires within renderHook.
+beforeEach(() => {
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    cb(0)
+    return 0
+  })
+  window.scrollTo = vi.fn() as unknown as typeof window.scrollTo
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+const noopProgress = {
+  updateProgress: vi.fn(),
+  flushSave: vi.fn(),
+}
+const noopUserProgress = {
+  saveProgress: vi.fn(),
+  flushSave: vi.fn(),
+}
+
+const baseProps = {
+  mode: 'public' as const,
+  chapterIdentifier: 'ch1',
+  chapterLoaded: true,
+  overallProgress: 0,
+  effectiveProgress: null,
+  effectiveLoading: false,
+  publicBookChapters: [{ id: 'ch1-id', slug: 'ch1' }] as any,
+  publicProgress: noopProgress,
+  userProgress: noopUserProgress,
+}
+
+describe('useReaderScrollSync — scroll restore', () => {
+  it('scrolls to top when no saved progress', () => {
+    renderHook(() => useReaderScrollSync(baseProps))
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'instant' })
+  })
+
+  it('scrolls to top when locator does not start with scroll:', () => {
+    renderHook(() =>
+      useReaderScrollSync({ ...baseProps, effectiveProgress: { locator: 'percent:0.5' } }),
+    )
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'instant' })
+  })
+
+  it('scrolls to top when locator chapter slug does not match current chapter', () => {
+    renderHook(() =>
+      useReaderScrollSync({
+        ...baseProps,
+        chapterIdentifier: 'ch2',
+        effectiveProgress: { locator: 'scroll:ch1:5000' },
+      }),
+    )
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'instant' })
+  })
+
+  it('scrolls to top when locator is malformed (parts < 3)', () => {
+    renderHook(() =>
+      useReaderScrollSync({ ...baseProps, effectiveProgress: { locator: 'scroll:ch1' } }),
+    )
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'instant' })
+  })
+
+  it('scrolls to top when offset is NaN', () => {
+    renderHook(() =>
+      useReaderScrollSync({ ...baseProps, effectiveProgress: { locator: 'scroll:ch1:abc' } }),
+    )
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'instant' })
+  })
+
+  it('restores to saved offset when locator chapter matches', () => {
+    renderHook(() =>
+      useReaderScrollSync({
+        ...baseProps,
+        effectiveProgress: { locator: 'scroll:ch1:5000' },
+      }),
+    )
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 5000, behavior: 'instant' })
+  })
+
+  it('does not restore while effectiveLoading', () => {
+    renderHook(() =>
+      useReaderScrollSync({
+        ...baseProps,
+        effectiveLoading: true,
+        effectiveProgress: { locator: 'scroll:ch1:5000' },
+      }),
+    )
+    expect(window.scrollTo).not.toHaveBeenCalled()
+  })
+
+  it('does not restore while chapter not loaded', () => {
+    renderHook(() =>
+      useReaderScrollSync({
+        ...baseProps,
+        chapterLoaded: false,
+        effectiveProgress: { locator: 'scroll:ch1:5000' },
+      }),
+    )
+    expect(window.scrollTo).not.toHaveBeenCalled()
+  })
+
+  it('on chapter change with stale locator (savedSlug=ch1, new=ch2) → scrolls to top', () => {
+    // Simulates the bug PR #193 fixed: user clicks Next at the bottom of ch1,
+    // chapterIdentifier flips to ch2, locator still points at ch1.
+    const { rerender } = renderHook((props: typeof baseProps) => useReaderScrollSync(props), {
+      initialProps: { ...baseProps, effectiveProgress: { locator: 'scroll:ch1:8000' } },
+    })
+    // First render restored to saved offset.
+    expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 8000, behavior: 'instant' })
+    ;(window.scrollTo as any).mockClear()
+
+    rerender({
+      ...baseProps,
+      chapterIdentifier: 'ch2',
+      effectiveProgress: { locator: 'scroll:ch1:8000' },
+    })
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'instant' })
+  })
+})

--- a/apps/web/src/locales/__tests__/no-duplicate-keys.test.ts
+++ b/apps/web/src/locales/__tests__/no-duplicate-keys.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+// JSON.parse silently keeps the LAST duplicate key — silently shadowing earlier
+// translations. We hit this in PR #191 → #192 (vocabulary.practice block had
+// title/cta/subtitle on one line and mode/length/blitz on another → cta lost).
+//
+// This walks the source text and reports any key declared twice in the same
+// object scope. Pure string scan, no parser dep.
+function findDuplicateKeys(jsonText: string): string[] {
+  const dups: string[] = []
+  const stack: { keys: Set<string>; path: string }[] = [{ keys: new Set(), path: '$' }]
+  let i = 0
+  let inString = false
+  let escape = false
+  let stringStart = -1
+
+  while (i < jsonText.length) {
+    const c = jsonText[i]
+
+    if (inString) {
+      if (escape) {
+        escape = false
+      } else if (c === '\\') {
+        escape = true
+      } else if (c === '"') {
+        // String just ended at index i. Check if this is a key (next non-space is ':').
+        const value = jsonText.slice(stringStart + 1, i)
+        let j = i + 1
+        while (j < jsonText.length && /\s/.test(jsonText[j])) j++
+        if (jsonText[j] === ':') {
+          const scope = stack[stack.length - 1]
+          if (scope.keys.has(value)) {
+            dups.push(`${scope.path}.${value}`)
+          } else {
+            scope.keys.add(value)
+          }
+        }
+        inString = false
+      }
+      i++
+      continue
+    }
+
+    if (c === '"') {
+      inString = true
+      stringStart = i
+      i++
+      continue
+    }
+
+    if (c === '{') {
+      stack.push({ keys: new Set(), path: stack[stack.length - 1]?.path + '.{}' })
+    } else if (c === '}') {
+      stack.pop()
+    }
+
+    i++
+  }
+
+  return dups
+}
+
+const cases = [
+  { name: 'apps/web/src/locales/en.json', path: resolve(__dirname, '../en.json') },
+  {
+    name: 'packages/shared/src/i18n/en.json',
+    path: resolve(__dirname, '../../../../../packages/shared/src/i18n/en.json'),
+  },
+]
+
+describe('i18n source files have no duplicate keys', () => {
+  for (const { name, path } of cases) {
+    it(name, () => {
+      const text = readFileSync(path, 'utf8')
+      const dups = findDuplicateKeys(text)
+      expect(dups).toEqual([])
+    })
+  }
+
+  it('detector catches a duplicate', () => {
+    const dups = findDuplicateKeys('{ "a": 1, "b": { "x": 1, "x": 2 } }')
+    expect(dups.length).toBe(1)
+    expect(dups[0]).toContain('x')
+  })
+
+  it('detector ignores same key in different scopes', () => {
+    const dups = findDuplicateKeys('{ "a": { "x": 1 }, "b": { "x": 2 } }')
+    expect(dups).toEqual([])
+  })
+
+  it('detector ignores key strings inside string values', () => {
+    const dups = findDuplicateKeys('{ "msg": "key: value", "other": 1 }')
+    expect(dups).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
Preventive tests for the two bugs shipped this session.

- \`useReaderScrollSync\` — 9 tests pinning PR #193 (chapter change scrolls to top, locator-match restores, malformed locator → top, etc.)
- i18n source-text scanner — pins PR #192 (catches duplicate keys at same object scope across en.json files). Pure string scan, no parser dep.

## Test plan
- [x] \`pnpm vitest run src/hooks/__tests__/useReaderScrollSync.test.ts\` — 9/9
- [x] \`pnpm vitest run src/locales/__tests__/no-duplicate-keys.test.ts\` — 5/5
- [x] Full suite \`pnpm vitest run --no-file-parallelism\` — 419/419
- Sanity: detector smoke test confirms it actually catches a dup

🤖 Generated with [Claude Code](https://claude.com/claude-code)