### PR TITLE
seo-poller: drop |head -1 — SIGPIPE was killing the script

### DIFF
--- a/infra/scripts/seo-generate.sh
+++ b/infra/scripts/seo-generate.sh
@@ -53,11 +53,16 @@ escape_sql() {
 generate_edition_seo() {
   local id="$1"
 
+  # `db_query | head -1` was the historical pattern but `head -1` closes the
+  # pipe after the first line; for multi-line values like plain_text excerpts
+  # that triggers SIGPIPE on psql, which `set -o pipefail` then propagates as
+  # a non-zero pipeline exit, killing the script via `set -e`. The queries
+  # already return one row each (LIMIT 1 / pk lookup), so just take the row.
   local title author lang excerpt
-  title=$(db_query "SELECT title FROM editions WHERE id='$id'" | head -1)
-  author=$(db_query "SELECT a.name FROM authors a JOIN edition_authors ea ON a.id = ea.author_id WHERE ea.edition_id='$id' LIMIT 1" | head -1)
-  lang=$(db_query "SELECT language FROM editions WHERE id='$id'" | head -1)
-  excerpt=$(db_query "SELECT LEFT(plain_text, 1000) FROM chapters WHERE edition_id='$id' ORDER BY sort_order LIMIT 1" | head -1)
+  title=$(db_query "SELECT title FROM editions WHERE id='$id'")
+  author=$(db_query "SELECT a.name FROM authors a JOIN edition_authors ea ON a.id = ea.author_id WHERE ea.edition_id='$id' LIMIT 1")
+  lang=$(db_query "SELECT language FROM editions WHERE id='$id'")
+  excerpt=$(db_query "SELECT LEFT(plain_text, 1000) FROM chapters WHERE edition_id='$id' ORDER BY sort_order LIMIT 1")
 
   if [ -z "$title" ]; then
     log "ERROR: Edition $id not found"
@@ -147,9 +152,9 @@ generate_author_seo() {
   local id="$1"
 
   local name books lang
-  name=$(db_query "SELECT name FROM authors WHERE id='$id'" | head -1)
-  books=$(db_query "SELECT string_agg(e.title, ', ' ORDER BY e.title) FROM editions e JOIN edition_authors ea ON e.id = ea.edition_id WHERE ea.author_id='$id' AND e.status = 1" | head -1)
-  lang=$(db_query "SELECT COALESCE(e.language, 'en') FROM editions e JOIN edition_authors ea ON e.id = ea.edition_id WHERE ea.author_id='$id' LIMIT 1" | head -1)
+  name=$(db_query "SELECT name FROM authors WHERE id='$id'")
+  books=$(db_query "SELECT string_agg(e.title, ', ' ORDER BY e.title) FROM editions e JOIN edition_authors ea ON e.id = ea.edition_id WHERE ea.author_id='$id' AND e.status = 1")
+  lang=$(db_query "SELECT COALESCE(e.language, 'en') FROM editions e JOIN edition_authors ea ON e.id = ea.edition_id WHERE ea.author_id='$id' LIMIT 1")
 
   if [ -z "$name" ]; then
     log "ERROR: Author $id not found"

--- a/infra/scripts/seo-publish-poll.sh
+++ b/infra/scripts/seo-publish-poll.sh
@@ -50,16 +50,20 @@ db_exec() {
     psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "$1" 2>/dev/null
 }
 
+# db_query already returns one row from psql -tAc; piping through `head -1`
+# closes the pipe early and triggers SIGPIPE on multi-line values, which
+# `set -o pipefail` then turns into a non-zero pipeline exit and `set -e`
+# kills the script. Drop the head; rely on the SQL itself returning one row.
 get_setting() {
   local key="$1" default="$2"
   local val
-  val=$(db_query "SELECT value FROM admin_settings WHERE key='$key'" | head -1)
+  val=$(db_query "SELECT value FROM admin_settings WHERE key='$key'")
   echo "${val:-$default}"
 }
 
 get_job_field() {
   local job_id="$1" field="$2"
-  db_query "SELECT $field FROM auto_publish_jobs WHERE id = '$job_id'" | head -1
+  db_query "SELECT $field FROM auto_publish_jobs WHERE id = '$job_id'"
 }
 
 update_job() {
@@ -76,7 +80,7 @@ check_edition_seo_ready() {
     AND seo_themes_json IS NOT NULL AND seo_themes_json != ''
     AND seo_faqs_json IS NOT NULL AND seo_faqs_json != ''
     THEN 'yes' ELSE 'no' END
-    FROM editions WHERE id='$edition_id'" | head -1
+    FROM editions WHERE id='$edition_id'"
 }
 
 check_author_seo_ready() {
@@ -87,7 +91,7 @@ check_author_seo_ready() {
     AND seo_themes_json IS NOT NULL AND seo_themes_json != ''
     AND seo_faqs_json IS NOT NULL AND seo_faqs_json != ''
     THEN 'yes' ELSE 'no' END
-    FROM authors WHERE id='$author_id'" | head -1
+    FROM authors WHERE id='$author_id'"
 }
 
 auto_create_job() {
@@ -105,7 +109,7 @@ auto_create_job() {
     AND NOT EXISTS(SELECT 1 FROM auto_publish_jobs j
       WHERE j.edition_id = e.id AND j.status IN (0,1,2,3,4,5))
     $lang_clause
-    ORDER BY e.created_at ASC LIMIT 1" | head -1)
+    ORDER BY e.created_at ASC LIMIT 1")
 
   if [ -z "$edition_id" ]; then
     return 1
@@ -130,7 +134,7 @@ process_job() {
   edition_id=$(get_job_field "$job_id" "edition_id")
 
   local title
-  title=$(db_query "SELECT title FROM editions WHERE id='$edition_id'" | head -1)
+  title=$(db_query "SELECT title FROM editions WHERE id='$edition_id'")
   log "Processing job $job_id: $title"
 
   update_job "$job_id" "status = $STATUS_RUNNING, started_at = NOW()"


### PR DESCRIPTION
## Summary
Books haven't been auto-publishing for days. Two blockers stacked on top of each other.

**1. \`.env\` syntax error (already fixed on server, not in git)**  
\`OPENAI_API_KEY = sk-...\` had spaces around \`=\`. \`source .env\` ran it as a command → \"command not found\" → \`set -e\` killed the script before claude. Fixed on prod by removing spaces.

**2. SIGPIPE in \`db_query | head -1\` (this PR)**  
\`db_query\` runs \`docker compose exec -T db psql -tAc\`. For multi-line values (\`LEFT(plain_text, 1000)\` excerpt is the trigger), psql keeps writing after \`head -1\` already closed the pipe — psql gets SIGPIPE, \`set -o pipefail\` propagates a non-zero pipeline exit, \`set -e\` exits.

In an interactive shell the pipe buffer absorbed psql's output before \`head\` closed (no SIGPIPE). Under the poller's command-substitution context the timing flipped and \`seo-generate.sh\` fast-failed in <1s on every job, before claude was even invoked.

Drop \`| head -1\` from every \`db_query\` callsite — the SQL already returns one row via PK lookup or \`LIMIT 1\`. Left \`head -1\` in \`echo | sed\` pipelines (small in-memory data, no SIGPIPE risk).

## Test plan
- [x] \`bash -n\` clean on both scripts
- [ ] After deploy: restart poller (\`systemctl --user restart seo-publish-poller\`), queue a priority job → completes (status=5) within ~5min
- [ ] Tomorrow UTC 10:00 — auto-publish runs daily quota without script failures

## Followups (separate, not in scope)
- \`process_job\` writes a detailed error then the outer wrapper overwrites it with literal \`'Script failed'\` — useful diagnostic info is lost. Leave the inner message.
- Maybe add a circuit breaker: editions with N>=5 failed jobs in 24h skipped from \`auto_create_job\` candidate pool, so one bad edition can't burn the daily window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)