### PR TITLE
mobile reader: fix stale chapter in footer/topbar + highlights race

### DIFF
--- a/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
+++ b/apps/mobile/app/reader/[bookSlug]/[chapterSlug].tsx
@@ -97,6 +97,19 @@ export default function ReaderScreen() {
     remove: removeBookmark,
   } = useReaderBookmarks({ editionIdRef, isAuthenticated, showToast })
 
+  // Hoisted above useReaderHighlights so its `editionId` state is available
+  // — without it the highlights effect can race chapterId against editionId
+  // and miss the load when chapter wins.
+  const { bookTitle, chapters, editionId } = useReaderBook({
+    bookSlug,
+    language,
+    isAuthenticated,
+    editionIdRef,
+    bookTitleRef,
+    totalWordCountRef,
+    setBookmarks,
+  })
+
   const {
     highlightsRef,
     editingHighlight,
@@ -105,6 +118,7 @@ export default function ReaderScreen() {
     saveNote: saveHighlightNote,
     remove: removeHighlight,
   } = useReaderHighlights({
+    editionId,
     editionIdRef,
     user,
     isAuthenticated,
@@ -176,16 +190,6 @@ export default function ReaderScreen() {
     editionId: editionIdRef.current,
     wordCount: wordCountRef.current,
     isAuthenticated,
-  })
-
-  const { bookTitle, chapters } = useReaderBook({
-    bookSlug,
-    language,
-    isAuthenticated,
-    editionIdRef,
-    bookTitleRef,
-    totalWordCountRef,
-    setBookmarks,
   })
 
   const { saveProgress } = useReaderProgress({
@@ -270,7 +274,10 @@ export default function ReaderScreen() {
     } catch (err) {
       if (__DEV__) console.warn('[reader] postMessage handler threw', err, event?.nativeEvent?.data)
     }
-  }, [chapter, language, settings.ttsSpeed, toggleTts, toggleBars, showBars, hideBars, vocabActions, setEditingHighlight, highlightsRef, updateSessionProgress, enableInfiniteScrollFor, loadNextChapter, openSelection, autoSavedRef])
+    // Refs (highlightsRef, autoSavedRef) are read inside but intentionally
+    // omitted from deps — refs don't trigger re-creation and listing them
+    // here only adds noise.
+  }, [chapter, language, settings.ttsSpeed, toggleTts, toggleBars, showBars, hideBars, vocabActions, setEditingHighlight, updateSessionProgress, enableInfiniteScrollFor, loadNextChapter, openSelection])
 
   const navigateChapter = (slug: string) => {
     saveProgress()
@@ -278,6 +285,11 @@ export default function ReaderScreen() {
   }
 
   const activeSlug = visibleChapterSlug ?? chapterSlug
+  // Footer/topbar reflect the chapter that's actually visible — during
+  // infinite scroll the URL chapterSlug stays put while visibleChapterSlug
+  // advances, so reading `chapter.title` (URL-keyed via useReaderChapter)
+  // would show the wrong title and counter.
+  const activeChapter = chapters.find(c => c.slug === activeSlug)
   const isCurrentBookmarked = isBookmarked(activeSlug)
   const toggleCurrentBookmark = () => {
     if (!chapter || !activeSlug) return
@@ -304,8 +316,8 @@ export default function ReaderScreen() {
 
   const isMultiWord = !!(selection && selection.text.includes(' '))
 
-  // Chapter counter for footer
-  const currentChapterIndex = chapters.findIndex(c => c.slug === chapterSlug)
+  // Chapter counter for footer — track the visible chapter, not the URL's.
+  const currentChapterIndex = chapters.findIndex(c => c.slug === activeSlug)
   const totalChapters = chapters.length
 
   // Large HTML string. Rebuilding every render burns CPU and — if the
@@ -463,7 +475,7 @@ export default function ReaderScreen() {
           barsVisible={barsVisible}
           topInset={insets.top}
           bookTitle={bookTitle}
-          chapterTitle={chapter.title}
+          chapterTitle={activeChapter?.title ?? chapter.title}
           sessionWordCount={sessionWordCount}
           isAuthenticated={isAuthenticated}
           hasChapters={chapters.length > 0}
@@ -538,7 +550,7 @@ export default function ReaderScreen() {
 
             <View style={styles.footerInfo}>
               <Text style={[styles.footerChapter, { color: barText }]} numberOfLines={1}>
-                {chapter?.title || ''}
+                {activeChapter?.title ?? chapter?.title ?? ''}
               </Text>
               <View style={styles.footerMeta}>
                 {totalChapters > 1 && currentChapterIndex >= 0 && (

--- a/apps/mobile/src/hooks/useReaderBook.ts
+++ b/apps/mobile/src/hooks/useReaderBook.ts
@@ -39,6 +39,10 @@ export function useReaderBook({
 }: Options) {
   const [bookTitle, setBookTitle] = useState('')
   const [chapters, setChapters] = useState<ChapterSummary[]>([])
+  // State mirror of editionIdRef so consumers (e.g. useReaderHighlights) can
+  // depend on it in effect deps. The ref alone wouldn't re-trigger an effect
+  // when its value lands after chapterId.
+  const [editionId, setEditionId] = useState<string | null>(null)
   const bookOpenedFiredRef = useRef(false)
 
   useEffect(() => {
@@ -49,6 +53,7 @@ export function useReaderBook({
       .then(b => {
         if (cancelled) return
         editionIdRef.current = b.id
+        setEditionId(b.id)
         bookTitleRef.current = b.title
         setBookTitle(b.title)
         if (!bookOpenedFiredRef.current) {
@@ -71,6 +76,7 @@ export function useReaderBook({
           const match = books.find(b => b.slug === bookSlug)
           if (match) {
             editionIdRef.current = match.editionId
+            setEditionId(match.editionId)
             bookTitleRef.current = match.title
             setBookTitle(match.title)
           }
@@ -79,5 +85,5 @@ export function useReaderBook({
     return () => { cancelled = true }
   }, [bookSlug, isAuthenticated, language, editionIdRef, bookTitleRef, totalWordCountRef, setBookmarks])
 
-  return { bookTitle, chapters }
+  return { bookTitle, chapters, editionId }
 }

--- a/apps/mobile/src/hooks/useReaderHighlights.ts
+++ b/apps/mobile/src/hooks/useReaderHighlights.ts
@@ -8,6 +8,9 @@ type ToastFn = (t: { message: string; variant: 'error' | 'success' | 'info' }) =
 type User = { id: string } | null | undefined
 
 type Options = {
+  /** State mirror — must come from useState so the load effect re-runs when it lands. */
+  editionId: string | null
+  /** Sync handle for callbacks (create/saveNote/remove) that fire later. */
   editionIdRef: MutableRefObject<string | null>
   user: User
   isAuthenticated: boolean
@@ -17,6 +20,7 @@ type Options = {
 }
 
 export function useReaderHighlights({
+  editionId,
   editionIdRef,
   user,
   isAuthenticated,
@@ -31,9 +35,10 @@ export function useReaderHighlights({
   // for offline survival; API refresh overwrites. Cache keyed per-user so
   // device-shared sign-ins can't leak another account's highlights.
   // Keys off chapterId (not the chapter object) so a refetch with the same
-  // id doesn't re-trigger.
+  // id doesn't re-trigger. Keys off editionId state (not the ref) so a race
+  // where chapterId arrives before editionId still loads highlights once
+  // editionId lands.
   useEffect(() => {
-    const editionId = editionIdRef.current
     if (!isAuthenticated || !editionId || !chapterId) return
     let cancelled = false
 
@@ -60,7 +65,7 @@ export function useReaderHighlights({
       })
       .catch(() => { /* offline — cache paint already rendered */ })
     return () => { cancelled = true }
-  }, [isAuthenticated, chapterId, user?.id, editionIdRef, injectJs])
+  }, [isAuthenticated, chapterId, user?.id, editionId, injectJs])
 
   const create = useCallback(
     async ({ color, selection, chapter }: { color: string; selection: NonNullable<Selection>; chapter: Chapter }) => {

--- a/apps/web/src/hooks/__tests__/useReaderScrollSync.test.ts
+++ b/apps/web/src/hooks/__tests__/useReaderScrollSync.test.ts
@@ -25,8 +25,10 @@ const noopUserProgress = {
   flushSave: vi.fn(),
 }
 
-const baseProps = {
-  mode: 'public' as const,
+type Props = Parameters<typeof useReaderScrollSync>[0]
+
+const baseProps: Props = {
+  mode: 'public',
   chapterIdentifier: 'ch1',
   chapterLoaded: true,
   overallProgress: 0,
@@ -110,7 +112,7 @@ describe('useReaderScrollSync — scroll restore', () => {
   it('on chapter change with stale locator (savedSlug=ch1, new=ch2) → scrolls to top', () => {
     // Simulates the bug PR #193 fixed: user clicks Next at the bottom of ch1,
     // chapterIdentifier flips to ch2, locator still points at ch1.
-    const { rerender } = renderHook((props: typeof baseProps) => useReaderScrollSync(props), {
+    const { rerender } = renderHook((props: Props) => useReaderScrollSync(props), {
       initialProps: { ...baseProps, effectiveProgress: { locator: 'scroll:ch1:8000' } },
     })
     // First render restored to saved offset.


### PR DESCRIPTION
## Summary
Three fixes from the mobile audit, scoped to the public reader screen.

**P0 — footer/topbar showed wrong chapter on infinite scroll**
\`chapters.findIndex\` used the URL \`chapterSlug\`; topbar + footer titles read \`chapter.title\` from \`useReaderChapter\` (URL-keyed). Once the user scrolled into an appended chapter, \`visibleChapterSlug\` advanced but the chrome stayed put. Drive title + counter from \`activeSlug = visibleChapterSlug ?? chapterSlug\` + \`chapters.find\`.

**P1 — \`useReaderHighlights\` race on edition vs chapter id**
Effect read \`editionIdRef.current\` and depended on the ref object. Refs don't trigger re-runs, so when \`chapterId\` arrived before \`editionId\`, the load bailed and never retried. Add \`editionId\` state in \`useReaderBook\`, thread it as a separate prop, depend on it. Keep the ref for sync callbacks.

**P1 — refs in \`handleMessage\` deps**
Dropped \`highlightsRef\` / \`autoSavedRef\` from deps with a one-line note.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: open book, scroll past ch1 end → footer + topbar reflect ch2 title and counter advances
- [ ] Manual: refresh on a chapter slug, verify highlights paint regardless of book/chapter fetch order

🤖 Generated with [Claude Code](https://claude.com/claude-code)