### PR TITLE
fix: admin healthcheck IPv6 + single-word distractor prompt

### DIFF
--- a/backend/src/Vocabulary/TextStack.Vocabulary/DistractorGenerator.cs
+++ b/backend/src/Vocabulary/TextStack.Vocabulary/DistractorGenerator.cs
@@ -49,6 +49,7 @@ public sealed class DistractorGenerator : IDistractorGenerator
         parts.Add("- Similar difficulty level");
         parts.Add("- NOT synonyms");
         parts.Add("- Could plausibly confuse a learner");
+        parts.Add("- SINGLE WORD ONLY — no spaces, no multi-word phrases (use \"linearizability\" not \"strong consistency\"; \"sharding\" not \"data partitioning\"). Hyphens are fine.");
         parts.Add("");
         parts.Add("Task 2 - Hint: Write ONE short sentence (under 15 words) describing what this word means.");
         parts.Add($"Do NOT use the word \"{word}\" or direct synonyms in the hint.");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,7 @@ services:
       - "127.0.0.1:81:81"  # Only localhost - not exposed to internet
     restart: always
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:81/ > /dev/null || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:81/ > /dev/null || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Two narrow fixes surfaced after the gemma4:e4b deploy

### 1. \`admin\` container has been (unhealthy) since deploy

**Symptom**: \`textstack_admin_prod\` shows \`(unhealthy)\` with \`FailingStreak=241\` (= 2 hours of consecutive 30s checks failing). Healthcheck output: \`wget: can't connect to remote host: Connection refused\`.

**Root cause**: healthcheck does \`wget http://localhost:81\`. In Alpine \`localhost\` resolves to \`::1\` (IPv6) first. Vite binds only to \`0.0.0.0\` (IPv4) per \`pnpm dev --host 0.0.0.0\`. wget tries IPv6 → connection refused.

**Fix**: \`localhost\` → \`127.0.0.1\` (single line in \`docker-compose.yml\`).

**Verified on prod**:
\`\`\`
docker exec textstack_admin_prod wget -qO- http://localhost:81/  # → Connection refused
docker exec textstack_admin_prod wget -qO- http://127.0.0.1:81/  # → returns HTML
\`\`\`

API healthcheck has the same \`localhost\` text but is fine because Kestrel binds both IPv4+IPv6 by default. Only Vite is affected.

### 2. Gemma4 distractor output gets stripped

**Symptom**: smoke tested \`gemma4:e4b\` for "eventual consistency" — it returned \`["strong consistency", "read-after-write", "data loss", ...]\`. After \`ParseWordList\`'s \`!w.Contains(' ')\` filter, only \`read-after-write\` and \`causality\` survive. \`distractors.Count >= 3\` fails → fallback to random vocab pool words.

**Root cause**: Gemma4 prefers phrasal answers; the parser is built for single tokens (existing constraint, not introduced by the model swap — but the swap surfaces it).

**Fix**: prompt now explicitly demands SINGLE-WORD distractors with concrete examples (\`linearizability\` not \`strong consistency\`). Hyphens still allowed since the parser permits them.

This keeps the existing parser logic intact (no risk of letting phrasal noise through) while giving the LLM clear guidance.

### Test plan

- [x] \`dotnet build\` — green.
- [x] \`dotnet test tests/TextStack.UnitTests\` — 216/216.
- [ ] After merge + deploy: \`textstack_admin_prod\` flips to \`(healthy)\` within 30–90s.
- [ ] After merge + deploy: save a vocab word, verify 5 distractors appear in DB (not fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)