### PR TITLE
fix(ollama): keep_alive=-1 + bump api timeout 10s→30s

### DIFF
--- a/backend/src/Api/appsettings.json
+++ b/backend/src/Api/appsettings.json
@@ -45,7 +45,7 @@
   "Ollama": {
     "BaseUrl": "http://localhost:11434",
     "Model": "gemma4:e4b",
-    "TimeoutSeconds": 10
+    "TimeoutSeconds": 30
   },
   "LLM": {
     "DefaultProvider": "openai",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,6 +232,8 @@ services:
     container_name: textstack_ollama
     volumes:
       - ./data/ollama:/root/.ollama
+    environment:
+      OLLAMA_KEEP_ALIVE: "-1"
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]


### PR DESCRIPTION
## Why

User noticed prod RAM showed only 3.1 GiB used despite gemma4:e4b being 9.8 GiB — the model unloads after idle. Cold reload takes ~50-60s on CPU and Ollama's pre-load memory check is conservative ("requires 9.8 GiB but only 8.2 GiB available" even though host has 27 GiB available) — both make fire-and-forget distractor calls fail intermittently.

## What

1. **\`OLLAMA_KEEP_ALIVE=-1\`** in compose env. Once the model loads, it stays resident for the lifetime of the container. Cold-load only happens on container restart (i.e. on each deploy), not after every 5-min idle window.

2. **Api/appsettings.json \`Ollama:TimeoutSeconds\` 10s → 30s**. Worker was already 30s; API was 10s. Warm gemma4 distractor inference measured at 2.8s (plenty of headroom under 30s) but 10s leaves no margin and definitely breaks on cold-load. Aligning to 30s removes the asymmetry.

## Verified on prod

After manual \`ollama run --keepalive=24h gemma4:e4b\`:
\`\`\`
$ docker compose exec ollama ollama ps
NAME          ID              SIZE     PROCESSOR    CONTEXT    UNTIL
gemma4:e4b    c6eb396dbd59    10 GB    100% CPU     4096       24 hours from now

$ free -h
               total        used        free      buff/cache   available
Mem:            30Gi        13Gi       351Mi       18Gi          17Gi
\`\`\`

Distractor inference timing:
\`\`\`
$ time ollama run gemma4:e4b "Generate 5 single-word distractors for linearizability..."
consistency, atomicity, serialization, concurrency, visibility
real    0m2.837s
\`\`\`

## Post-deploy step

After this merges + auto-deploys, prod's container will recreate with the new env. Need to trigger first load once:

\`\`\`bash
ssh asus
cd ~/projects/onlinelib/textstack
docker compose exec ollama ollama run gemma4:e4b "" --keepalive=-1
docker compose exec ollama ollama ps  # verify UNTIL=Forever
\`\`\`

After that, \`KEEP_ALIVE=-1\` env on the daemon side keeps it resident across all subsequent inference calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)