### PR TITLE
mobile: auto-refetch collection book IDs after invalidation

### DIFF
--- a/apps/mobile/app/(tabs)/library.tsx
+++ b/apps/mobile/app/(tabs)/library.tsx
@@ -15,6 +15,7 @@ import { useTheme } from '../../src/context/ThemeContext'
 import { useLanguage } from '../../src/context/LanguageContext'
 import { useToast } from '../../src/context/ToastContext'
 import { AddToCollectionSheet } from '../../src/components/library/AddToCollectionSheet'
+import { useCollectionsVersion } from '../../src/hooks/useCollections'
 import { fonts } from '../../src/theme/typography'
 import { SkeletonLoader } from '../../src/components/ui/SkeletonLoader'
 import { EmptyState } from '../../src/components/ui/EmptyState'
@@ -60,6 +61,7 @@ export default function LibraryScreen() {
   const [activeCollectionId, setActiveCollectionId] = useState<string | null>(null)
   const [collectionSavedIds, setCollectionSavedIds] = useState<Set<string> | null>(null)
   const [collectionUploadIds, setCollectionUploadIds] = useState<Set<string> | null>(null)
+  const collectionsVersion = useCollectionsVersion()
   const [library, setLibrary] = useState<UserLibraryItem[]>([])
   const [userBooks, setUserBooks] = useState<UserBookDto[]>([])
   const [progressMap, setProgressMap] = useState<Record<string, ReadingProgressDto>>({})
@@ -144,7 +146,10 @@ export default function LibraryScreen() {
       setCollectionUploadIds(new Set(u))
     })
     return () => { cancelled = true }
-  }, [activeCollectionId])
+    // collectionsVersion bumps when caches invalidate (e.g. after add-to-
+    // collection) — refetch keeps the active filter in sync without the user
+    // having to leave & re-enter the collection.
+  }, [activeCollectionId, collectionsVersion])
 
   const onRefresh = async () => {
     setRefreshing(true)

--- a/apps/mobile/src/hooks/useCollections.ts
+++ b/apps/mobile/src/hooks/useCollections.ts
@@ -4,7 +4,14 @@ import { collectionsApi, type Collection } from '@textstack/shared'
 let cache: { ts: number; data: Collection[] } | null = null
 let inflight: Promise<Collection[]> | null = null
 const subs = new Set<(c: Collection[]) => void>()
+const versionSubs = new Set<(v: number) => void>()
+let version = 0
 const TTL = 60_000
+
+function bumpVersion() {
+  version += 1
+  versionSubs.forEach((s) => s(version))
+}
 
 async function load(force: boolean): Promise<Collection[]> {
   if (!force && cache && Date.now() - cache.ts < TTL) return cache.data
@@ -14,6 +21,7 @@ async function load(force: boolean): Promise<Collection[]> {
       const data = await collectionsApi.listCollections()
       cache = { ts: Date.now(), data }
       subs.forEach((s) => s(data))
+      bumpVersion()
       return data
     } finally {
       inflight = null
@@ -24,6 +32,25 @@ async function load(force: boolean): Promise<Collection[]> {
 
 export function invalidateCollectionsCache() {
   cache = null
+  // Bump version eagerly so subscribers can refetch derived data (collection
+  // membership, etc.) without waiting for the next refresh cycle.
+  bumpVersion()
+}
+
+/**
+ * Subscribe to the global collections cache version. Increments on every
+ * successful refresh and on every invalidation, so consumers that depend on
+ * derived data (e.g. /me/library/collections/{id}/books) can refetch without
+ * holding the full collection list themselves.
+ */
+export function useCollectionsVersion(): number {
+  const [v, setV] = useState(version)
+  useEffect(() => {
+    const sub = (next: number) => setV(next)
+    versionSubs.add(sub)
+    return () => { versionSubs.delete(sub) }
+  }, [])
+  return v
 }
 
 export function useCollections() {


### PR DESCRIPTION
Bug from PR #210 audit: when the active sidebar collection was selected and the user added a book to it, the new entry didn't appear in the filtered list. useCollections now exposes a versioned subscription; library.tsx adds it to the useEffect that fetches collection membership so invalidateCollectionsCache() triggers a refetch automatically.