### PR TITLE
mobile: default status filter to all

### DIFF
--- a/apps/mobile/src/hooks/useLibraryStatus.ts
+++ b/apps/mobile/src/hooks/useLibraryStatus.ts
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react'
 import type { LibraryFilterKey } from './useLibraryFilter'
 
 export type LibraryStatus = LibraryFilterKey
-export const DEFAULT_STATUS: LibraryStatus = 'reading'
+export const DEFAULT_STATUS: LibraryStatus = 'all'
 
 export interface LibraryStatusState {
   status: LibraryStatus


### PR DESCRIPTION
Mirror of web PR #205. Mobile useLibraryStatus DEFAULT_STATUS was 'reading', silently hiding 13 not-started + 6 finished books out of 26 uploads. Switched to 'all'.