### PR TITLE
mobile: useCollectionsVersion via useSyncExternalStore

### DIFF
--- a/apps/mobile/src/hooks/useCollections.ts
+++ b/apps/mobile/src/hooks/useCollections.ts
@@ -1,16 +1,16 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react'
 import { collectionsApi, type Collection } from '@textstack/shared'
 
 let cache: { ts: number; data: Collection[] } | null = null
 let inflight: Promise<Collection[]> | null = null
 const subs = new Set<(c: Collection[]) => void>()
-const versionSubs = new Set<(v: number) => void>()
+const versionSubs = new Set<() => void>()
 let version = 0
 const TTL = 60_000
 
 function bumpVersion() {
   version += 1
-  versionSubs.forEach((s) => s(version))
+  versionSubs.forEach((s) => s())
 }
 
 async function load(force: boolean): Promise<Collection[]> {
@@ -42,15 +42,22 @@ export function invalidateCollectionsCache() {
  * successful refresh and on every invalidation, so consumers that depend on
  * derived data (e.g. /me/library/collections/{id}/books) can refetch without
  * holding the full collection list themselves.
+ *
+ * Implemented with useSyncExternalStore so React batches consistent reads,
+ * works correctly with concurrent rendering, and skips re-renders when the
+ * snapshot is stable — all the things a hand-rolled useState+useEffect
+ * subscription has to handle manually.
  */
+function subscribeVersion(onChange: () => void) {
+  const sub = () => onChange()
+  versionSubs.add(sub)
+  return () => { versionSubs.delete(sub) }
+}
+function getVersionSnapshot() {
+  return version
+}
 export function useCollectionsVersion(): number {
-  const [v, setV] = useState(version)
-  useEffect(() => {
-    const sub = (next: number) => setV(next)
-    versionSubs.add(sub)
-    return () => { versionSubs.delete(sub) }
-  }, [])
-  return v
+  return useSyncExternalStore(subscribeVersion, getVersionSnapshot, getVersionSnapshot)
 }
 
 export function useCollections() {


### PR DESCRIPTION
Replaces the hand-rolled useState+useEffect subscription with React 18's useSyncExternalStore primitive: tear-free reads under concurrent rendering, automatic re-render skipping when snapshot is stable, less ceremony.