### PR TITLE
mobile: render author on saved library cards

### DIFF
--- a/apps/mobile/app/(tabs)/library.tsx
+++ b/apps/mobile/app/(tabs)/library.tsx
@@ -350,6 +350,9 @@ function SavedList({ library, setLibrary, progressMap, setProgressMap, refreshin
                     </View>
                   )}
                   <Text style={[styles.gridTitle, { color: colors.text }]} numberOfLines={2}>{item.title}</Text>
+                  {item.author && (
+                    <Text style={[styles.bookAuthor, { color: colors.textSecondary }]} numberOfLines={1}>{item.author}</Text>
+                  )}
                 </TouchableOpacity>
                 <TouchableOpacity
                   style={[styles.gridDotsBtn, { backgroundColor: 'rgba(0,0,0,0.45)' }]}
@@ -384,6 +387,9 @@ function SavedList({ library, setLibrary, progressMap, setProgressMap, refreshin
                 </View>
                 <View style={styles.bookInfo}>
                   <Text style={[styles.bookTitle, { color: colors.text }]} numberOfLines={2}>{item.title}</Text>
+                  {item.author && (
+                    <Text style={[styles.bookAuthor, { color: colors.textSecondary }]} numberOfLines={1}>{item.author}</Text>
+                  )}
                   {pct >= 100 ? (
                     <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, marginTop: 4 }}>
                       <Ionicons name="checkmark-circle" size={14} color={colors.success} />

--- a/apps/mobile/src/hooks/useLibrarySort.ts
+++ b/apps/mobile/src/hooks/useLibrarySort.ts
@@ -46,7 +46,14 @@ export function sortLibraryItems(
     case 'progress':
       return copy.sort((a, b) => (progressMap[b.editionId]?.percent ?? 0) - (progressMap[a.editionId]?.percent ?? 0))
     case 'author':
-      return copy
+      return copy.sort((a, b) => {
+        const aa = a.author || ''
+        const ab = b.author || ''
+        if (!aa && !ab) return 0
+        if (!aa) return 1
+        if (!ab) return -1
+        return collator.compare(aa, ab)
+      })
     case 'recent':
     default:
       return copy.sort((a, b) => {

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -392,6 +392,7 @@ export interface UserLibraryItem {
   language: string
   coverPath: string | null
   createdAt: string
+  author: string | null
 }
 
 // User Books


### PR DESCRIPTION
Backend LibraryItemDto now ships Author. Shared UserLibraryItem type was missing it. Saved books on mobile now render author and sort='author' actually sorts.