### PR TITLE
mobile: gitignore dist-web/ exports

### DIFF
--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 # Expo
 .expo/
 dist/
+dist-web/
 web-build/
 expo-env.d.ts
 


### PR DESCRIPTION
Closes the off-by-one: had dist/ and web-build/, missing dist-web/.