### PR TITLE
mobile: add updates.url to app.json (EAS Updates active)

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -3,6 +3,9 @@
     "name": "TextStack",
     "slug": "textstack",
     "version": "1.0.0",
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -6,6 +6,10 @@
     "runtimeVersion": {
       "policy": "appVersion"
     },
+    "updates": {
+      "url": "https://u.expo.dev/204518f7-24cf-4984-962d-f636508be861",
+      "fallbackToCacheTimeout": 0
+    },
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
Pairs with #213 runtimeVersion. Sets OTA endpoint to https://u.expo.dev/204518f7-24cf-4984-962d-f636508be861 (existing project id). fallbackToCacheTimeout=0 = production default. Verified: M1-M5+fixes shipped via eas update to iOS+Android.