### PR TITLE
mobile: configure runtimeVersion for EAS Updates (OTA prep)

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -3,6 +3,9 @@
     "name": "TextStack",
     "slug": "textstack",
     "version": "1.0.0",
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
expo-updates is in package.json but app config didn't declare runtimeVersion. Setting policy=appVersion ties OTA bundles to native app version. After 'eas update:configure' once, 'eas update' ships JS-only changes (M1-M5+) without binary rebuild.