### PR TITLE
library UX polish 3: sticky offset + delete danger zone

### DIFF
--- a/apps/web/src/pages/UserBookDetailPage.tsx
+++ b/apps/web/src/pages/UserBookDetailPage.tsx
@@ -264,14 +264,6 @@ export function UserBookDetailPage() {
               />
             )}
 
-            <button
-              onClick={handleDelete}
-              disabled={deleting}
-              className="user-book-detail__delete-btn"
-            >
-              {deleting ? 'Deleting...' : 'Delete Book'}
-            </button>
-
             {isReady && (
               <ShareButtons
                 url={window.location.href}
@@ -310,6 +302,19 @@ export function UserBookDetailPage() {
               </li>
             ))}
           </ul>
+        </div>
+      )}
+
+      {isReady && (
+        <div className="user-book-detail__danger-zone">
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={deleting}
+            className="user-book-detail__delete-link"
+          >
+            {deleting ? 'Deleting…' : 'Delete this book'}
+          </button>
         </div>
       )}
     </div>

--- a/apps/web/src/styles/books.css
+++ b/apps/web/src/styles/books.css
@@ -4491,22 +4491,34 @@ html.dark .add-to-collection-button--icon:hover:not(:disabled) {
   background: rgba(0, 0, 0, 0.04);
 }
 
-.user-book-detail__delete-btn {
-  padding: 12px 24px;
+/* Danger zone — destructive actions live below the chapters list, not
+   in the primary action row. Apple HIG: distance + understatement
+   reduce accidental clicks. */
+.user-book-detail__danger-zone {
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid var(--color-border, #E8E2D9);
+  display: flex;
+  justify-content: center;
+}
+.user-book-detail__delete-link {
   background: none;
-  border: 1px solid #dc2626;
+  border: none;
   color: #dc2626;
-  border-radius: 8px;
-  font-weight: 500;
+  font-size: 13px;
+  font-family: inherit;
   cursor: pointer;
+  padding: 8px 16px;
+  border-radius: 6px;
+  text-decoration: underline;
+  text-underline-offset: 3px;
   transition: background 0.15s ease;
 }
-
-.user-book-detail__delete-btn:hover {
-  background: #fef2f2;
+.user-book-detail__delete-link:hover:not(:disabled) {
+  background: rgba(220, 38, 38, 0.06);
+  text-decoration: none;
 }
-
-.user-book-detail__delete-btn:disabled {
+.user-book-detail__delete-link:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
@@ -5211,9 +5223,11 @@ html.dark .user-book-detail__spinner {
   margin-bottom: 24px;
   border-bottom: 1px solid var(--color-border);
   /* Sticky on scroll so users keep status filters visible while browsing
-     a long grid. top:64px sits below the page header. */
+     a long grid. .site-header is 80px at top, 64px when scrolled — using
+     80 means a small (16px) gap when the header collapses but never an
+     overlap. */
   position: sticky;
-  top: 64px;
+  top: 80px;
   background: var(--color-bg, #fff);
   z-index: 5;
 }


### PR DESCRIPTION
Sticky tabs at top:80 (matches site-header height, no overlap during collapse). Delete moved out of primary action row to a small text-link in a danger zone below chapters.