### PR TITLE
test: deflake NativeLanguage updateProfile test

### DIFF
--- a/apps/web/src/context/__tests__/NativeLanguageContext.test.tsx
+++ b/apps/web/src/context/__tests__/NativeLanguageContext.test.tsx
@@ -129,7 +129,12 @@ describe('NativeLanguageContext', () => {
     })
 
     const { result } = renderHook(() => useNativeLanguage(), { wrapper })
-    await waitFor(() => expect(result.current.nativeLanguage).toBe('en'))
+    // Wait for auth bootstrap to actually load the user — `nativeLanguage`
+    // defaults to 'en' from navigator.language before user is set, so waiting
+    // on it races: we'd fire setNativeLanguage with user still null and
+    // updateProfile would be skipped. hasConfirmedLanguage flips true only
+    // inside the server→local effect, which requires user.
+    await waitFor(() => expect(result.current.hasConfirmedLanguage).toBe(true))
 
     act(() => result.current.setNativeLanguage('fr'))
 


### PR DESCRIPTION
## Summary
- Wait condition raced: \`nativeLanguage === 'en'\` is true on first render via \`detectDefault() → navigator.language\`, **before** \`getCurrentUser\` resolves and \`user\` enters state. \`setNativeLanguage('fr')\` then runs with user=null closure, skipping the \`updateProfile\` branch.
- Solo runs won the race; parallel pressure surfaced the bug — spy called 0 times.
- Wait on \`hasConfirmedLanguage === true\` instead — it flips inside the server→local effect, which gates on \`user\`.

## Test plan
- [x] \`pnpm vitest run\` — 419/419 (3 runs in a row, stable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)