### PR TITLE
library UX polish: scroll-to-grid + chip contrast + icon CTA

### DIFF
--- a/apps/web/src/components/library/AddToCollectionButton.tsx
+++ b/apps/web/src/components/library/AddToCollectionButton.tsx
@@ -19,6 +19,8 @@ interface MenuVariantProps extends CommonProps {
 interface ButtonVariantProps extends CommonProps {
   variant: 'button'
   className?: string
+  /** Render a circular `+` icon instead of the text label. */
+  iconOnly?: boolean
 }
 
 type Props = MenuVariantProps | ButtonVariantProps
@@ -121,7 +123,16 @@ export function AddToCollectionButton(props: Props) {
   }
 
   // variant === 'button'
-  const baseClass = props.className || 'add-to-collection-button'
+  const iconOnly = !!props.iconOnly
+  const baseClass = props.className
+    || (iconOnly ? 'add-to-collection-button add-to-collection-button--icon' : 'add-to-collection-button')
+  const label = t('library.actions.addToCollection')
+  const buttonContent = iconOnly ? (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  ) : label
   if (collections.length === 0) {
     return (
       <button
@@ -129,9 +140,10 @@ export function AddToCollectionButton(props: Props) {
         className={baseClass}
         disabled
         aria-disabled="true"
+        aria-label={iconOnly ? label : undefined}
         title={t('library.actions.addToCollectionEmpty')}
       >
-        {t('library.actions.addToCollection')}
+        {buttonContent}
       </button>
     )
   }
@@ -147,9 +159,11 @@ export function AddToCollectionButton(props: Props) {
         className={baseClass}
         aria-haspopup="menu"
         aria-expanded={expanded}
+        aria-label={iconOnly ? label : undefined}
+        title={iconOnly ? label : undefined}
         onClick={() => setExpanded((v) => !v)}
       >
-        {t('library.actions.addToCollection')}
+        {buttonContent}
       </button>
       {expanded && (
         <div className="add-to-collection__popover" role="menu">

--- a/apps/web/src/pages/BookDetailPage.tsx
+++ b/apps/web/src/pages/BookDetailPage.tsx
@@ -307,7 +307,7 @@ export function BookDetailPage() {
                 variant="button"
                 bookId={book.id}
                 bookType="savedbook"
-                className="book-hero__read-btn book-hero__read-btn--secondary"
+                iconOnly
               />
             )}
 

--- a/apps/web/src/pages/LibraryPage.tsx
+++ b/apps/web/src/pages/LibraryPage.tsx
@@ -102,6 +102,13 @@ export function LibraryPage() {
       else sp.delete('collection')
       return sp
     }, { replace: true })
+    // Anchor scroll to the grid so the user sees the filtered list update
+    // immediately. Defer one frame so the layout has applied the new filter.
+    if (id) {
+      window.requestAnimationFrame(() => {
+        document.getElementById('library-grid')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      })
+    }
   }
 
   const onUploadTagSelect = (tag: string | null) => {
@@ -442,7 +449,7 @@ export function LibraryPage() {
           const isLoadingAny = (showSavedBlock && loading) || (showUploadsBlock && userBooksLoading && userBooks.length === 0)
 
           return (
-            <>
+            <div id="library-grid" style={{ scrollMarginTop: '90px' }}>
               {/* Toolbar (single, unified) */}
               <div className="library-toolbar">
                 <div className="library-toolbar__left">
@@ -772,7 +779,7 @@ export function LibraryPage() {
                   })())}
                 </div>
               )}
-            </>
+            </div>
           )
         })()}
 

--- a/apps/web/src/pages/UserBookDetailPage.tsx
+++ b/apps/web/src/pages/UserBookDetailPage.tsx
@@ -260,7 +260,7 @@ export function UserBookDetailPage() {
                 variant="button"
                 bookId={book.id}
                 bookType="userbook"
-                className="user-book-detail__mark-btn"
+                iconOnly
               />
             )}
 

--- a/apps/web/src/styles/books.css
+++ b/apps/web/src/styles/books.css
@@ -3586,6 +3586,39 @@ html.dark .search-page__sub-result-highlight b {
   background: #15803d;
 }
 
+/* Icon-only "Add to collection" button — circular, sits next to share/copy
+   icons on detail pages. Apple-style: small affordance, not a third pill. */
+.add-to-collection-button--icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: transparent;
+  border: 1px solid var(--color-border, #E8E2D9);
+  color: var(--color-text, #191919);
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.add-to-collection-button--icon:hover:not(:disabled) {
+  background: var(--color-bg-secondary, #F5F0E8);
+  border-color: var(--color-text, #191919);
+}
+.add-to-collection-button--icon:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+html.dark .add-to-collection-button--icon {
+  border-color: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+html.dark .add-to-collection-button--icon:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: #fff;
+}
+
 /* =============================================
    Library Shelf Page (/library/shelf/:id)
    ============================================= */
@@ -7438,7 +7471,18 @@ html.dark .book-hero__read-btn--secondary {
   transition: background 120ms, border-color 120ms, color 120ms;
 }
 .collection-chip:hover { background: var(--color-bg-secondary, #f1ece2); border-color: var(--color-primary, #8b7355); }
-.collection-chip--active { background: var(--color-primary, #8b7355); color: var(--color-bg, #fff); border-color: var(--color-primary, #8b7355); }
+.collection-chip--active {
+  background: var(--color-text, #191919);
+  color: var(--color-bg, #fff);
+  border-color: var(--color-text, #191919);
+  font-weight: 600;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+}
+html.dark .collection-chip--active {
+  background: #fff;
+  color: #0a0a0a;
+  border-color: #fff;
+}
 .collection-chip__count { font-size: 11px; opacity: 0.7; }
 .collection-chip--add { color: var(--color-primary, #8b7355); border-style: dashed; background: transparent; }
 .collection-chip--add:hover { background: var(--color-bg-secondary, #f1ece2); }


### PR DESCRIPTION
Three fixes from user audit:
1. scrollIntoView on collection select — was invisible change above fold
2. active chip contrast — light-mode active state was nearly invisible
3. Add to collection on detail pages → 36px circular + icon (not third big pill)